### PR TITLE
Change a let to const

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ const MyForm = withFormik({
   mapPropsToValues: props => ({ email: '', password: '' }),
   // Add a custom validation function (this can be async too!)
   validate: (values, props) => {
-    let errors = {};
+    const errors = {};
     if (!values.email) {
       errors.email = 'Required';
     } else if (


### PR DESCRIPTION
The errors variable is never reassigned so can be a const. Typical eslint configurations will complain about this example code otherwise.