### PR TITLE
Close #162, #139. Fix validation defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ const validate = (values, props) => {
 
 #### `validateOnBlur?: boolean`
 
-Default is `false`. Use this option to run validations on `blur` events. More specifically, when either [`handleBlur`], [`setFieldTouched`], or [`setTouched`] are called.
+Default is `true`. Use this option to run validations on `blur` events. More specifically, when either [`handleBlur`], [`setFieldTouched`], or [`setTouched`] are called.
 
 #### `validateOnChange?: boolean`
 
@@ -888,7 +888,7 @@ const validate = (values, props) => {
 
 ##### `validateOnBlur?: boolean`
 
-Default is `false`. Use this option to run validations on `blur` events. More specifically, when either [`handleBlur`], [`setFieldTouched`], or [`setTouched`] are called.
+Default is `true`. Use this option to run validations on `blur` events. More specifically, when either [`handleBlur`], [`setFieldTouched`], or [`setTouched`] are called.
 
 ##### `validateOnChange?: boolean`
 

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -166,7 +166,7 @@ export class Formik<
 > extends React.Component<Props, FormikState<any>> {
   static defaultProps = {
     validateOnChange: true,
-    validateOnBlur: false,
+    validateOnBlur: true,
     isInitialValid: false,
   };
 

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -63,11 +63,7 @@ const Form: React.SFC<FormikProps<Values>> = ({
 };
 
 const BasicForm = (
-  <Formik
-    initialValues={{ name: 'jared' }}
-    onSubmit={noop}
-    component={Form}
-  />
+  <Formik initialValues={{ name: 'jared' }} onSubmit={noop} component={Form} />
 );
 
 describe('Formik Next', () => {
@@ -504,7 +500,7 @@ describe('Formik Next', () => {
         />
       );
       tree.find(Form).props().setTouched({ name: true });
-      expect(validate).not.toHaveBeenCalled();
+      expect(validate).toHaveBeenCalled();
     });
 
     it('setTouched should run validations when validateOnBlur is true', () => {


### PR DESCRIPTION
Due to consensus, this PR sets `validateOnBlur` and `validateOnChange` to true by default in Formik. 

The suggested method for showing feedback to the user is officially:
```
{errors.field && touched.field && <div>{errors.field}</div>}
```

It's worth considering codifying this by creating a `<FieldFeedback name render />` component. Im not sure it's worth it as it's more likely people will include standardized errors in a custom `Field component/>`. However, an optimized `<FieldFeedback >` might be more performant.