### PR TITLE
Check `e.persist` exists before calling

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -352,7 +352,7 @@ export class Formik<
       }
       return;
     }
-    e.persist();
+    if (typeof e.persist === 'function') e.persist();
     const { type, name, id, value, checked, outerHTML } = e.target;
     const field = name ? name : id;
     const val = /number|range/.test(type)
@@ -504,7 +504,7 @@ Formik cannot determine which value to update. For more info see https://github.
       }
       return;
     }
-    e.persist();
+    if (typeof e.persist === 'function') e.persist();
     const { name, id } = e.target;
     const field = name ? name : id;
     this.setState(prevState => ({


### PR DESCRIPTION
In `react-material-ui@1.0.0-beta.x` the `Select` component doesn't return an event w/ `persist()` causing an error to occur.