### PR TITLE
Add `transformValues` prop to allow auto-modification of form values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I wrote Formik while building a large internal administrative dashboard with [Ia
 By now, you might be thinking, "Why didn't you just use [Redux-Form](https://github.com/erikras/redux-form)?" Good question.
 
  1. According to our prophet Dan Abramov, [**form state is inherently emphemeral and local**, so tracking it in Redux (or any kind of Flux library) is unnecessary](https://github.com/reactjs/redux/issues/1287#issuecomment-175351978)
- 2. Redux-Form calls your entire top-level Redux reducer multiple times ON EVERY SINGLE KEYSTROKE. This is fine for small apps, but as your Redux app grows, input latency will continue increase if you use Redux-Form. 
+ 2. Redux-Form calls your entire top-level Redux reducer multiple times ON EVERY SINGLE KEYSTROKE. This is fine for small apps, but as your Redux app grows, input latency will continue increase if you use Redux-Form.
  3. Redux-Form is 22.5 kB minified gzipped (Formik is 9.2 kB)  
 
 **My goal with Formik was to create a scalable, performant, form helper with a minimal API that does the really really annoying stuff, and leaves the rest up to you.**
@@ -256,6 +256,7 @@ npm install yup --save
     - [`enableReinitialize?: boolean`](#enablereinitialize-boolean)
     - [`isInitialValid?: boolean`](#isinitialvalid-boolean)
     - [`initialValues?: Values`](#initialvalues-values)
+    - [`transformValues?: Values`](#transformvalues-values-values--values)
     - [`onSubmit: (values: Values, formikBag: FormikBag) => void`](#onsubmit-values-values-formikbag-formikbag--void)
     - [`validate?: (values: Values) => FormikError<Values> | Promise<any>`](#validate-values-values--formikerrorvalues--promiseany)
     - [`validateOnBlur?: boolean`](#validateonblur-boolean)
@@ -655,11 +656,17 @@ Default is `false`. Control the initial value of [`isValid`] prop prior to mount
 
 #### `initialValues?: Values`
 
-Initial field values of the form, Formik will make these values available to render methods component as [`props.values`][`values`]. 
+Initial field values of the form, Formik will make these values available to render methods component as [`props.values`][`values`].
 
 Even if your form is empty by default, you must initialize all fields with initial values otherwise React will throw an error saying that you have changed an input from uncontrolled to controlled.
 
 Note: `initialValues` not available to the higher-order component, use [`mapPropsToValues`] instead.
+
+#### `transformValues?: (values: Values) => Values`
+
+Transform the values before updating and validating the Form. The values passed to `handleChange` and `setValues` will be transformed with this function first and foremost.
+
+This is also called on the `initialValues` props.
 
 #### `onSubmit: (values: Values, formikBag: FormikBag) => void`
 Your form submission handler. It is passed your forms [`values`] and the "FormikBag", which includes an object containing a subset of the [injected props and methods](/#injected-props-and-methods) (i.e. all the methods with names that start with `set<Thing>` + `resetForm`) and any props that were passed to the the wrapped component.

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -77,6 +77,20 @@ describe('Formik Next', () => {
     expect(tree.find(Form).props().isValid).toBe(false);
   });
 
+  it('should transform the initial values if transformValues is passed in', () => {
+    const transformValues = values => ({ ...values, name: values.name.trim() });
+    const tree = shallow(
+      <Formik
+        initialValues={{ name: '       jared   ' }}
+        onSubmit={noop}
+        component={Form}
+        transformValues={transformValues}
+      />
+    );
+    expect(tree.find(Form).props().values).toEqual({ name: 'jared' });
+    expect(tree.instance().initialValues).toEqual({ name: 'jared' });
+  });
+
   describe('FormikHandlers', () => {
     describe('handleChange', () => {
       it('sets values state', async () => {
@@ -116,6 +130,32 @@ describe('Formik Next', () => {
         ).toEqual('ian');
       });
 
+      it('transforms values if transformValues is passed in', () => {
+        const transformValues = values => ({
+          ...values,
+          name: values.name.trim(),
+        });
+        const tree = shallow(
+          <Formik
+            initialValues={{ name: 'jared' }}
+            onSubmit={noop}
+            component={Form}
+            transformValues={transformValues}
+          />
+        );
+        tree.find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: '   ian   ',
+          },
+        });
+        expect(tree.update().state().values).toEqual({ name: 'ian' });
+        expect(
+          tree.update().find(Form).dive().find('input').props().value
+        ).toEqual('ian');
+      });
+
       it('runs validations if validateOnChange is set to true', async () => {
         const validate = jest.fn(noop);
         const tree = shallow(
@@ -135,6 +175,32 @@ describe('Formik Next', () => {
           },
         });
         expect(validate).toHaveBeenCalled();
+      });
+
+      it('runs validations with the transformed values if transformValues is passed', () => {
+        const validate = jest.fn(noop);
+        const transformValues = values => ({
+          ...values,
+          name: values.name.trim(),
+        });
+        const tree = shallow(
+          <Formik
+            initialValues={{ name: 'jared' }}
+            onSubmit={noop}
+            component={Form}
+            validate={validate}
+            validateOnChange={true}
+            transformValues={transformValues}
+          />
+        );
+        tree.find(Form).dive().find('input').simulate('change', {
+          persist: noop,
+          target: {
+            name: 'name',
+            value: '   ian    ',
+          },
+        });
+        expect(validate).toBeCalledWith({ name: 'ian' });
       });
 
       it('does NOT run validations if validateOnChange is set to false', async () => {
@@ -415,6 +481,24 @@ describe('Formik Next', () => {
       expect(tree.find(Form).dive().find('input').props().value).toEqual('ian');
     });
 
+    it('setValues transforms values if transformValues is passed in', () => {
+      const transformValues = values => ({
+        ...values,
+        name: values.name.trim(),
+      });
+      const tree = shallow(
+        <Formik
+          initialValues={{ name: 'jared' }}
+          onSubmit={noop}
+          component={Form}
+          transformValues={transformValues}
+        />
+      );
+
+      tree.find(Form).props().setValues({ name: '     ian    ' });
+      expect(tree.find(Form).dive().find('input').props().value).toEqual('ian');
+    });
+
     it('setValues should run validations when validateOnChange is true', async () => {
       const validate = jest.fn().mockReturnValue({});
       const tree = shallow(
@@ -428,6 +512,27 @@ describe('Formik Next', () => {
       );
       tree.find(Form).props().setValues({ name: 'ian' });
       expect(validate).toHaveBeenCalled();
+    });
+
+    it('setValues validate with transformed values if transformValues is passed in', () => {
+      const transformValues = values => ({
+        ...values,
+        name: values.name.trim(),
+      });
+      const validate = jest.fn().mockReturnValue({});
+      const tree = shallow(
+        <Formik
+          initialValues={{ name: 'jared' }}
+          onSubmit={noop}
+          component={Form}
+          validate={validate}
+          validateOnChange={true}
+          transformValues={transformValues}
+        />
+      );
+
+      tree.find(Form).props().setValues({ name: '     ian    ' });
+      expect(validate).toBeCalledWith({ name: 'ian' });
     });
 
     it('setValues should NOT run validations when validateOnChange is false', () => {


### PR DESCRIPTION
In the case where the user wants the form values to be modified before validating and updating, this prop can be helpful. The most recent use case I have encountered using this is the behavior of trimming input values and adding commas to multiple digit number. 

Obviously one may wrap the formik's `handleChange` prop and modify e.target.value, but that's tedious. I believe this prop would be useful :)

Thank you in advance for reviewing!