### PR TITLE
changing handleSubmit to onSubmit, mapping to old handleSubmit correctly

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -132,7 +132,7 @@ export interface FormikConfig extends FormikSharedConfig {
   /** 
    * Submission handler 
    */
-  handleSubmit: (values: object, formikActions: FormikActions<any>) => void;
+  onSubmit: (values: object, formikActions: FormikActions<any>) => void;
 
   /**
    * Form component to render
@@ -175,7 +175,7 @@ export class Formik<
     validateOnBlur: PropTypes.bool,
     isInitialValid: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     initialValues: PropTypes.object,
-    handleSubmit: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
     validationSchema: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     validate: PropTypes.func,
     component: PropTypes.func,
@@ -477,7 +477,7 @@ Formik cannot determine which value to update. For more info see https://github.
   };
 
   executeSubmit = () => {
-    this.props.handleSubmit(this.state.values, {
+    this.props.onSubmit(this.state.values, {
       setStatus: this.setStatus,
       setTouched: this.setTouched,
       setErrors: this.setErrors,

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -100,6 +100,9 @@ export function withFormik<
           {...props}
           {...config}
           initialValues={mapPropsToValues(props)}
+          onSubmit={(values, actions) => {
+            config.handleSubmit(values as Values, { ...actions, props })
+          }}
           render={(formikProps: FormikProps<Values>) =>
             <Component {...props} {...formikProps} />}
         />

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -65,7 +65,7 @@ const Form: React.SFC<FormikProps<Values>> = ({
 const BasicForm = (
   <Formik
     initialValues={{ name: 'jared' }}
-    handleSubmit={noop}
+    onSubmit={noop}
     component={Form}
   />
 );
@@ -125,7 +125,7 @@ describe('Formik Next', () => {
         const tree = shallow(
           <Formik
             initialValues={{ name: 'jared' }}
-            handleSubmit={noop}
+            onSubmit={noop}
             component={Form}
             validate={validate}
             validateOnChange={true}
@@ -147,7 +147,7 @@ describe('Formik Next', () => {
         const tree = shallow(
           <Formik
             initialValues={{ name: 'jared' }}
-            handleSubmit={noop}
+            onSubmit={noop}
             component={Form}
             validate={validate}
             validateOnChange={false}
@@ -198,7 +198,7 @@ describe('Formik Next', () => {
         const tree = shallow(
           <Formik
             initialValues={{ name: 'jared' }}
-            handleSubmit={noop}
+            onSubmit={noop}
             component={Form}
             validate={validate}
             validateOnBlur={true}
@@ -252,7 +252,7 @@ describe('Formik Next', () => {
       //   const CustomPayloadForm = Formik<Props, Values, Payload>({
       //     mapPropsToValues: ({ user }) => ({ ...user }),
       //     mapValuesToPayload: ({ name }) => ({ user: { name } }),
-      //     handleSubmit: payload => {
+      //     onSubmit: payload => {
       //       expect(payload).toEqual({ user: { name: 'jared' } });
       //       expect(payload).not.toEqual({ name: 'jared' });
       //     },
@@ -269,7 +269,7 @@ describe('Formik Next', () => {
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={noop}
+              onSubmit={noop}
               component={Form}
               validate={validate}
             />
@@ -281,11 +281,11 @@ describe('Formik Next', () => {
         });
 
         it('should submit the form if valid', () => {
-          const handleSubmit = jest.fn();
+          const onSubmit = jest.fn();
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={handleSubmit}
+              onSubmit={onSubmit}
               component={Form}
               validate={noop}
             />
@@ -293,17 +293,17 @@ describe('Formik Next', () => {
           tree.find(Form).dive().find('form').simulate('submit', {
             preventDefault: noop,
           });
-          expect(handleSubmit).toHaveBeenCalled();
+          expect(onSubmit).toHaveBeenCalled();
         });
 
         it('should not submit the form if invalid', () => {
           const validate = jest.fn().mockReturnValue({ name: 'Error!' });
-          const handleSubmit = jest.fn();
+          const onSubmit = jest.fn();
 
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={handleSubmit}
+              onSubmit={onSubmit}
               component={Form}
               validate={validate}
             />
@@ -312,7 +312,7 @@ describe('Formik Next', () => {
             preventDefault: noop,
           });
           expect(validate).toHaveBeenCalled();
-          expect(handleSubmit).not.toHaveBeenCalled();
+          expect(onSubmit).not.toHaveBeenCalled();
         });
       });
 
@@ -323,7 +323,7 @@ describe('Formik Next', () => {
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={noop}
+              onSubmit={noop}
               component={Form}
               validate={validate}
             />
@@ -335,28 +335,28 @@ describe('Formik Next', () => {
         });
 
         it('should submit the form if valid', async () => {
-          const handleSubmit = jest.fn();
+          const onSubmit = jest.fn();
 
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={handleSubmit}
+              onSubmit={onSubmit}
               component={Form}
               validate={() => Promise.resolve({})}
             />
           );
           await tree.find(Form).props().submitForm();
 
-          expect(handleSubmit).toHaveBeenCalled();
+          expect(onSubmit).toHaveBeenCalled();
         });
 
         it('should not submit the form if invalid', async () => {
-          const handleSubmit = jest.fn();
+          const onSubmit = jest.fn();
 
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={handleSubmit}
+              onSubmit={onSubmit}
               component={Form}
               validate={() =>
                 sleep(25).then(() => {
@@ -366,7 +366,7 @@ describe('Formik Next', () => {
           );
           await tree.find(Form).props().submitForm();
 
-          expect(handleSubmit).not.toHaveBeenCalled();
+          expect(onSubmit).not.toHaveBeenCalled();
         });
       });
 
@@ -376,7 +376,7 @@ describe('Formik Next', () => {
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={noop}
+              onSubmit={noop}
               component={Form}
               validate={validate}
               validationSchema={{
@@ -395,7 +395,7 @@ describe('Formik Next', () => {
           const tree = shallow(
             <Formik
               initialValues={{ name: 'jared' }}
-              handleSubmit={noop}
+              onSubmit={noop}
               component={Form}
               validate={validate}
               validationSchema={() => ({
@@ -424,7 +424,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnChange={true}
@@ -439,7 +439,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnChange={false}
@@ -461,7 +461,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnChange={true}
@@ -477,7 +477,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnChange={false}
@@ -498,7 +498,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
         />
@@ -513,7 +513,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnBlur={true}
@@ -538,7 +538,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnBlur={true}
@@ -554,7 +554,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           validate={validate}
           validateOnBlur={false}
@@ -599,7 +599,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           isInitialValid={props => true}
         />
@@ -612,7 +612,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           isInitialValid={props => false}
         />
@@ -625,7 +625,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           isInitialValid={true}
         />
@@ -638,7 +638,7 @@ describe('Formik Next', () => {
       const tree = shallow(
         <Formik
           initialValues={{ name: 'jared' }}
-          handleSubmit={noop}
+          onSubmit={noop}
           component={Form}
           isInitialValid={false}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,16 +759,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2050,17 +2043,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@^0.5.1:
   version "0.5.1"


### PR DESCRIPTION
As discussed, `onSubmit` is a more appropriate name for the `<Formik>` component's submit handler callback in the new render-props version.

Meanwhile there's a backwards-compat bug in `withFormik`'s `handleSubmit`, such that `props` does not get passed through anymore.

This PR renames `onSubmit` to `handleSubmit` for the render-prop version, and preserves backwards-compatible behavior of `handleSubmit` for the HOC/withFormik version.