### PR TITLE
Fix gzip size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://user-images.githubusercontent.com/4060187/27243721-3b5219d0-52b1-11e7-96f1-dae8391a3ef6.png)
 
-[![gzip size](https://img.badgesize.io/https://unpkg.com/formik/dist/formik.umd.min.js?compression=gzip)](https://unpkg.com/formik/dist/formik.umd.min.js)
+[![gzip size](http://img.badgesize.io/https://unpkg.com/formik/dist/formik.umd.min.js?compression=gzip)](https://unpkg.com/formik/dist/formik.umd.min.js)
 [![Build Status](https://travis-ci.org/jaredpalmer/formik.svg?branch=master)](https://travis-ci.org/jaredpalmer/formik)
 [![npm](https://img.shields.io/npm/v/formik.svg)](https://npm.im/formik)
 [![license](https://img.shields.io/npm/l/formik.svg)](./LICENSE)


### PR DESCRIPTION
 When pointing to secured `https://img.badgesize.io` url, the request fails due to insecure connection and no badge is shown. However when pointing to `http` it automatically redirects to `https` and then it works correctly (https://github.com/prichodko/formik/tree/fix/gzip-badge).