### PR TITLE
Fix checkbox validation

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -406,7 +406,7 @@ Formik cannot determine which value to update. For more info see https://github.
       this.runValidations(
         {
           ...this.state.values as object,
-          [field]: value,
+          [field]: val,
         } as Object
       );
     }


### PR DESCRIPTION
When using `Formik` with `yup` and running a validation onChange of checkbox input I get this error:
> ${name} must be a `boolean` type, but the final value was: `"on"`

Here is a minimal reproducible example: https://codesandbox.io/s/8wzvyll98

I believe it's because Formik is running validation with a different value then one we are setting `setState` with (on line 401).

```bash
$ yarn info formik version
0.9.4
```

Thank you for this great library, using it is a joy 👍 