### PR TITLE
Fix #183. Add tests, warnings, better types for <Field/> render props

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -2,52 +2,8 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
 import { FormikProps } from './formik';
-
-/**
- * Custom Field component for quickly hooking into Formik
- * context and wiring up forms.
- */
-export const Field: React.SFC<any> = (
-  { component = 'input', render, children, name, ...props },
-  context
-) => {
-  const field = {
-    value:
-      props.type === 'radio' || props.type === 'checkbox'
-        ? props.value
-        : context.formik.values[name],
-    name,
-    onChange: context.formik.handleChange,
-    onBlur: context.formik.handleBlur,
-  };
-  const bag =
-    typeof component === 'string'
-      ? field
-      : {
-          field,
-          form: context.formik,
-        };
-  const componentProps = {
-    ...props,
-    ...bag,
-  };
-  if (typeof render === 'function') {
-    return render(componentProps);
-  }
-  if (typeof children === 'function') {
-    return children(componentProps);
-  }
-  return React.createElement(component, componentProps);
-};
-
-Field.contextTypes = {
-  formik: PropTypes.object,
-};
-
-Field.propTypes = {
-  name: PropTypes.string.isRequired,
-  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-};
+import { isEmptyChildren } from './utils';
+import warning from 'warning';
 
 /**
  * Note: These typings could be more restrictive, but then it would limit the
@@ -68,7 +24,7 @@ Field.propTypes = {
  *     {form.touched[field.name] && form.errors[field.name]}
  *   </div>
  */
-export interface FieldProps {
+export interface FieldProps<V = any> {
   field: {
     /** Classic React change handler, keyed by input name */
     onChange: (e: React.ChangeEvent<any>) => void;
@@ -76,6 +32,101 @@ export interface FieldProps {
     onBlur: (e: any) => void;
     /** Value of the input */
     value: any;
+    /* name of the input */
+    name: string;
   };
-  form: FormikProps<any>;
+  form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
+}
+
+export interface FieldConfig {
+  /**
+   * Field component to render. Can either be a string like 'select' or a component.
+   */
+  component?: string | React.ComponentType<FieldProps<any> | void>;
+
+  /**
+   * Render prop (works like React router's <Route render={props =>} />)
+   */
+  render?: ((props: FieldProps<any>) => React.ReactNode);
+
+  /**
+   * Children render function <Field name>{props => ...}</Field>)
+   */
+  children?: ((props: FieldProps<any>) => React.ReactNode);
+
+  /**
+   * Field name
+   */
+  name: string;
+
+  /** HTML input type */
+  type?: string;
+
+  /** Field value */
+  value?: any;
+}
+
+/**
+ * Custom Field component for quickly hooking into Formik
+ * context and wiring up forms.
+ */
+export class Field<
+  Props extends FieldConfig = FieldConfig
+> extends React.Component<Props, {}> {
+  static contextTypes = {
+    formik: PropTypes.object,
+  };
+
+  static defaultProps = {
+    component: 'input',
+  };
+
+  componentWillMount() {
+    warning(
+      !(typeof this.props.component !== 'string' && this.props.render),
+      'You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored'
+    );
+
+    warning(
+      !(
+        typeof this.props.component !== 'string' &&
+        this.props.children &&
+        !isEmptyChildren(this.props.children)
+      ),
+      'You should not use <Field component> and <Field children> in the same <Field> component; <Field component> will be ignored'
+    );
+
+    warning(
+      !(
+        this.props.render &&
+        this.props.children &&
+        !isEmptyChildren(this.props.children)
+      ),
+      'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
+    );
+  }
+
+  render() {
+    const { component, render, children, name, ...props } = this
+      .props as FieldConfig;
+    const { formik } = this.context;
+    const field = {
+      value:
+        props.type === 'radio' || props.type === 'checkbox'
+          ? props.value
+          : formik.values[name],
+      name,
+      onChange: formik.handleChange,
+      onBlur: formik.handleBlur,
+    };
+    const bag = { field, form: formik };
+
+    return render
+      ? (render as any)(bag)
+      : children
+        ? (children as (props: FieldProps<any>) => React.ReactNode)(bag)
+        : typeof component === 'string'
+          ? React.createElement(component as any, { ...field, ...props })
+          : React.createElement(component as any, { ...bag, ...props });
+  }
 }

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -1,8 +1,13 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import isEqual from 'lodash.isequal';
-
-import { isFunction, isPromise, isReactNative, values } from './utils';
+import {
+  isEmptyChildren,
+  isFunction,
+  isPromise,
+  isReactNative,
+  values,
+} from './utils';
 
 import warning from 'warning';
 
@@ -170,8 +175,6 @@ export type FormikProps<Values> = FormikState<Values> &
   FormikActions<Values> &
   FormikHandlers &
   FormikComputedProps<Values>;
-
-const isEmptyChildren = (children: any) => React.Children.count(children) === 0;
 
 export class Formik<
   Props extends FormikConfig = FormikConfig

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 /** @private is the given object/value a promise? */
 export function isPromise(value: any): boolean {
   if (value !== null && typeof value === 'object') {
@@ -27,3 +29,6 @@ export function values<T>(obj: any): T[] {
 
 /** @private is the given object a Function? */
 export const isFunction = (obj: any) => 'function' === typeof obj;
+
+export const isEmptyChildren = (children: any) =>
+  React.Children.count(children) === 0;

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Field } from '../src/Field';
+import { Formik } from '../src/formik';
+
+// tslint:disable-next-line:no-empty
+const noop = () => {};
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const TestForm: React.SFC<any> = p =>
+  <Formik
+    onSubmit={noop}
+    initialValues={{ name: 'jared', email: 'hello@reason.nyc' }}
+    {...p}
+  />;
+
+describe('A <Field />', () => {
+  describe('<Field component />', () => {
+    const node = document.createElement('div');
+    const placeholder = 'First name';
+    const TEXT = 'Mrs. Kato';
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(node);
+    });
+
+    it('renders an <input /> by default', () => {
+      ReactDOM.render(
+        <TestForm render={formikProps => <Field name="name" />} />,
+        node
+      );
+
+      expect((node.firstChild as HTMLInputElement).name).toBe('name');
+    });
+
+    it('renders the component', () => {
+      const SuperInput = () =>
+        <div>
+          {TEXT}
+        </div>;
+      ReactDOM.render(
+        <TestForm
+          render={formikProps => <Field name="name" component={SuperInput} />}
+        />,
+        node
+      );
+
+      expect((node.firstChild as HTMLInputElement).innerHTML).toBe(TEXT);
+    });
+
+    it('renders string components', () => {
+      ReactDOM.render(
+        <TestForm
+          render={formikProps => <Field component="textarea" name="name" />}
+        />,
+        node
+      );
+
+      expect((node.firstChild as HTMLTextAreaElement).name).toBe('name');
+    });
+
+    it('receives { field, form } props', () => {
+      let actual;
+      let injected;
+      const Component = props => (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          render={formikProps =>
+            (injected = formikProps) &&
+            <Field name="name" component={Component} />}
+        />,
+        node
+      );
+      const { handleBlur, handleChange } = injected;
+      expect(actual.field.name).toBe('name');
+      expect(actual.field.value).toBe('jared');
+      expect(actual.field.onChange).toBe(handleChange);
+      expect(actual.field.onBlur).toBe(handleBlur);
+      expect(actual.form).toEqual(injected);
+    });
+  });
+
+  describe('<Field render />', () => {
+    const node = document.createElement('div');
+    const placeholder = 'First name';
+    const TEXT = 'Mrs. Kato';
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(node);
+    });
+
+    it('renders its return value', () => {
+      ReactDOM.render(
+        <TestForm
+          render={formikProps =>
+            <Field
+              name="name"
+              render={props =>
+                <div>
+                  {TEXT}
+                </div>}
+            />}
+        />,
+        node
+      );
+
+      expect(node.innerHTML).toContain(TEXT);
+    });
+
+    it('receives { field, form } props', () => {
+      ReactDOM.render(
+        <TestForm
+          render={formikProps =>
+            <Field
+              placeholder={placeholder}
+              name="name"
+              render={({ field, form }) => {
+                const { handleBlur, handleChange } = formikProps;
+                expect(field.name).toBe('name');
+                expect(field.value).toBe('jared');
+                expect(field.onChange).toBe(handleChange);
+                expect(field.onBlur).toBe(handleBlur);
+                expect(form).toEqual(formikProps);
+
+                return null;
+              }}
+            />}
+        />,
+        node
+      );
+    });
+  });
+
+  describe('<Field children />', () => {
+    const node = document.createElement('div');
+
+    const TEXT = 'Mrs. Kato';
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(node);
+    });
+
+    it('renders a function', () => {
+      ReactDOM.render(
+        <TestForm
+          render={() =>
+            <Field
+              name="name"
+              children={() =>
+                <div>
+                  {TEXT}
+                </div>}
+            />}
+        />,
+        node
+      );
+
+      expect(node.innerHTML).toContain(TEXT);
+    });
+
+    it('renders a child element', () => {
+      ReactDOM.render(
+        <TestForm
+          render={() =>
+            <Field name="name">
+              {() =>
+                <div>
+                  {TEXT}
+                </div>}
+            </Field>}
+        />,
+        node
+      );
+
+      expect(node.innerHTML).toContain(TEXT);
+    });
+
+    it('receives { field, form } props', () => {
+      let actual;
+      let injected;
+      const Component = props => (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          children={formikProps =>
+            (injected = formikProps) &&
+            <Field name="name" component={Component} />}
+        />,
+        node
+      );
+      const { handleBlur, handleChange } = injected;
+      expect(actual.field.name).toBe('name');
+      expect(actual.field.onChange).toBe(handleChange);
+      expect(actual.field.onBlur).toBe(handleBlur);
+      expect(actual.field.value).toBe('jared');
+      expect(actual.form).toEqual(injected);
+    });
+  });
+});


### PR DESCRIPTION
Builds on #183 and #186 

### Before

```jsx
<Field name="firstName" placeholder="First Name"  />
<Field name="firstName" placeholder="First Name" component={MyInput}  />
```


### After
```jsx
<Field name="firstName" placeholder="First Name"  /> // same as before
<Field name="firstName" placeholder="First Name" component={MyInput}   /> // same as before

<Field 
   name="firstName"
   render={({field, form}) => /* note: props to Field not passed thru, cuz they are available already  */
      <div>
          <input {...field} placeholder="firstName" />
           {/* whatever */}
      </div>
  } 
/>

<Field name="firstName">
   {({field, form}) => 
      <div>
          <input {...field} placeholder="firstName" />
           {/* whatever */}
      </div>}
</Field>
```

### With TypeScript
```tsx
import * as React from 'react';
import { Formik, FormikProps, Form, Field, FieldProps } from 'formik';


interface MyFormValues {
  firstName: string;
}

export const MyApp: React.SFC<{}> = () => {
  return (
    <div>
      <h1>My Example</h1>
      <Formik
        initialValues={{ firstName: '' }}
        onSubmit={(values: MyFormValues) => alert(JSON.stringify(values))}
        render={(_formikBag: FormikProps<MyFormValues>) =>
          <Form>
            <Field
              name="firstName"
              render={({ field, form }: FieldProps<MyFormValues>) =>
                <div>
                  <input type="text" {...field} placeholder="First Name" />
                  {form.touched.firstName &&
                    form.errors.firstName &&
                    form.errors.firstName}
                </div>}
            />
          </Form>}
      />
    </div>
  );
};
```

### Real-world example (composing render functions)
```tsx
import * as React from 'react';
import * as cx from 'classnames';
import { Field, FieldConfig, FieldProps } from 'formik';

export interface FieldsetProps {
   /** blah */
}
// This wraps `<Field render>` with our error/touched logic, display, and formatting. 
export const Fieldset: React.SFC<FieldsetProps & FieldConfig> = ({ name, render, ...rest }) =>
  <Field
    name={name}
    render={({ field, form }: FieldProps<MyFormValues>) =>
      <div
        className={cx('fieldset', {
          'fieldset--error': form.errors[name] && form.touched[name],
        })}
      >
        {render({ field, form })}
        {form.touched.firstName &&
          form.errors.firstName &&
          form.errors.firstName}
      </div>
   }
   {...rest}
  />;
```

```tsx

import * as React from 'react';
import { Formik, FormikProps, Form, Field, FieldProps } from 'formik';

export interface MyAppProps {}

interface MyFormValues {
  firstName: string;
}

export const MyApp: React.SFC<MyAppProps> = () => {
  return (
    <div>
      <h1>My Example</h1>
      <Formik
        initialValues={{ firstName: '' }}
        onSubmit={(values: MyFormValues) => alert(JSON.stringify(values))}
        render={({
          _formikBag /* values, errors, handleChange ... */,
        }: FormikProps<MyFormValues>) =>
          <Form>
            <Fieldset
              name="firstName"
              render={({ field }: FieldProps<MyFormValues>) =>
                /** Stay DRY, just deal with the input, since errors handled in Fieldset */
                <input type="text" {...field} />}
            />
          </Form>}
      />
    </div>
  );
};

```

Note: In order to maintain backwards compat, the order or precedence among the render functions is DIFFERENT than` <Formik />`'s.

- `<Field>`: `render` > `children` > `component`
- `<Formik>`:  `component` > `render` > `children`

This is because `<Field/>` defaults to `component="input"`