### PR TITLE
[Field] Improve typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ const EditUserDialog = ({ user, updateUser, onClose }) => {
               touched.twitter &&
               <div>
                 {errors.twitter}
-              </div>}          
+              </div>}
             <button type="submit" disabled={isSubmitting}>
               Submit
             </button>
@@ -435,7 +435,7 @@ const EditUserDialog = ({ user, updateUser, onClose }) => {
               touched.twitter &&
               <div>
                 {errors.twitter}
-              </div>}          
+              </div>}
             <button type="submit" disabled={isSubmitting}>
               Submit
             </button>
@@ -722,9 +722,9 @@ Default is `true`. Use this option to tell Formik to run validations on `change`
 
 `<Field />` will automagically hook up inputs to Formik. It uses the `name` attribute to match up with Formik state. `<Field/>` will default to and `<input/>` element. To change the underlying element of `<Field/>`, specify a `component` prop. It can either be a string like `select` or another React component.
 
-```js
+```typescript
 import  React from 'react';
-import { Formik, Field } from 'formik';
+import { Field, FieldComponentProps, Formik } from 'formik';
 
 const Example = () => (
   <div>
@@ -737,7 +737,7 @@ const Example = () => (
           actions.setSubmitting(false)
         }, 1000);
       }}
-      render={(props: FormikProps<Values>) =>
+      render={props =>
         <form onSubmit={props.handleSubmit}>
           <Field type="email" name="email" placeholder="Email" />
           <Field component="select" name="color" >
@@ -752,7 +752,9 @@ const Example = () => (
   </div>
 );
 
-const CustomInputComponent: React.SFC<FormikProps<Values> & CustomInputProps> => ({
+type CustomInputProps = { customProp: any }
+
+const CustomInputComponent: React.SFC<CustomInputProps & FieldComponentProps> => ({
   field, // { name, value, onChange, onBlur }
   form: { touched, errors } // also values, setXXXX, handleXXXX, isDirty, isValid, status, etc.
   ...props
@@ -763,7 +765,7 @@ const CustomInputComponent: React.SFC<FormikProps<Values> & CustomInputProps> =>
       {...field}
       {...props}
     />
-    {touched[name] && errors[name] && <div className="error">{errors[name]}</div>}
+    {touched[field.name] && errors[field.name] && <div className="error">{errors[field.name]}</div>}
   </div>
 )
 ```
@@ -977,10 +979,10 @@ The reason is that Formik's [`handleChange`] function expects its first argument
 
 In React Native, neither [`<TextInput />`](https://facebook.github.io/react-native/docs/textinput.html)'s [`onChange`](https://facebook.github.io/react-native/docs/textinput.html#onchange) nor [`onChangeText`](https://facebook.github.io/react-native/docs/textinput.html#onchange) callbacks pass such an event or one like it to its callback. Instead, they do the following *(emphasis added)*:
 
-> [`onChange?: function`](https://facebook.github.io/react-native/docs/textinput.html#onchange)  
+> [`onChange?: function`](https://facebook.github.io/react-native/docs/textinput.html#onchange)
 > Callback that is called when the text input's text changes.
 >
-> [`onChangeText?: function`](https://facebook.github.io/react-native/docs/textinput.html#onchangetext)  
+> [`onChangeText?: function`](https://facebook.github.io/react-native/docs/textinput.html#onchangetext)
 > Callback that is called when the text input's text changes. **Changed text is passed as an argument to the callback handler.**
 
 However, Formik works just fine if you use `props.setFieldValue`! Philisophically, just treat React Native's `<TextInput/>` the same way you would any other 3rd party custom input element.

--- a/package.json
+++ b/package.json
@@ -79,10 +79,15 @@
     "yup": "0.21.3"
   },
   "lint-staged": {
-    "*.(ts|tsx)": [
+    "**/*.{ts,tsx}": [
       "prettier --trailing-comma es5 --single-quote --write",
       "git add"
     ]
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "semi": true
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -3,15 +3,33 @@ import * as React from 'react';
 
 import { FormikProps } from './formik';
 
+export interface FieldProps {
+  component: keyof React.ReactHTML | React.ComponentType<any>;
+  name: string;
+  type?: string;
+  value?: any;
+}
+
+export interface InputProps {
+  /** Name of the input */
+  name: string;
+  /** Classic React change handler, keyed by input name */
+  onChange: (event: React.ChangeEvent<any>) => void;
+  /** Mark input as touched */
+  onBlur: (event: any) => void;
+  /** Value of the input */
+  value?: any;
+}
+
 /**
  * Custom Field component for quickly hooking into Formik
  * context and wiring up forms.
  */
-export const Field: React.SFC<any> = (
+export const Field: React.SFC<FieldProps> = (
   { component = 'input', name, ...props },
   context
 ) => {
-  const field = {
+  const field: InputProps = {
     value:
       props.type === 'radio' || props.type === 'checkbox'
         ? props.value
@@ -20,14 +38,16 @@ export const Field: React.SFC<any> = (
     onChange: context.formik.handleChange,
     onBlur: context.formik.handleBlur,
   };
-  const bag =
+  const bag: InputProps | FieldComponentProps =
     typeof component === 'string'
       ? field
       : {
           field,
           form: context.formik,
         };
-  return React.createElement(component, {
+  // Cast component to React.ComponentClass to prevent typescript error
+  // https://github.com/Microsoft/TypeScript/issues/15019
+  return React.createElement(component as React.ComponentClass<any>, {
     ...props,
     ...bag,
   });
@@ -37,38 +57,26 @@ Field.contextTypes = {
   formik: PropTypes.object,
 };
 
-Field.propTypes = {
-  name: PropTypes.string.isRequired,
-  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-};
-
 /**
  * Note: These typings could be more restrictive, but then it would limit the
  * reusability of custom <Field/> components.
- * 
- * @example 
+ *
+ * @example
  * interface MyProps {
  *   ...
  * }
- * 
- * export const MyInput: React.SFC<MyProps & FieldProps> = ({
+ *
+ * export const MyInput: React.SFC<MyProps & FieldComponentProps> = ({
  *   field,
  *   form,
  *   ...props
- * }) => 
+ * }) =>
  *   <div>
  *     <input {...field} {...props}/>
  *     {form.touched[field.name] && form.errors[field.name]}
  *   </div>
  */
-export interface FieldProps {
-  field: {
-    /** Classic React change handler, keyed by input name */
-    onChange: (e: React.ChangeEvent<any>) => void;
-    /** Mark input as touched */
-    onBlur: (e: any) => void;
-    /** Value of the input */
-    value: any;
-  };
+export interface FieldComponentProps {
+  field: InputProps;
   form: FormikProps<any>;
 }

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -76,7 +76,7 @@ Field.contextTypes = {
  *     {form.touched[field.name] && form.errors[field.name]}
  *   </div>
  */
-export interface FieldComponentProps {
+export interface FieldComponentProps<Values = any> {
   field: InputProps;
-  form: FormikProps<any>;
+  form: FormikProps<Values>;
 }


### PR DESCRIPTION
Add missing `name` field in `InputProps`.
⚠️ BreakingChange: `FieldProps` has been renamed to `FieldComponentProps`. It's more coherent like that I think (`react-router` package uses this naming too)