### PR TITLE
[0.8] Add singular validate method

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
+import { isPromise, isReactNative, touchAllFields } from './utils';
+
 import { hoistNonReactStatics } from './hoistStatics';
-import { isReactNative } from './isReactNative';
 
 /**
  * Transform Yup ValidationError to a more usable object
@@ -17,19 +18,9 @@ export function yupToFormErrors(yupError: any): FormikErrors {
 }
 
 /**
- * Given an object, map keys to boolean
- */
-export function touchAllFields<T>(fields: T): { [field: string]: boolean } {
-  let touched: { [field: string]: boolean } = {};
-  for (let k of Object.keys(fields)) {
-    touched[k] = true;
-  }
-  return touched;
-}
-/**
  * Validate a yup schema.
  */
-export function validateFormData<T>(data: T, schema: any): Promise<void> {
+export function validateYupSchema<T>(data: T, schema: any): Promise<void> {
   let validateData: any = {};
   for (let k in data) {
     if (data.hasOwnProperty(k)) {
@@ -41,18 +32,28 @@ export function validateFormData<T>(data: T, schema: any): Promise<void> {
   return schema.validate(validateData, { abortEarly: false });
 }
 
+/**
+ * Values of fields in the form
+ */
 export interface FormikValues {
   [field: string]: any;
 }
 
-// @todo make this limited to keys of values
+/**
+ * An object containing error messages whose keys ideally correspond to FormikValues.
+ * 
+ * @todo make this limited to keys of values in typescript
+ */
 export interface FormikErrors {
   [field: string]: string;
 }
 
-// @todo make this limited to keys of values
-// interfact FormikTouched<Values, Field extends keyof Values> ??
+/**
+ * An objectg containing touched state of the form whose keys ideally correspond to FormikValues.
+ * @todo make this limited to keys of valuesField extends keyof Values> ??
+ */
 export interface FormikTouched {
+  // interface FormikTouched<Values,
   [field: string]: boolean;
 }
 
@@ -65,11 +66,15 @@ export interface FormikConfig<Props, Values, Payload> {
   mapPropsToValues?: (props: Props) => Values;
   /** Map form values to submission payload */
   mapValuesToPayload?: (values: Values) => Payload;
-  /** Synchronous validation function. must return an error object */
-  validate: (values: Values) => FormikErrors;
-  /** Asynchronous validation function. Error must be in shape of a Formik error object */
-  validateAsync: (values: Values, props: Props) => Promise<any>;
-  /**  Yup Schema */
+  /** 
+   * Validation function. Must return an error object or promise that 
+   * throws an error object where that object keys map to corresponding value.
+   */
+  validate?: (
+    values: Values,
+    props: Props
+  ) => void | FormikErrors | Promise<any>;
+  /** A Yup Schema */
   validationSchema?: any;
   /** Submission handler */
   handleSubmit: (payload: Payload, formikBag: FormikBag<Props, Values>) => void;
@@ -190,7 +195,6 @@ export function Formik<Props, Values extends FormikValues, Payload>({
     return payload;
   },
   validate,
-  validateAsync,
   validationSchema,
   handleSubmit,
   validateOnChange = false,
@@ -249,7 +253,7 @@ export function Formik<Props, Values extends FormikValues, Payload>({
       };
 
       runValidationSchema = (values: Values, cb?: Function) => {
-        validateFormData<Values>(values, validationSchema).then(
+        validateYupSchema<Values>(values, validationSchema).then(
           () => {
             this.setState({ errors: {} });
             if (cb) {
@@ -261,29 +265,21 @@ export function Formik<Props, Values extends FormikValues, Payload>({
         );
       };
 
-      runValidationAsync = (values: Values, cb?: Function) => {
-        validateAsync(values, this.props).then(
-          () => {
-            this.setState({ errors: {} });
-            if (cb) {
-              cb();
-            }
-          },
-          errors => this.setState({ errors, isSubmitting: false })
-        );
-      };
-
-      runValidationSync = (values: Values) => {
-        this.setErrors(validate(values));
-      };
-
       runValidations = (values: Values) => {
         if (validate) {
-          this.runValidationSync(values);
+          const maybePromisedErrors = validate(values, this.props);
+          if (isPromise(maybePromisedErrors)) {
+            (validate(values, this.props) as Promise<any>).then(
+              () => {
+                this.setState({ errors: {} });
+              },
+              errors => this.setState({ errors, isSubmitting: false })
+            );
+          } else {
+            this.setErrors(maybePromisedErrors as FormikErrors);
+          }
         }
-        if (validateAsync) {
-          this.runValidationAsync(values);
-        }
+
         if (validationSchema) {
           this.runValidationSchema(values);
         }
@@ -388,24 +384,32 @@ Formik cannot determine which value to update. See docs for more information: ht
         });
 
         if (validate) {
-          const errors = validate(this.state.values);
-          this.setState({ errors, isSubmitting: errors.keys.length > 0 });
+          const maybePromisedErrors =
+            validate(this.state.values, this.props) || {};
+          if (isPromise(maybePromisedErrors)) {
+            (validate(this.state.values, this.props) as Promise<
+              any
+            >).then(() => {
+              this.setState({ errors: {} });
+              console.log('submitting');
+              this.submitForm();
+            }, errors => console.log(errors) || this.setState({ errors, isSubmitting: false }));
+            return;
+          } else {
+            this.setState({
+              errors: maybePromisedErrors as FormikErrors,
+              isSubmitting: Object.keys(maybePromisedErrors).length > 0,
+            });
 
-          // only call if there are no errors errors
-          if (errors.keys.length === 0) {
-            this.submitForm();
+            // only submit if there are no errors
+            if (Object.keys(maybePromisedErrors).length === 0) {
+              this.submitForm();
+            }
           }
-          return;
-        }
-
-        if (validateAsync) {
-          this.runValidationAsync(this.state.values, this.submitForm);
-          return;
-        }
-
-        if (validationSchema) {
+        } else if (validationSchema) {
           this.runValidationSchema(this.state.values, this.submitForm);
-          return;
+        } else {
+          this.submitForm();
         }
       };
 

--- a/src/isReactNative.ts
+++ b/src/isReactNative.ts
@@ -1,5 +1,0 @@
-export const isReactNative =
-  typeof window !== 'undefined' &&
-  window.navigator &&
-  window.navigator.product &&
-  window.navigator.product === 'ReactNative';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Returns whether something is a Promise or not.
+ * @param value anything
+ * 
+ * @see https://github.com/pburtchaell/redux-promise-middleware/blob/master/src/isPromise.js
+ */
+export function isPromise(value: any): boolean {
+  if (value !== null && typeof value === 'object') {
+    return value && typeof value.then === 'function';
+  }
+
+  return false;
+}
+
+/**
+ * True if running in React Native. 
+ */
+export const isReactNative =
+  typeof window !== 'undefined' &&
+  window.navigator &&
+  window.navigator.product &&
+  window.navigator.product === 'ReactNative';
+
+/**
+ * Given an object, map keys to boolean
+ */
+export function touchAllFields<T>(fields: T): { [field: string]: boolean } {
+  let touched: { [field: string]: boolean } = {};
+  for (let k of Object.keys(fields)) {
+    touched[k] = true;
+  }
+  return touched;
+}

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -202,7 +202,7 @@ describe('Formik', () => {
           expect(handleSubmit).toHaveBeenCalled();
         });
 
-        it('should not submit the form if validation errors are present', () => {
+        it('should not submit the form if invalid', () => {
           const validate = jest.fn().mockReturnValue({ name: 'Error!' });
           const handleSubmit = jest.fn();
 
@@ -236,7 +236,7 @@ describe('Formik', () => {
           expect(validate).toHaveBeenCalled();
         });
 
-        it('should not submit the form if valid', async () => {
+        it('should submit the form if valid', async () => {
           const handleSubmit = jest.fn();
 
           const ValidateForm = Formik<Props, Values, Values>({

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -63,9 +63,6 @@ const Form: React.SFC<InjectedFormikProps<Props, Values>> = ({
 };
 
 const BasicForm = Formik<Props, Values, Values>({
-  validationSchema: Yup.object().shape({
-    name: Yup.string().required(),
-  }),
   mapPropsToValues: ({ user }) => ({ ...user }),
   handleSubmit: noop,
 })(Form);
@@ -80,19 +77,9 @@ describe('Formik', () => {
   });
 
   describe('FormikHandlers', () => {
-    const CustomConfigForm = Formik<Props, Values, Values>({
-      validationSchema: Yup.object().shape({
-        name: Yup.string().required(),
-      }),
-      mapPropsToValues: ({ user }) => ({ ...user }),
-      handleSubmit: payload => {
-        expect(payload).toEqual({ name: 'jared' });
-      },
-    })(Form);
-
     describe('handleChange', () => {
       it('sets values, and updates inputs', async () => {
-        const hoc = shallow(<CustomConfigForm user={{ name: 'jared' }} />);
+        const hoc = shallow(<BasicForm user={{ name: 'jared' }} />);
 
         // Simulate a change event in the inner Form component's input
         hoc.find(Form).dive().find('input').simulate('change', {
@@ -112,7 +99,7 @@ describe('Formik', () => {
 
     describe('handleBlur', () => {
       it('handleBlur sets touched', async () => {
-        const hoc = shallow(<CustomConfigForm user={{ name: 'jared' }} />);
+        const hoc = shallow(<BasicForm user={{ name: 'jared' }} />);
 
         // Simulate a blur event in the inner Form component's input
         hoc.find(Form).dive().find('input').simulate('blur', {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { validateFormData, yupToFormErrors } from '../src/formik';
+import { validateYupSchema, yupToFormErrors } from '../src/formik';
 
 const Yup = require('yup');
 const schema = Yup.object().shape({
@@ -18,10 +18,10 @@ describe('helpers', () => {
     });
   });
 
-  describe('validateFormData()', () => {
+  describe('validateYupSchema()', () => {
     it('should validate', async () => {
       try {
-        await validateFormData({}, schema);
+        await validateYupSchema({}, schema);
       } catch (e) {
         expect(e.name).toEqual('ValidationError');
         expect(e.errors).toEqual(['required']);
@@ -30,7 +30,7 @@ describe('helpers', () => {
 
     it('should stringify all values', async () => {
       try {
-        const result = await validateFormData({ name: 1 }, schema);
+        const result = await validateYupSchema({ name: 1 }, schema);
         expect(result).not.toEqual({ name: 1 });
         expect(result).toEqual({ name: '1' });
       } catch (e) {


### PR DESCRIPTION
- Adds singular `validate?: (values: Values, props: Props) => FormikErrors | Promise<any>` configuration option. Validate may either return a map of error messages `{ [field: string]: string}` or a promise whose error is a map of error messages. Unfortunately TypeScript does not let me express the shape of the error object of the promise with a type signature. So that kind of sucks. #61 
-  Adds `submitForm` to `FormikBag`. #25 #42

Contrary to my initial opinion described in #25 and #42 (and while not that useful in the component itself), having a `submitForm` function turns out to be _extremely_ useful as way to test Formik submissions without dealing with or simulating a submission event. This needs to be documented as well as other testing recipes in a guide.

The problem is that a React synthetic submission event is synchronous. This is fine for when validate is also sync, but when it comes to testing an async validation function the event, the call to the consumer's `handleSubmit()` is swallowed. However, if we encapsulate validation and submission into its own function (`submitForm()`) and thus move it away from the synthetic event, we can just [test that function using enzyme's mount](https://github.com/jaredpalmer/formik/blob/cbbb08f2bd7aaaed33ccea687fd96aa0dc56ca86/test/formik.test.tsx#L249) for the async test case + and test [`e.preventDefault()`](https://github.com/jaredpalmer/formik/blob/cbbb08f2bd7aaaed33ccea687fd96aa0dc56ca86/test/formik.test.tsx#L132) is getting called and we are :100:.

