### PR TITLE
Fix #178. Pass props to validate and validationSchema in withFormik()

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -108,11 +108,6 @@ export interface FormikHandlers {
  * Base formik configuration/props shared between the HoC and Component.
  */
 export interface FormikSharedConfig {
-  /** 
-   * Validation function. Must return an error object or promise that 
-   * throws an error object where that object keys map to corresponding value.
-   */
-  validate?: ((values: any) => void | object | Promise<any>);
   /** A Yup Schema */
   validationSchema?: any;
 
@@ -143,6 +138,12 @@ export interface FormikConfig extends FormikSharedConfig {
    * Render prop (works like React router's <Route render={props =>} />)
    */
   render?: ((props: FormikProps<any>) => React.ReactNode);
+
+  /** 
+   * Validation function. Must return an error object or promise that 
+   * throws an error object where that object keys map to corresponding value.
+   */
+  validate?: ((values: any) => void | object | Promise<any>);
 
   /**
    * React children or child render callback

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -108,9 +108,6 @@ export interface FormikHandlers {
  * Base formik configuration/props shared between the HoC and Component.
  */
 export interface FormikSharedConfig {
-  /** A Yup Schema */
-  validationSchema?: any;
-
   /** Tells Formik to validate the form on each input's onChange event */
   validateOnChange?: boolean;
   /** Tells Formik to validate the form on each input's onBlur event */
@@ -123,7 +120,11 @@ export interface FormikSharedConfig {
  * <Formik /> props
  */
 export interface FormikConfig extends FormikSharedConfig {
+  /** 
+   * Initial values of the form
+   */
   initialValues: object;
+
   /** 
    * Submission handler 
    */
@@ -138,6 +139,11 @@ export interface FormikConfig extends FormikSharedConfig {
    * Render prop (works like React router's <Route render={props =>} />)
    */
   render?: ((props: FormikProps<any>) => React.ReactNode);
+
+  /** 
+   * A Yup Schema or a function that returns a Yup schema 
+   */
+  validationSchema?: any | (() => any);
 
   /** 
    * Validation function. Must return an error object or promise that 

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -305,7 +305,7 @@ export class Formik<
   runValidationSchema = (values: FormikValues, onSuccess?: Function) => {
     const { validationSchema } = this.props;
     const schema = isFunction(validationSchema)
-      ? validationSchema(this.props)
+      ? validationSchema()
       : validationSchema;
     validateYupSchema(values, schema).then(
       () => {

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -115,12 +115,12 @@ export function withFormik<
      */
     class C extends React.Component<Props, {}> {
       validate = (values: Values): void | object | Promise<any> => {
-        return config.validate && config.validate(values, this.props);
+        return config.validate!(values, this.props);
       };
 
       validationSchema = () => {
-        return config.validationSchema && isFunction(config.validationSchema)
-          ? config.validationSchema(this.props)
+        return isFunction(config.validationSchema)
+          ? config.validationSchema!(this.props)
           : config.validationSchema;
       };
 
@@ -143,8 +143,8 @@ export function withFormik<
           <Formik
             {...this.props}
             {...config}
-            validate={this.validate}
-            validationSchema={this.validationSchema}
+            validate={config.validate && this.validate}
+            validationSchema={config.validationSchema && this.validationSchema}
             initialValues={mapPropsToValues(this.props)}
             onSubmit={this.handleSubmit}
             render={this.renderFormComponent}

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -65,7 +65,7 @@ export interface WithFormikConfig<
    * Validation function. Must return an error object or promise that 
    * throws an error object where that object keys map to corresponding value.
    */
-  validate?: ((values: any, props: Props) => void | object | Promise<any>);
+  validate?: (values: any, props: Props) => void | object | Promise<any>;
 }
 
 export type CompositeComponent<P> =
@@ -114,15 +114,15 @@ export function withFormik<
      */
     class C extends React.Component<Props, {}> {
       validate = (values: Values) => {
-        config.validate!(values, this.props);
+        return config.validate!(values, this.props);
       };
 
       validationSchema = () => {
-        config.validationSchema!(this.props);
+        return config.validationSchema!(this.props);
       };
 
       handleSubmit = (values: Values, actions: FormikActions<Values>) => {
-        config.handleSubmit(values as Values, {
+        return config.handleSubmit(values as Values, {
           ...actions,
           props: this.props,
         });

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -57,6 +57,11 @@ export interface WithFormikConfig<
   mapValuesToPayload?: (values: Values) => DeprecatedPayload;
 
   /** 
+   * A Yup Schema or a function that returns a Yup schema 
+   */
+  validationSchema?: any | ((props: Props) => any);
+
+  /** 
    * Validation function. Must return an error object or promise that 
    * throws an error object where that object keys map to corresponding value.
    */
@@ -112,8 +117,8 @@ export function withFormik<
         config.validate!(values, this.props);
       };
 
-      validationSchema = (values: Values) => {
-        config.validationSchema!(values, this.props);
+      validationSchema = () => {
+        config.validationSchema!(this.props);
       };
 
       handleSubmit = (values: Values, actions: FormikActions<Values>) => {

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -12,6 +12,7 @@ import {
 } from './formik';
 
 import { hoistNonReactStatics } from './hoistStatics';
+import { isFunction } from './utils';
 
 /**
  * State, handlers, and helpers injected as props into the wrapped form component.
@@ -118,7 +119,9 @@ export function withFormik<
       };
 
       validationSchema = () => {
-        return config.validationSchema!(this.props);
+        return isFunction(config.validationSchema)
+          ? config.validationSchema!(this.props)
+          : config.validationSchema;
       };
 
       handleSubmit = (values: Values, actions: FormikActions<Values>) => {

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -114,13 +114,13 @@ export function withFormik<
      * the respective withFormik config methods. 
      */
     class C extends React.Component<Props, {}> {
-      validate = (values: Values) => {
-        return config.validate!(values, this.props);
+      validate = (values: Values): void | object | Promise<any> => {
+        return config.validate && config.validate(values, this.props);
       };
 
       validationSchema = () => {
-        return isFunction(config.validationSchema)
-          ? config.validationSchema!(this.props)
+        return config.validationSchema && isFunction(config.validationSchema)
+          ? config.validationSchema(this.props)
           : config.validationSchema;
       };
 
@@ -143,8 +143,8 @@ export function withFormik<
           <Formik
             {...this.props}
             {...config}
-            validate={config.validate && this.validate}
-            validationSchema={config.validationSchema && this.validationSchema}
+            validate={this.validate}
+            validationSchema={this.validationSchema}
             initialValues={mapPropsToValues(this.props)}
             onSubmit={this.handleSubmit}
             render={this.renderFormComponent}

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -51,7 +51,16 @@ export interface WithFormikConfig<
    */
   mapPropsToValues?: (props: Props) => Values;
 
+  /**
+   * @deprecated in 0.9.0 (but needed to break TS types)
+   */
   mapValuesToPayload?: (values: Values) => DeprecatedPayload;
+
+  /** 
+   * Validation function. Must return an error object or promise that 
+   * throws an error object where that object keys map to corresponding value.
+   */
+  validate?: ((values: any, props: Props) => void | object | Promise<any>);
 }
 
 export type CompositeComponent<P> =
@@ -94,20 +103,48 @@ export function withFormik<
   InjectedFormikProps<Props, Values>
 > {
   return function createFormik(Component: CompositeComponent<Props>) {
-    const C: React.SFC<Props> = props => {
-      return (
-        <Formik
-          {...props}
-          {...config}
-          initialValues={mapPropsToValues(props)}
-          onSubmit={(values, actions) => {
-            config.handleSubmit(values as Values, { ...actions, props });
-          }}
-          render={(formikProps: FormikProps<Values>) =>
-            <Component {...props} {...formikProps} />}
-        />
-      );
-    };
+    /**
+     * We need to use closures here for to provide the wrapped component's props to
+     * the respective withFormik config methods. 
+     */
+    class C extends React.Component<Props, {}> {
+      validate = (values: Values) => {
+        config.validate!(values, this.props);
+      };
+
+      validationSchema = (values: Values) => {
+        config.validationSchema!(values, this.props);
+      };
+
+      handleSubmit = (values: Values, actions: FormikActions<Values>) => {
+        config.handleSubmit(values as Values, {
+          ...actions,
+          props: this.props,
+        });
+      };
+
+      /**
+       * Just avoiding a render callback for perf here
+       */
+      renderFormComponent = (formikProps: FormikProps<Values>) => {
+        return <Component {...this.props} {...formikProps} />;
+      };
+
+      render() {
+        return (
+          <Formik
+            {...this.props}
+            {...config}
+            validate={config.validate && this.validate}
+            validationSchema={config.validationSchema && this.validationSchema}
+            initialValues={mapPropsToValues(this.props)}
+            onSubmit={this.handleSubmit}
+            render={this.renderFormComponent}
+          />
+        );
+      }
+    }
+
     return hoistNonReactStatics<Props>(
       C as any,
       Component as React.ComponentClass<InjectedFormikProps<Props, Values>> // cast type to ComponentClass (even if SFC)

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -1,0 +1,408 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import { withFormik, InjectedFormikProps } from '../src/withFormik';
+import { mount, shallow } from 'enzyme';
+import { values } from '../src/utils';
+import { Formik } from '../src/formik';
+
+const Yup = require('yup');
+
+// tslint:disable-next-line:no-empty
+const noop = () => {};
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+interface Props {
+  user: {
+    name: string;
+  };
+  someFunction?: () => void;
+}
+
+interface Values {
+  name: string;
+}
+
+const Form: React.SFC<InjectedFormikProps<Props, Values>> = ({
+  values,
+  handleSubmit,
+  handleChange,
+  handleBlur,
+  touched,
+  setStatus,
+  status,
+  errors,
+  isSubmitting,
+}) => {
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="text"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.name}
+        name="name"
+      />
+      {touched.name &&
+        errors.name &&
+        <div id="feedback">
+          {errors.name}
+        </div>}
+      {isSubmitting && <div id="submitting">Submitting</div>}
+      <button
+        id="statusButton"
+        onClick={() => setStatus({ myStatusMessage: 'True' })}
+      >
+        Call setStatus
+      </button>
+      {status &&
+        !!status.myStatusMessage &&
+        <div id="statusMessage">
+          {status.myStatusMessage}
+        </div>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+const FormFactory = (options = {}) =>
+  withFormik<Props, Values, Values>({
+    mapPropsToValues: ({ user }) => ({ ...user }),
+    handleSubmit: noop,
+    ...options,
+  })(Form);
+
+const BasicForm = FormFactory();
+
+describe('withFormik()', () => {
+  it('should initialize Formik state and pass down props', () => {
+    const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+    expect(tree.find(Form).props().isSubmitting).toBe(false);
+    expect(tree.find(Form).props().touched).toEqual({});
+    expect(tree.find(Form).props().values).toEqual({ name: 'jared' });
+    expect(tree.find(Form).props().errors).toEqual({});
+    expect(tree.find(Form).props().dirty).toBe(false);
+    expect(tree.find(Form).props().isValid).toBe(false);
+  });
+
+  describe('FormikHandlers', () => {
+    describe('handleChange', () => {
+      it('sets values state', async () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+
+        // Simulate a change event in the inner Form component's input
+        tree.find(Form).find('input').simulate('change', {
+          persist: noop,
+          target: {
+            id: 'name',
+            value: 'ian',
+          },
+        });
+        expect(tree.find(Form).find('input').props().value).toEqual('ian');
+      });
+
+      it('updates values state via `name` instead of `id` attribute when both are present', async () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+
+        // Simulate a change event in the inner Form component's input
+        tree.find(Form).find('input').simulate('change', {
+          persist: noop,
+          target: {
+            id: 'person-1-thinger',
+            name: 'name',
+            value: 'ian',
+          },
+        });
+
+        expect(tree.find(Form).props().values).toEqual({ name: 'ian' });
+        expect(tree.find(Form).find('input').props().value).toEqual('ian');
+      });
+
+      it('runs validations by default (validate)', async () => {
+        const validate = jest.fn(noop);
+        const ValidationForm = FormFactory({
+          validate,
+        });
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+        tree.dive().find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: 'ian',
+          },
+        });
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('does NOT run validations if validateOnChange is false (validate)', async () => {
+        const validate = jest.fn(noop);
+        const ValidationForm = FormFactory({
+          validate,
+          validateOnChange: false,
+        });
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+
+        tree.dive().find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: 'ian',
+          },
+        });
+        expect(validate).not.toHaveBeenCalled();
+      });
+
+      it('runs validations by default (validationSchema)', async () => {
+        const validate = jest.fn(() => Promise.resolve({}));
+        const ValidationForm = FormFactory({ validationSchema: { validate } });
+
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+
+        tree.dive().find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: 'ian',
+          },
+        });
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('does NOT run validations if validateOnChange is false (validationSchema)', async () => {
+        const validate = jest.fn(() => Promise.resolve({}));
+        const ValidationForm = FormFactory({
+          validateOnChange: false,
+          validationSchema: { validate },
+        });
+
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+
+        tree.dive().find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: 'ian',
+          },
+        });
+        expect(validate).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('handleBlur', () => {
+      it('sets touched state', () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+
+        // Simulate a blur event in the inner Form component's input
+        tree.find(Form).find('input').simulate('blur', {
+          persist: noop,
+          target: {
+            id: 'name',
+          },
+        });
+        expect(tree.find(Form).props().touched).toEqual({ name: true });
+      });
+
+      it('updates touched state via `name` instead of `id` attribute when both are present', () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+
+        // Simulate a blur event in the inner Form component's input
+        tree.find(Form).find('input').simulate('blur', {
+          persist: noop,
+          target: {
+            id: 'person-1-name-blah',
+            name: 'name',
+          },
+        });
+        expect(tree.find(Form).props().touched).toEqual({ name: true });
+      });
+
+      it('runs validations by default (validate)', async () => {
+        const validate = jest.fn(noop);
+        const ValidationForm = FormFactory({ validate });
+
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+
+        tree.dive().find(Form).dive().find('input').simulate('blur', {
+          persist: noop,
+          target: {
+            name: 'name',
+          },
+        });
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('runs validations by default (validationSchema)', async () => {
+        const validate = jest.fn(() => Promise.resolve({}));
+        const ValidationForm = FormFactory({ validationSchema: { validate } });
+
+        const tree = shallow(<ValidationForm user={{ name: 'jared' }} />);
+
+        tree.dive().find(Form).dive().find('input').simulate('blur', {
+          persist: noop,
+          target: {
+            name: 'name',
+          },
+        });
+
+        expect(validate).toHaveBeenCalled();
+      });
+    });
+
+    describe('handleSubmit', () => {
+      it('should call preventDefault()', () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+        const preventDefault = jest.fn();
+        tree.find(Form).find('form').simulate('submit', {
+          preventDefault,
+        });
+        expect(preventDefault).toHaveBeenCalled();
+      });
+
+      it('should touch all fields', () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+        tree.find(Form).find('form').simulate('submit', {
+          preventDefault: noop,
+        });
+        expect(tree.find(Form).props().touched).toEqual({
+          name: true,
+        });
+      });
+
+      it('should push submission state changes to child component', () => {
+        const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+
+        expect(tree.find(Form).find('#submitting')).toHaveLength(0);
+
+        tree.find(Form).find('form').simulate('submit', {
+          preventDefault: noop,
+        });
+
+        expect(tree.find(Form).find('#submitting')).toHaveLength(1);
+      });
+
+      describe('with validate (SYNC)', () => {
+        it('should call validate if present', () => {
+          const validate = jest.fn().mockReturnValue({});
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate,
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit: noop,
+          })(Form);
+          const tree = mount(<ValidateForm user={{ name: 'jared' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(validate).toHaveBeenCalled();
+        });
+
+        it('should submit the form if valid', () => {
+          const handleSubmit = jest.fn();
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate: noop,
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit,
+          })(Form);
+          const tree = mount(<ValidateForm user={{ name: 'jared' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(handleSubmit).toHaveBeenCalled();
+        });
+
+        it('should not submit the form if invalid', () => {
+          const validate = jest.fn().mockReturnValue({ name: 'Error!' });
+          const handleSubmit = jest.fn();
+
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate,
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit,
+          })(Form);
+
+          const tree = mount(<ValidateForm user={{ name: '' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(validate).toHaveBeenCalled();
+          expect(handleSubmit).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('with validate (ASYNC)', () => {
+        it('should call validate if present', () => {
+          const validate = jest.fn(() => Promise.resolve({}));
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate,
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit: noop,
+          })(Form);
+          const tree = mount(<ValidateForm user={{ name: 'jared' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(validate).toHaveBeenCalled();
+        });
+
+        it('should submit the form if valid', async () => {
+          const handleSubmit = jest.fn();
+
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate: () => Promise.resolve({}),
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit,
+          })(Form);
+
+          const tree = mount(<ValidateForm user={{ name: '' }} />);
+          await tree.find(Form).props().submitForm();
+
+          expect(handleSubmit).toHaveBeenCalled();
+        });
+
+        it('should not submit the form if invalid', async () => {
+          const handleSubmit = jest.fn();
+
+          const ValidateForm = withFormik<Props, Values, Values>({
+            validate: () =>
+              sleep(25).then(() => {
+                throw { name: 'error!' };
+              }),
+            mapPropsToValues: ({ user }) => ({ ...user }),
+            handleSubmit,
+          })(Form);
+
+          const tree = mount(<ValidateForm user={{ name: '' }} />);
+          await tree.find(Form).props().submitForm();
+
+          expect(handleSubmit).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('with validationSchema (ASYNC)', () => {
+        it('should run validationSchema if present', () => {
+          const validate = jest.fn(() => Promise.resolve({}));
+          const ValidateForm = FormFactory({ validationSchema: { validate } });
+          const tree = mount(<ValidateForm user={{ name: 'jared' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(validate).toHaveBeenCalled();
+        });
+
+        it('should call validationSchema if it is a function and present', () => {
+          const validate = jest.fn(() => Promise.resolve({}));
+          const ValidateForm = FormFactory({
+            validationSchema: () => ({
+              validate,
+            }),
+          });
+          const tree = mount(<ValidateForm user={{ name: 'jared' }} />);
+          tree.find(Form).find('form').simulate('submit', {
+            preventDefault: noop,
+          });
+          expect(validate).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Moves validate out of `FormikSharedConfig` interface
- Exposes outer props to `validate`, `validationSchema` with closures
- Refactors `withFormik()` to use a class component