### PR TITLE
#114 Add touchOnBlur and touchOnChange options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You can also try before you buy with this **[demo of Formik on CodeSandbox.io](h
         - [The "FormikBag":](#the-formikbag)
       - [`isInitialValid?: boolean | (props: Props) => boolean`](#isinitialvalid-boolean--props-props--boolean)
       - [`mapPropsToValues?: (props: Props) => Values`](#mappropstovalues-props-props--values)
+      - [`touchOnBlur?: boolean`](#touchonblur-boolean)
+      - [`touchOnChange?: boolean`](#touchonchange-boolean)
       - [`validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`](#validate-values-values-props-props--formikerrorvalues--promiseany)
       - [`validateOnBlur?: boolean`](#validateonblur-boolean)
       - [`validateOnChange?: boolean`](#validateonchange-boolean)
@@ -272,6 +274,14 @@ Default is `false`. Control the initial value of [`isValid`] prop prior to mount
 If this option is specified, then Formik will transfer its results into updatable form state and make these values available to the new component as [`props.values`][`values`]. If `mapPropsToValues` is not specified, then Formik will map all props that are not functions to the inner component's [`props.values`][`values`]. That is, if you omit it, Formik will only pass `props` where `typeof props[k] !== 'function'`, where `k` is some key. 
 
 Even if your form is not receiving any props from its parent, use `mapPropsToValues` to initialize your forms empty state.
+
+##### `touchOnBlur?: boolean`
+
+Default is `true`. If `true`, Formik will mark fields as `touched` on `blur` events and blur related functions. Thus, `handleBlur` and `setFieldTouched` will automatically mark fields as touched.
+
+##### `touchOnChange?: boolean`
+
+Default is `false`. If `true`, Formik will mark fields as `touched` on `change` events and change-related functions. Thus, `handleChange` and `setFieldValue` will automatically mark fields as `touched` when called.
 
 ##### `validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`
 

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -57,10 +57,14 @@ export interface FormikConfig<
     values: Values | DeprecatedPayload,
     formikBag: FormikBag<Props, Values>
   ) => void;
-  /** Tells Formik to validate the form on each input's onChange event */
+  /** Tells Formik to validate the form on each input's on change events */
   validateOnChange?: boolean;
-  /** Tells Formik to validate the form on each input's onBlur event */
+  /** Tells Formik to validate the form on each input's on blur events */
   validateOnBlur?: boolean;
+  /** Tells Formik to mark fields as touched on change events */
+  touchOnChange?: boolean;
+  /** Tells Formik to mark fields as touched on blur events */
+  touchOnBlur?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
   isInitialValid?: boolean | ((props: Props) => boolean | undefined);
 }
@@ -189,6 +193,8 @@ export function Formik<Props, Values extends FormikValues, Payload = Values>({
   validate,
   validationSchema,
   handleSubmit,
+  touchOnChange = false,
+  touchOnBlur = true,
   validateOnChange = false,
   validateOnBlur = true,
   isInitialValid = false,
@@ -334,6 +340,12 @@ Formik cannot determine which value to update. For more info see https://github.
             ...prevState.values as object,
             [field]: val,
           },
+          touched: touchOnChange
+            ? {
+                ...prevState.touched as object,
+                [field]: true,
+              }
+            : prevState.touched,
         }));
 
         if (validateOnChange) {
@@ -381,6 +393,12 @@ Formik cannot determine which value to update. For more info see https://github.
             ...prevState.values as object,
             [field]: value,
           },
+          touched: touchOnChange
+            ? {
+                ...prevState.touched as object,
+                [field]: true,
+              }
+            : prevState.touched,
         }));
 
         if (validateOnChange) {
@@ -467,9 +485,12 @@ Formik cannot determine which value to update. For more info see https://github.
         e.persist();
         const { name, id } = e.target;
         const field = name ? name : id;
-        this.setState(prevState => ({
-          touched: { ...prevState.touched as object, [field]: true },
-        }));
+
+        if (touchOnBlur) {
+          this.setState(prevState => ({
+            touched: { ...prevState.touched as object, [field]: true },
+          }));
+        }
 
         if (validateOnBlur) {
           this.runValidations(this.state.values);

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -102,6 +102,28 @@ describe('Formik', () => {
         ).toEqual('ian');
       });
 
+      it('sets values and touched state if touchOnChange is true', async () => {
+        const TouchOnChangeForm = FormFactory({ touchOnChange: true });
+        const tree = shallow(<TouchOnChangeForm user={{ name: 'jared' }} />);
+
+        // Simulate a change event in the inner Form component's input
+        tree.find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            id: 'name',
+            value: 'ian',
+          },
+        });
+
+        expect(tree.update().state().values).toEqual({ name: 'ian' });
+        expect(
+          tree.update().find(Form).dive().find('input').props().value
+        ).toEqual('ian');
+        expect(tree.update().find(Form).props().touched).toEqual({
+          name: true,
+        });
+      });
+
       it('updates values state via `name` instead of `id` attribute when both are present', async () => {
         const tree = shallow(<BasicForm user={{ name: 'jared' }} />);
 
@@ -154,7 +176,7 @@ describe('Formik', () => {
     });
 
     describe('handleBlur', () => {
-      it('sets touched state', () => {
+      it('sets touched state by default', () => {
         const tree = shallow(<BasicForm user={{ name: 'jared' }} />);
 
         // Simulate a blur event in the inner Form component's input
@@ -165,6 +187,20 @@ describe('Formik', () => {
           },
         });
         expect(tree.update().state().touched).toEqual({ name: true });
+      });
+
+      it('does not set touched state if touchOnBlur is false', () => {
+        const NeverTouch = FormFactory({ touchOnBlur: false });
+        const tree = shallow(<NeverTouch user={{ name: 'jared' }} />);
+
+        // Simulate a blur event in the inner Form component's input
+        tree.find(Form).dive().find('input').simulate('blur', {
+          persist: noop,
+          target: {
+            id: 'name',
+          },
+        });
+        expect(tree.update().state().touched).toEqual({});
       });
 
       it('updates touched state via `name` instead of `id` attribute when both are present', () => {
@@ -425,6 +461,16 @@ describe('Formik', () => {
       const tree = shallow(<ValidateOnBlurForm user={{ name: 'jared' }} />);
       tree.find(Form).props().setFieldValue('name', 'ian');
       expect(validate).not.toHaveBeenCalled();
+    });
+
+    it('setFieldValue should touch field if touchOnChange is set to true', () => {
+      const validate = jest.fn();
+      const ValidateOnBlurForm = FormFactory({ validate, touchOnChange: true });
+      const tree = shallow(<ValidateOnBlurForm user={{ name: 'jared' }} />);
+      tree.find(Form).props().setFieldValue('name', 'ian');
+      expect(tree.find(Form).props().dirty).toBe(true);
+      expect(tree.find(Form).props().touched).toEqual({ name: true });
+      expect(tree.find(Form).props().values).toEqual({ name: 'ian' });
     });
 
     it('setTouched sets touched', async () => {

--- a/tslint.json
+++ b/tslint.json
@@ -32,7 +32,6 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,


### PR DESCRIPTION
Fix #114 and #116 

Adds `touchOnBlur?: boolean = true` and `touchOnChange?: boolean = false` options to Formik configuration. This gives much needed control over updates to `touched`.

**To Discuss**

- I wonder if `setFieldValue()` should accept an optional third argument that will set `touched` regardless of config like so:

```js
props.setFieldValue(field: string, value: any, setTouched?: boolean) => void;
```
- Are these defaults correct?



