### PR TITLE
Fix code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,8 +697,7 @@ const ContactForm = ({
   handleBlur,
   values,
   errors,
-}) => {
-  return;
+}) => (
   <form onSubmit={handleSubmit}>
     <input
       type="text"
@@ -709,7 +708,7 @@ const ContactForm = ({
     />
     {errors.name && <div>{errors.name}</div>}
     <button type="submit">Submit</button>
-  </form>;
+  </form>
 };
 ```
 


### PR DESCRIPTION
Noticed the example code was broken (looks like prettier autoformating gone wrong). Just noticed this while referencing the README