### PR TITLE
[Next] Add backwards compat with withFormik HoC

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "format": "prettier --trailing-comma es5 --single-quote --write 'src/**/*' 'test/**/*'",
     "precommit": "lint-staged"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
     "react": ">=15"
   },
@@ -52,7 +54,6 @@
     "jest": "20.0.4",
     "lint-staged": "4.0.2",
     "prettier": "1.5.3",
-    "prop-types": "15.5.10",
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-test-renderer": "15.6.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,10 +8,9 @@ import uglify from 'rollup-plugin-uglify';
 const shared = {
   entry: `compiled/formik.js`,
   sourceMap: true,
-  external: ['react', 'prop-types'],
+  external: ['react'],
   globals: {
     react: 'React',
-    'prop-types': 'PropTypes',
   },
   exports: 'named',
 };
@@ -32,7 +31,40 @@ export default [
           process.env.NODE_ENV || 'development'
         ),
       }),
-      commonjs(),
+      resolve(),
+      commonjs({
+        include: /node_modules/,
+      }),
+
+      sourceMaps(),
+      process.env.NODE_ENV === 'production' && filesize(),
+      process.env.NODE_ENV === 'production' && uglify(),
+    ],
+  }),
+  Object.assign({}, shared, {
+    moduleName: 'Formik',
+    format: 'umd',
+    entry: `compiled/next.js`,
+    dest:
+      process.env.NODE_ENV === 'production'
+        ? './dist/next.umd.min.js'
+        : './dist/next.umd.js',
+    plugins: [
+      resolve(),
+      replace({
+        exclude: 'node_modules/**',
+        'process.env.NODE_ENV': JSON.stringify(
+          process.env.NODE_ENV || 'development'
+        ),
+      }),
+      resolve(),
+      commonjs({
+        include: /node_modules/,
+        namedExports: {
+          'node_modules/prop-types/index.js': ['object'],
+        },
+      }),
+
       sourceMaps(),
       process.env.NODE_ENV === 'production' && filesize(),
       process.env.NODE_ENV === 'production' && uglify(),
@@ -43,7 +75,14 @@ export default [
       { dest: 'dist/formik.es6.js', format: 'es' },
       { dest: 'dist/formik.js', format: 'cjs' },
     ],
-    plugins: [resolve(), sourceMaps()],
+    plugins: [
+      resolve(),
+      commonjs({
+        include: /node_modules/,
+      }),
+      ,
+      sourceMaps(),
+    ],
   }),
   Object.assign({}, shared, {
     entry: `compiled/next.js`,
@@ -51,6 +90,16 @@ export default [
       { dest: 'dist/next.es6.js', format: 'es' },
       { dest: 'dist/next.js', format: 'cjs' },
     ],
-    plugins: [resolve(), sourceMaps()],
+    plugins: [
+      resolve(),
+      commonjs({
+        include: /node_modules/,
+        namedExports: {
+          'node_modules/prop-types/index.js': ['object'],
+        },
+      }),
+      ,
+      sourceMaps(),
+    ],
   }),
 ];

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import { Formik, FormikConfig, FormikProps, FormikValues } from './next';
+
+import { InjectedFormikProps } from './formik';
+import { hoistNonReactStatics } from './hoistStatics';
+
+export type CompositeComponent<P> =
+  | React.ComponentClass<P>
+  | React.StatelessComponent<P>;
+
+export interface ComponentDecorator<TOwnProps, TMergedProps> {
+  (component: CompositeComponent<TMergedProps>): React.ComponentClass<
+    TOwnProps
+  >;
+}
+
+export interface InferableComponentDecorator<TOwnProps> {
+  <T extends CompositeComponent<TOwnProps>>(component: T): T;
+}
+
+/**
+ * A public higher-order component to access the imperative API
+ */
+export function withFormik<
+  Props,
+  Values extends FormikValues,
+  Payload = Values
+>({
+  mapPropsToValues = (vanillaProps: any) => {
+    let val: FormikValues = {} as FormikValues;
+    for (let k in vanillaProps) {
+      if (
+        vanillaProps.hasOwnProperty(k) &&
+        typeof vanillaProps[k] !== 'function'
+      ) {
+        val[k] = vanillaProps[k];
+      }
+    }
+    return val;
+  },
+  ...config,
+}: FormikConfig<Props, Values, Payload>): ComponentDecorator<
+  Props,
+  InjectedFormikProps<Props, Values>
+> {
+  return function createFormik(Component: CompositeComponent<Props>) {
+    const C: React.SFC<Props> = props => {
+      return (
+        <Formik
+          {...props}
+          {...config}
+          getInitialValues={mapPropsToValues(props)}
+          render={(formikProps: FormikProps<Values>) =>
+            <Component {...props} {...formikProps} />}
+        />
+      );
+    };
+    return hoistNonReactStatics<Props>(
+      C as any,
+      Component as React.ComponentClass<InjectedFormikProps<Props, Values>> // cast type to ComponentClass (even if SFC)
+    ) as React.ComponentClass<Props>;
+  };
+}

--- a/test/next.test.tsx
+++ b/test/next.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
-import { FormComponentProps, Formik, FormikProps } from '../src/next';
+import { Formik, FormikProps } from '../src/next';
 import { mount, shallow } from 'enzyme';
 
 const Yup = require('yup');
@@ -22,7 +22,7 @@ interface Values {
   name: string;
 }
 
-const Form: React.SFC<FormComponentProps<Values>> = ({
+const Form: React.SFC<FormikProps<Values>> = ({
   values,
   handleSubmit,
   handleChange,

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { Formik, InjectedFormikProps, withFormik } from '../src/next';
+import { mount, render, shallow } from 'enzyme';
+
+const Yup = require('yup');
+
+// tslint:disable-next-line:no-empty
+const noop = () => {};
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('withFormik', () => {
+  const node = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  it('provides correct props', () => {
+    const Basic = withFormik<{ passThru: string }, {}>({
+      handleSubmit: noop,
+      isInitialValid: true,
+    })(props => {
+      expect(props.dirty).toBe(false);
+      expect(props.isValid).toBe(true);
+      expect(props.values).toEqual({
+        passThru: 'pass',
+      });
+      expect(props.errors).toEqual({});
+      expect(props.touched).toEqual({});
+      expect(props.isSubmitting).toEqual(false);
+      return null;
+    });
+    ReactDOM.render(<Basic passThru="pass" />, node);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,7 +2389,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.10, prop-types@^15.5.10:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
An attempt to add backwards compat for JS and TS users. 

Weird stuff... 

Formik config and the Formik HOC props are not 1:1 in their implementation (like React Router's withRouter HOC is)...
- the default `mapValuesToProps function is problematic because in HOC land that needs to be lifted up above the new <Formik/> component.
- passing props in the Formik bag to `handleSubmit` is required in the HoC but redundant in the Component
   - Idea 1: Add `onSubmit` that is just for the component version
   
