### PR TITLE
BUGFIX: ensure that handleBlur doesn't clobber entire touched state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -282,8 +282,7 @@ Formik cannot determine which value to update. See docs for more information: ht
         e.persist();
         const { name, id } = e.target;
         const field = name ? name : id;
-        const { touched } = this.state;
-        this.setTouched({ ...touched, [field]: true });
+        this.setState(state => ({ touched: { ...state.touched, [field]: true } }));
       };
 
       handleChangeValue = (field: string, value: any) => {


### PR DESCRIPTION
The current `handleBlur` calls `setTouched`, which clobbers the entire touched state when handleBlur should only be setting a single field to touched. This caused a tricky race condition bug when competing with an `resetForm` or other call intended to reset `touched`.

This PR changes `handleBlur` to make an async setState call that will only ever set the touch state of the single field.

We may want to make a `touchField()` function to make this easier for other callers that want to accomplish their own touch handling, but I'll leave that for another day.