### PR TITLE
Add warning to handleChange when id/name is omitted during dev

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -214,11 +214,23 @@ export function Formik<Props, Values extends FormikValues, Payload>({
 
       handleChange = (e: React.ChangeEvent<any>) => {
         e.persist();
-        const { type, name, id, value, checked } = e.target;
+        const { type, name, id, value, checked, outerHTML } = e.target;
         const field = name ? name : id;
+        console.log(e);
         const val = /number|range/.test(type)
           ? parseFloat(value)
           : /checkbox/.test(type) ? checked : value;
+
+        if (!field && process.env.NODE_ENV !== 'production') {
+          console.error(
+            `Warning: You forgot to pass an \`id\` or \`name\` attribute to your input:
+
+  ${outerHTML}
+
+Formik cannot determine which value to update. Check the See docs for more information: https://github.com/jaredpalmer/formik#handlechange-e-reactchangeeventany--void
+`
+          );
+        }
 
         const { values } = this.state;
         // Set form fields by name

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,7 +216,6 @@ export function Formik<Props, Values extends FormikValues, Payload>({
         e.persist();
         const { type, name, id, value, checked, outerHTML } = e.target;
         const field = name ? name : id;
-        console.log(e);
         const val = /number|range/.test(type)
           ? parseFloat(value)
           : /checkbox/.test(type) ? checked : value;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -227,7 +227,7 @@ export function Formik<Props, Values extends FormikValues, Payload>({
 
   ${outerHTML}
 
-Formik cannot determine which value to update. Check the See docs for more information: https://github.com/jaredpalmer/formik#handlechange-e-reactchangeeventany--void
+Formik cannot determine which value to update. See docs for more information: https://github.com/jaredpalmer/formik#handlechange-e-reactchangeeventany--void
 `
           );
         }


### PR DESCRIPTION
Note: there might be a better way to print which component / node the error originates from instead of `e.target.outerHTML`.

This does not impact React Native because `handleChange` is useless anyway. However, it could be useful to also have a React Native-specific error message that points users to `handleChangeValue` in the future.