### PR TITLE
Improve Field warnings

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -2,7 +2,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
 import { FormikProps } from './formik';
-import { isEmptyChildren } from './utils';
+import { isFunction, isEmptyChildren } from './utils';
 import warning from 'warning';
 
 export type GenericFieldHTMLAttributes =
@@ -86,10 +86,6 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
     formik: PropTypes.object,
   };
 
-  static defaultProps = {
-    component: 'input',
-  };
-
   static propTypes = {
     name: PropTypes.string.isRequired,
     component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -98,33 +94,28 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
   };
 
   componentWillMount() {
+    const { render, children, component } = this.props;
+
     warning(
-      !(typeof this.props.component !== 'string' && this.props.render),
+      !(component && render),
       'You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored'
     );
 
     warning(
-      !(
-        typeof this.props.component !== 'string' &&
-        this.props.children &&
-        !isEmptyChildren(this.props.children)
-      ),
-      'You should not use a non-string <Field component> and <Field children> in the same <Field> component; <Field component> will be ignored.'
+      !(component && children && isFunction(children)),
+      'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
     );
 
     warning(
-      !(
-        this.props.render &&
-        this.props.children &&
-        !isEmptyChildren(this.props.children)
-      ),
+      !(render && children && !isEmptyChildren(children)),
       'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
     );
   }
 
   render() {
-    const { component, render, children, name, ...props } = this
+    const { component = 'input', render, children, name, ...props } = this
       .props as FieldConfig;
+
     const { formik } = this.context;
     const field = {
       value:
@@ -141,7 +132,7 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
       return (render as any)(bag);
     }
 
-    if (typeof children === 'function') {
+    if (isFunction(children)) {
       return (children as (props: FieldProps<any>) => React.ReactNode)(bag);
     }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -113,7 +113,7 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
   }
 
   render() {
-    const { component = 'input', render, children, name, ...props } = this
+    const { name, render, children, component = 'input', ...props } = this
       .props as FieldConfig;
 
     const { formik } = this.context;

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -164,11 +164,35 @@ describe('A <Field />', () => {
         />,
         node
       );
-      console.log(node.innerHTML);
+
       expect(node.innerHTML).toContain(TEXT);
     });
 
-    it('warns if both non-string component and children', () => {
+    it('warns if both string component and children as a function', () => {
+      let output = '';
+      let actual;
+
+      (global as any).console = {
+        error: jest.fn(input => (output += input)),
+      };
+
+      ReactDOM.render(
+        <TestForm
+          render={() => (
+            <Field name="name" component="select">
+              {() => <option value="Jared">{TEXT}</option>}
+            </Field>
+          )}
+        />,
+        node
+      );
+
+      expect(output).toContain(
+        'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
+      );
+    });
+
+    it('warns if both non-string component and children children as a function', () => {
       let output = '';
       let actual;
       const Component = props => (actual = props) && null;
@@ -181,7 +205,7 @@ describe('A <Field />', () => {
         <TestForm
           render={() => (
             <Field component={Component} name="name">
-              <option value="Jared">{TEXT}</option>
+              {() => <option value="Jared">{TEXT}</option>}
             </Field>
           )}
         />,
@@ -189,7 +213,33 @@ describe('A <Field />', () => {
       );
 
       expect(output).toContain(
-        'You should not use a non-string <Field component> and <Field children> in the same <Field> component; <Field component> will be ignored.'
+        'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
+      );
+    });
+
+    it('warns if both string component and render', () => {
+      let output = '';
+      let actual;
+
+      (global as any).console = {
+        error: jest.fn(input => (output += input)),
+      };
+
+      ReactDOM.render(
+        <TestForm
+          render={() => (
+            <Field
+              component="select"
+              name="name"
+              render={() => <div>{TEXT}</div>}
+            />
+          )}
+        />,
+        node
+      );
+
+      expect(output).toContain(
+        'You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored'
       );
     });
 


### PR DESCRIPTION
I tried to improve warnings to cover all invalid cases.

First of all I removed `component` default prop and moved it to the `render()` as default argument. This way can check for `component`'s existence rather if it isn't a string.

This passed checks before:

```javascript
<Field
  name="text"
  component="select"
  render={() => <input type="text" />}
/>
```

Now it warns user that `You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored`. It of course still warns user, if React component is passed and it works if nothing is specified.

Same condition is also applied for the check with `children`, but here I also changed condition to check if children is a function to fix #255.

**PROPOSAL**
`warning` logic is inconsistent between `Field` and [formik](https://github.com/jaredpalmer/formik/blob/master/src/formik.tsx#L271). Maybe we should make it so?

**Qs**
In React documentation, `createElement`'s states to pass children as a third argument - https://reactjs.org/docs/react-api.html#createelement, does it make any difference?

When running `test` script a get bunch of `Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs`, is it happening to you too?

Fixes #255 
Closes #256 