### PR TITLE
Add warning if validationSchema is missing form fields

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -8,7 +8,8 @@ import {
   isReactNative,
   isEmptyChildren,
   values,
-  setDeep
+  setDeep,
+  warnIfValidationSchemaHasMissingFields,
 } from './utils';
 
 import warning from 'warning';
@@ -255,6 +256,7 @@ export class Formik<
     };
 
     this.initialValues = props.initialValues || ({} as any);
+    warnIfValidationSchemaHasMissingFields(this.props);
   }
 
   componentWillReceiveProps(nextProps: Props) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,11 +93,15 @@ export const isEmptyChildren = (children: any) =>
 export function warnIfValidationSchemaHasMissingFields(props: any): void {
   if (!props.validationSchema) return;
 
+  const schema = isFunction(props.validationSchema)
+    ? props.validationSchema()
+    : props.validationSchema;
+
   const initialValuePropsStringified: string[] = Object.keys(
     props.initialValues || []
   );
   const validationSchemaFieldsStringified: string[] = Object.keys(
-    props.validationSchema().fields
+    schema.fields || []
   );
 
   const missingFields: string[] = initialValuePropsStringified.filter(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,8 +27,8 @@ export function values<T>(obj: any): T[] {
   return vals;
 }
 
-/** 
- * @private Deeply get a value from an object via it's dot path. 
+/**
+ * @private Deeply get a value from an object via it's dot path.
  * See https://github.com/developit/dlv/blob/master/index.js
  */
 export function dlv(
@@ -44,8 +44,8 @@ export function dlv(
   return obj === undefined ? def : obj;
 }
 
-/** 
- * @private Deeply set a value from in object via it's dot path. 
+/**
+ * @private Deeply set a value from in object via it's dot path.
  * See https://github.com/developit/linkstate
  */
 export function setDeep(path: string, value: any, obj: any): any {
@@ -78,15 +78,36 @@ export function setDeep(path: string, value: any, obj: any): any {
 /** @private is the given object a Function? */
 export const isFunction = (obj: any) => 'function' === typeof obj;
 
-
 /** @private is the given object an Object? */
 export const isObject = (obj: any) => obj !== null && typeof obj === 'object';
 
 /**
- * @private is the given object an Integer? 
+ * @private is the given object an Integer?
  * see https://stackoverflow.com/questions/10834796/validate-that-a-string-is-a-positive-integer
-*/
+ */
 export const isInteger = (obj: any) => String(Math.floor(Number(obj))) === obj;
 
 export const isEmptyChildren = (children: any) =>
   React.Children.count(children) === 0;
+
+export function warnIfValidationSchemaHasMissingFields(props: any): void {
+  if (!props.validationSchema) return;
+
+  const initialValuePropsStringified: string[] = Object.keys(
+    props.initialValues || []
+  );
+  const validationSchemaFieldsStringified: string[] = Object.keys(
+    props.validationSchema().fields
+  );
+
+  const missingFields: string[] = initialValuePropsStringified.filter(
+    field => validationSchemaFieldsStringified.indexOf(field) === -1
+  );
+  if (missingFields.length) {
+    console.warn(
+      `Warning: You have some missing fields in the validationSchema (${missingFields.join(
+        ', '
+      )}), which exist in the form's initialValues`
+    );
+  }
+}


### PR DESCRIPTION
Hello,

I really like your project and while using it I've run into a bug when using Yup with Formik.

TL;DR:

This PR adds a warning when some fields are specified through props.initialValues but are missing from the validationSchema.

In long:

An uncaught error is thrown when using Yup's object validation.

**Versions:**

formik@0.10.5
yup@0.23.0

If you don't specify all the form fields/initial values inside of the Yup object and
use Yup.when then a uncaught error is thrown and it crashes your app.

To recreate the bug all that's needed is:

```js
// validation schema
Yup.object().shape({
    // email: Yup.string().email(), // this should be commented out for the bug to surface
    username: Yup.string().when('email', {
        is: 'test@email.com',
        then: Yup.string().min(2),
        otherwise: Yup.string().min(6)
    })
})

// initial fields / values
{
    username: '',
    email: ''
}
```

You can see the bug on [![Codesandbox example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/rypmz212rp)


It took me a few hours to track down the bug, the error it throws "Uncaught (in promise) TypeError: Cannot read property 'length' of undefined" doesn't give much info.

I was thinking of adding a warning if you have some fields in the validation schema missing but they are present in the initialValues. This will probably save someone the headache I already had.

