### PR TITLE
Fix hoistStatics

### DIFF
--- a/src/hoistStatics.tsx
+++ b/src/hoistStatics.tsx
@@ -44,11 +44,11 @@ export function hoistNonReactStatics<P>(
         // Only hoist enumerables and non-enumerable functions
         if (
           propIsEnumerable.call(sourceComponent, key) ||
-          typeof (targetComponent as any)[key] === 'function'
+          typeof (sourceComponent as any)[key] === 'function'
         ) {
           try {
             // Avoid failures from read-only properties
-            (targetComponent as any)[key] = (targetComponent as any)[key];
+            (targetComponent as any)[key] = (sourceComponent as any)[key];
             // tslint:disable-next-line:no-empty
           } catch (e) {}
         }


### PR DESCRIPTION
1909ec9536bfc8fa1d91daf0de9ecb06383ae392 added `hoistStatics.tsx` in lieu of `hoist-non-react-statics`.  However, it appears that typos were made, judging by the `hoist-non-react-statics` [source](https://github.com/mridgway/hoist-non-react-statics/blob/master/index.js#L55-L57).

0.8.1 currently crashes in React Native without this fix.