### PR TITLE
Enable `handleBlur` to warn about missing identifiers like `handleChange` does

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -386,14 +386,11 @@ export class Formik<
       : /checkbox/.test(type) ? checked : value;
 
     if (!field && process.env.NODE_ENV !== 'production') {
-      console.error(
-        `Warning: You forgot to pass an \`id\` or \`name\` attribute to your input:
-
-  ${outerHTML}
-
-Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#handlechange-e-reactchangeeventany--void
-`
-      );
+      warnAboutMissingIdentifier({
+        htmlContent: outerHTML,
+        documentationAnchorLink: 'handlechange-e-reactchangeeventany--void',
+        handlerName: 'handleChange',
+      });
     }
 
     // Set form fields by name
@@ -527,8 +524,17 @@ Formik cannot determine which value to update. For more info see https://github.
       return;
     }
     e.persist();
-    const { name, id } = e.target;
+    const { name, id, outerHTML } = e.target;
     const field = name ? name : id;
+
+    if (!field && process.env.NODE_ENV !== 'production') {
+      warnAboutMissingIdentifier({
+        htmlContent: outerHTML,
+        documentationAnchorLink: 'handleblur-e-any--void',
+        handlerName: 'handleBlur',
+      });
+    }
+
     this.setState(prevState => ({
       touched: { ...(prevState.touched as object), [field]: true },
     }));
@@ -627,6 +633,29 @@ Formik cannot determine which value to update. For more info see https://github.
             : !isEmptyChildren(children) ? React.Children.only(children) : null
           : null;
   }
+}
+
+function warnAboutMissingIdentifier({
+  htmlContent,
+  documentationAnchorLink,
+  handlerName,
+}: {
+  htmlContent: string;
+  documentationAnchorLink: string;
+  handlerName: string;
+}) {
+  console.error(
+    `Warning: \`${
+      handlerName
+    }\` has triggered and you forgot to pass an \`id\` or \`name\` attribute to your input:
+  
+    ${htmlContent}
+  
+    Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#${
+      documentationAnchorLink
+    }
+  `
+  );
 }
 
 /**


### PR DESCRIPTION
Fix #244 

`handleBlur` will now warn the same way `handleChange` does. I took the liberty of adding the handler function name in the warning message.