### PR TITLE
Add enableReinitialize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,26 +252,28 @@ npm install yup --save
     - [`component`](#component)
     - [`render: (props: FormikProps<Values>) => ReactNode`](#render-props-formikpropsvalues--reactnode)
     - [`children: func`](#children-func)
-    - [`onSubmit: (values: Values, formikBag: FormikBag) => void`](#onsubmit-values-values-formikbag-formikbag--void)
+    - [`enableReinitialize?: boolean`](#enablereinitialize-boolean)
     - [`isInitialValid?: boolean`](#isinitialvalid-boolean)
     - [`initialValues?: Values`](#initialvalues-values)
-    - [`validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`](#validate-values-values-props-props--formikerrorvalues--promiseany)
+    - [`onSubmit: (values: Values, formikBag: FormikBag) => void`](#onsubmit-values-values-formikbag-formikbag--void)
+    - [`validate?: (values: Values) => FormikError<Values> | Promise<any>`](#validate-values-values--formikerrorvalues--promiseany)
     - [`validateOnBlur?: boolean`](#validateonblur-boolean)
     - [`validateOnChange?: boolean`](#validateonchange-boolean)
-    - [`validationSchema?: Schema | ((props: Props) => Schema)`](#validationschema-schema--props-props--schema)
+    - [`validationSchema?: Schema | (() => Schema)`](#validationschema-schema----schema)
   - [`<Field />`](#field-)
   - [`<Form />`](#form-)
   - [`withFormik(options)`](#withformikoptions)
     - [`options`](#options)
       - [`displayName?: string`](#displayname-string)
+      - [`enableReinitialize?: boolean`](#enablereinitialize-boolean-1)
       - [`handleSubmit: (values: Values, formikBag: FormikBag) => void`](#handlesubmit-values-values-formikbag-formikbag--void)
         - [The "FormikBag":](#the-formikbag)
       - [`isInitialValid?: boolean | (props: Props) => boolean`](#isinitialvalid-boolean--props-props--boolean)
       - [`mapPropsToValues?: (props: Props) => Values`](#mappropstovalues-props-props--values)
-      - [`validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`](#validate-values-values-props-props--formikerrorvalues--promiseany-1)
+      - [`validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`](#validate-values-values-props-props--formikerrorvalues--promiseany)
       - [`validateOnBlur?: boolean`](#validateonblur-boolean-1)
       - [`validateOnChange?: boolean`](#validateonchange-boolean-1)
-      - [`validationSchema?: Schema | ((props: Props) => Schema)`](#validationschema-schema--props-props--schema-1)
+      - [`validationSchema?: Schema | ((props: Props) => Schema)`](#validationschema-schema--props-props--schema)
     - [Injected props and methods](#injected-props-and-methods)
 - [Guides](#guides)
   - [React Native](#react-native)
@@ -646,11 +648,9 @@ const ContactForm = ({ handleSubmit, handleChange, handleBlur, values, errors })
 ```
 
 
+#### `enableReinitialize?: boolean`
 
-#### `onSubmit: (values: Values, formikBag: FormikBag) => void`
-Your form submission handler. It is passed your forms [`values`] and the "FormikBag", which includes an object containing a subset of the [injected props and methods](/#injected-props-and-methods) (i.e. all the methods with names that start with `set<Thing>` + `resetForm`) and any props that were passed to the the wrapped component.
-
-Note: [`errors`], [`touched`], [`status`] and all event handlers are NOT included in the `FormikBag`.
+Default is `false`. Control whether Formik should reset the form if [`initialValues`] changes (using deep equality).
 
 #### `isInitialValid?: boolean`
 
@@ -658,11 +658,18 @@ Default is `false`. Control the initial value of [`isValid`] prop prior to mount
 
 #### `initialValues?: Values`
 
-If this option is specified, then Formik will transfer its results into updatable form state and make these values available to the new component as [`props.values`][`values`]. If `mapPropsToValues` is not specified, then Formik will map all props that are not functions to the inner component's [`props.values`][`values`]. That is, if you omit it, Formik will only pass `props` where `typeof props[k] !== 'function'`, where `k` is some key.
+Initial field values of the form, Formik will make these values available to render methods component as [`props.values`][`values`]. 
 
-Even if your form is not receiving any props from its parent, use `mapPropsToValues` to initialize your forms empty state.
+Even if your form is empty by default, you must initialize all fields with initial values otherwise React will throw an error saying that you have changed an input from uncontrolled to controlled.
 
-#### `validate?: (values: Values, props: Props) => FormikError<Values> | Promise<any>`
+Note: `initialValues` not available to the higher-order component, use [`mapPropsToValues`] instead.
+
+#### `onSubmit: (values: Values, formikBag: FormikBag) => void`
+Your form submission handler. It is passed your forms [`values`] and the "FormikBag", which includes an object containing a subset of the [injected props and methods](/#injected-props-and-methods) (i.e. all the methods with names that start with `set<Thing>` + `resetForm`) and any props that were passed to the the wrapped component.
+
+Note: [`errors`], [`touched`], [`status`] and all event handlers are NOT included in the `FormikBag`.
+
+#### `validate?: (values: Values) => FormikError<Values> | Promise<any>`
 
 _Note: I suggest using [`validationSchema`] and Yup for validation. However, `validate` is a dependency-free, straightforward way to validate your forms._
 
@@ -714,7 +721,7 @@ Default is `true`. Use this option to run validations on `blur` events. More spe
 
 Default is `true`. Use this option to tell Formik to run validations on `change` events and `change`-related methods. More specifically, when either [`handleChange`], [`setFieldValue`], or [`setValues`] are called.
 
-#### `validationSchema?: Schema | ((props: Props) => Schema)`
+#### `validationSchema?: Schema | (() => Schema)`
 
 [A Yup schema](https://github.com/jquense/yup) or a function that returns a Yup schema. This is used for validation. Errors are mapped by key to the inner component's [`errors`]. Its keys should match those of [`values`].
 
@@ -814,6 +821,10 @@ Create a higher-order React component class that passes props and form handlers 
 
 ##### `displayName?: string`
 When your inner form component is a stateless functional component, you can use the `displayName` option to give the component a proper name so you can more easily find it in [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en). If specified, your wrapped form will show up as `Formik(displayName)`. If omitted, it will show up as `Formik(Component)`. This option is not required for class components (e.g. `class XXXXX extends React.Component {..}`).
+
+##### `enableReinitialize?: boolean`
+
+Default is `false`. Control whether Formik should reset the form if the wrapped component props change (using deep equality).
 
 ##### `handleSubmit: (values: Values, formikBag: FormikBag) => void`
 Your form submission handler. It is passed your forms [`values`] and the "FormikBag", which includes an object containing a subset of the [injected props and methods](/#injected-props-and-methods) (i.e. all the methods with names that start with `set<Thing>` + `resetForm`) and any props that were passed to the the wrapped component.

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -117,10 +117,8 @@ export interface FormikSharedConfig {
   validateOnBlur?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
   isInitialValid?: boolean | ((props: object) => boolean | undefined);
-  /** Reinitialize when new initial va */
+  /** Should Formik reset the form when new initialValues change */
   enableReinitialize?: boolean;
-  /** Keep dirty values on reinitialize */
-  keepDirtyOnReinitalize?: boolean;
 }
 
 /**
@@ -183,7 +181,6 @@ export class Formik<
     validateOnBlur: true,
     isInitialValid: false,
     enableReinitialize: false,
-    keepDirtyOnReinitialize: false,
   };
 
   static propTypes = {
@@ -197,6 +194,7 @@ export class Formik<
     component: PropTypes.func,
     render: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+    enableReinitialize: PropTypes.bool,
   };
 
   static childContextTypes = {
@@ -235,6 +233,7 @@ export class Formik<
         setSubmitting: this.setSubmitting,
         resetForm: this.resetForm,
         submitForm: this.submitForm,
+        initialValues: this.initialValues,
       },
     };
   }
@@ -257,24 +256,9 @@ export class Formik<
       this.props.enableReinitialize &&
       !isEqual(nextProps.initialValues, this.props.initialValues)
     ) {
-      if (this.props.keepDirtyOnReinitalize) {
-        const values = keepKeys(
-          nextProps.initialValues,
-          this.state.values,
-          this.state.touched
-        );
-        this.initialValues = values;
-        this.setState({ values });
-      } else {
-        this.initialValues = nextProps.initialValues;
-        this.resetForm(nextProps.initialValues);
-      }
+      this.initialValues = nextProps.initialValues;
+      this.resetForm(nextProps.initialValues);
     }
-    // if (this.props.enableReinitialize) {
-    //   if (!isEqual(nextProps.initialValues, this.props.initialValues)) {
-    //     this.resetForm(nextProps.initialValues);
-    //   }
-    // }
   }
 
   componentWillMount() {
@@ -522,16 +506,16 @@ Formik cannot determine which value to update. For more info see https://github.
 
   executeSubmit = () => {
     this.props.onSubmit(this.state.values, {
-      setStatus: this.setStatus,
-      setTouched: this.setTouched,
-      setErrors: this.setErrors,
-      setError: this.setError,
-      setValues: this.setValues,
-      setFieldError: this.setFieldError,
-      setFieldValue: this.setFieldValue,
-      setFieldTouched: this.setFieldTouched,
-      setSubmitting: this.setSubmitting,
       resetForm: this.resetForm,
+      setError: this.setError,
+      setErrors: this.setErrors,
+      setFieldError: this.setFieldError,
+      setFieldTouched: this.setFieldTouched,
+      setFieldValue: this.setFieldValue,
+      setStatus: this.setStatus,
+      setSubmitting: this.setSubmitting,
+      setTouched: this.setTouched,
+      setValues: this.setValues,
       submitForm: this.submitForm,
     });
   };
@@ -613,21 +597,21 @@ Formik cannot determine which value to update. For more info see https://github.
         : isInitialValid !== false && isFunction(isInitialValid)
           ? (isInitialValid as (props: Props) => boolean)(this.props)
           : isInitialValid as boolean,
-      initialValues: this.initialValues,
-      handleSubmit: this.handleSubmit,
-      handleChange: this.handleChange,
       handleBlur: this.handleBlur,
+      handleChange: this.handleChange,
       handleReset: this.handleReset,
-      setStatus: this.setStatus,
-      setTouched: this.setTouched,
-      setErrors: this.setErrors,
-      setError: this.setError,
-      setValues: this.setValues,
-      setFieldError: this.setFieldError,
-      setFieldValue: this.setFieldValue,
-      setFieldTouched: this.setFieldTouched,
-      setSubmitting: this.setSubmitting,
+      handleSubmit: this.handleSubmit,
+      initialValues: this.initialValues,
       resetForm: this.resetForm,
+      setError: this.setError,
+      setErrors: this.setErrors,
+      setFieldError: this.setFieldError,
+      setFieldTouched: this.setFieldTouched,
+      setFieldValue: this.setFieldValue,
+      setStatus: this.setStatus,
+      setSubmitting: this.setSubmitting,
+      setTouched: this.setTouched,
+      setValues: this.setValues,
       submitForm: this.submitForm,
     };
     return component
@@ -678,20 +662,6 @@ export function touchAllFields<T>(fields: T): FormikTouched {
     touched[k] = true;
   }
   return touched;
-}
-
-export function keepKeys(
-  fresh: any,
-  old: any,
-  keys: { [field: string]: boolean }
-) {
-  const override = Object.keys(keys).reduce((prev: any, curr: string) => {
-    if (keys[curr]) {
-      prev[curr] = old[curr];
-    }
-    return prev;
-  }, {});
-  return { ...fresh, ...override };
 }
 
 export * from './Field';

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -22,7 +22,7 @@ export type InjectedFormikProps<Props, Values> = Props &
   FormikState<Values> &
   FormikActions<Values> &
   FormikHandlers &
-  FormikComputedProps;
+  FormikComputedProps<Values>;
 
 /**
  * Formik actions + { props }

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -666,9 +666,14 @@ describe('Formik Next', () => {
         github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
         watchers: ['ian', 'sam'],
       };
-      form = new Formik({ initialValues, onSubmit: jest.fn() });
+      form = new Formik({
+        initialValues,
+        onSubmit: jest.fn(),
+        enableReinitialize: true,
+      });
       form.resetForm = jest.fn();
     });
+
     it('should not resetForm if new initialValues are the same as previous', () => {
       const newInitialValues = Object.assign({}, initialValues);
       form.componentWillReceiveProps({
@@ -679,9 +684,10 @@ describe('Formik Next', () => {
     });
 
     it('should resetForm if new initialValues are different than previous', () => {
-      const newInitialValues = Object.assign({}, initialValues, {
+      const newInitialValues = {
+        ...initialValues,
         watchers: ['jared', 'ian', 'sam'],
-      });
+      };
       form.componentWillReceiveProps({
         initialValues: newInitialValues,
         onSubmit: jest.fn(),
@@ -690,9 +696,10 @@ describe('Formik Next', () => {
     });
 
     it('should resetForm if new initialValues are deeply different than previous', () => {
-      const newInitialValues = Object.assign({}, initialValues, {
+      const newInitialValues = {
+        ...initialValues,
         github: { repoUrl: 'different' },
-      });
+      };
       form.componentWillReceiveProps({
         initialValues: newInitialValues,
         onSubmit: jest.fn(),

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -659,7 +659,7 @@ describe('Formik Next', () => {
   });
 
   describe('componentWillReceiveProps', () => {
-    let form, initialValues;
+    let form, defaultForm, initialValues;
     beforeEach(() => {
       initialValues = {
         name: 'formik',
@@ -705,6 +705,23 @@ describe('Formik Next', () => {
         onSubmit: jest.fn(),
       });
       expect(form.resetForm).toHaveBeenCalled();
+    });
+
+    it('should NOT resetForm without enableReinitialize flag', () => {
+      form = new Formik({
+        initialValues,
+        onSubmit: jest.fn(),
+      });
+      form.resetForm = jest.fn();
+      const newInitialValues = {
+        ...initialValues,
+        watchers: ['jared', 'ian', 'sam'],
+      };
+      form.componentWillReceiveProps({
+        initialValues: newInitialValues,
+        onSubmit: jest.fn(),
+      });
+      expect(form.resetForm).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { validateYupSchema, yupToFormErrors, keepKeys } from '../src/formik';
+import { validateYupSchema, yupToFormErrors } from '../src/formik';
 
 const Yup = require('yup');
 const schema = Yup.object().shape({
@@ -36,31 +36,6 @@ describe('helpers', () => {
       } catch (e) {
         throw e;
       }
-    });
-
-    it('should reinitialize', () => {
-      const initialValues = {
-        name: 'formik',
-        github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
-        watchers: ['ian', 'sam'],
-      };
-
-      const touched = {
-        watchers: true,
-        github: true,
-      };
-
-      const newValues = {
-        name: 'jared',
-        github: { repoUrl: 'https://github.com/jaredpalmer/formiksss' },
-        watchers: ['ianddd', 'samddd'],
-      };
-
-      expect(keepKeys(newValues, initialValues, touched)).toEqual({
-        name: 'jared',
-        github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
-        watchers: ['ian', 'sam'],
-      });
     });
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { validateYupSchema, yupToFormErrors } from '../src/formik';
+import { validateYupSchema, yupToFormErrors, keepKeys } from '../src/formik';
 
 const Yup = require('yup');
 const schema = Yup.object().shape({
@@ -36,6 +36,31 @@ describe('helpers', () => {
       } catch (e) {
         throw e;
       }
+    });
+
+    it('should reinitialize', () => {
+      const initialValues = {
+        name: 'formik',
+        github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+        watchers: ['ian', 'sam'],
+      };
+
+      const touched = {
+        watchers: true,
+        github: true,
+      };
+
+      const newValues = {
+        name: 'jared',
+        github: { repoUrl: 'https://github.com/jaredpalmer/formiksss' },
+        watchers: ['ianddd', 'samddd'],
+      };
+
+      expect(keepKeys(newValues, initialValues, touched)).toEqual({
+        name: 'jared',
+        github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+        watchers: ['ian', 'sam'],
+      });
     });
   });
 });


### PR DESCRIPTION

- Adds a `enableReinitialize`  option, default is `false`. If true, form will reset when `initialValues` (or the result of `mapPropsToValues` in HoC land) is different (using deep equality). (#168 , #188) 
- Adds readonly `initialValues` prop to the Formik bag (#161)