### PR TITLE
Fix check to call resetForm on componentWillReceiveProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gen-docs": "all-contributors generate && doctoc README.md"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0",
+    "lodash.isequal": "4.5.0",
     "prop-types": "^15.5.10",
     "warning": "^3.0.0"
   },
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/enzyme": "2.8.4",
     "@types/jest": "20.0.6",
-    "@types/lodash.isequal": "^4.5.2",
+    "@types/lodash.isequal": "4.5.2",
     "@types/node": "8.0.19",
     "@types/prop-types": "15.5.1",
     "@types/react": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gen-docs": "all-contributors generate && doctoc README.md"
   },
   "dependencies": {
+    "lodash.isequal": "^4.5.0",
     "prop-types": "^15.5.10",
     "warning": "^3.0.0"
   },
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@types/enzyme": "2.8.4",
     "@types/jest": "20.0.6",
+    "@types/lodash.isequal": "^4.5.2",
     "@types/node": "8.0.19",
     "@types/prop-types": "15.5.1",
     "@types/react": "16.0.0",

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -1,5 +1,6 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import isEqual from 'lodash.isequal';
 
 import { isFunction, isPromise, isReactNative, values } from './utils';
 
@@ -233,7 +234,7 @@ export class Formik<
 
   componentWillReceiveProps(nextProps: Props) {
     // If the initialValues change, reset the form
-    if (nextProps.initialValues !== this.props.initialValues) {
+    if (!isEqual(nextProps.initialValues, this.props.initialValues)) {
       this.resetForm(nextProps.initialValues);
     }
   }

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -661,4 +661,30 @@ describe('Formik Next', () => {
       expect(tree.find(Form).props().isValid).toBe(true);
     });
   });
+
+  describe('componentWillReceiveProps', () => {
+    let form, initialValues
+    beforeEach(() => {
+      initialValues = { name: 'formik', github: { repoUrl: 'https://github.com/jaredpalmer/formik' }, watchers: ['ian', 'sam'] }
+      form = new Formik({ initialValues, onSubmit: jest.fn()})
+      form.resetForm = jest.fn()
+    })
+    it('should not resetForm if new initialValues are the same as previous', () => {
+      const newInitialValues = Object.assign({}, initialValues)
+      form.componentWillReceiveProps({ initialValues: newInitialValues, onSubmit: jest.fn() })
+      expect(form.resetForm).not.toHaveBeenCalled()
+    })
+
+    it('should resetForm if new initialValues are different than previous', () => {
+      const newInitialValues = Object.assign({}, initialValues, { watchers: ['jared', 'ian', 'sam'] })
+      form.componentWillReceiveProps({ initialValues: newInitialValues, onSubmit: jest.fn() })
+      expect(form.resetForm).toHaveBeenCalled()
+    })
+
+    it('should resetForm if new initialValues are deeply different than previous', () => {
+      const newInitialValues = Object.assign({}, initialValues, { github: { repoUrl: 'different' } })
+      form.componentWillReceiveProps({ initialValues: newInitialValues, onSubmit: jest.fn() })
+      expect(form.resetForm).toHaveBeenCalled()
+    })
+  })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,16 @@
   version "20.0.6"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.6.tgz#7e0ba76ddfacb42ee9bb0d8833e5208cf0680431"
 
+"@types/lodash.isequal@4.5.2":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.2.tgz#adbdff67f7c956ed703009e5466a34eeddb0b712"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.76"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.76.tgz#87874f766774d54e89589697340be9496fb8bf70"
+
 "@types/node@8.0.19":
   version "8.0.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.19.tgz#e46e2b0243de7d03f15b26b45c59ebb84f657a4e"
@@ -2060,6 +2070,10 @@ lodash.flatten@^4.2.0:
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.isequal@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.map@^4.4.0:
   version "4.6.0"


### PR DESCRIPTION
initialValues comparison was using an object equality check with !== this was replaced with a deepequal check from lodash.isEqual

Fixes #164 
