### PR TITLE
fix CustomInputComponent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ const Example = () => (
 
 const CustomInputComponent: React.SFC<FormikProps<Values> & CustomInputProps> => ({
   field, // { name, value, onChange, onBlur }
-  form: { touched, errors } // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
   ...props
 }) => (
   <div>
@@ -782,7 +782,7 @@ const CustomInputComponent: React.SFC<FormikProps<Values> & CustomInputProps> =>
       {...field}
       {...props}
     />
-    {touched[name] && errors[name] && <div className="error">{errors[name]}</div>}
+    {touched[field.name] && errors[field.name] && <div className="error">{errors[field.name]}</div>}
   </div>
 )
 ```


### PR DESCRIPTION
fixed couple of problems with `CustomInputComponent` so it can be copy&pasted from docs.

Not sure about repeated `.name`, but at the same time don't want to replace `field` in arguments with `{ name }`, I think it'll make it less clear