### PR TITLE
Prevent shadowing in React Native README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,14 +583,14 @@ const MyReactNativeForm = props => (
           actions.setSubmitting(false);
         }, 1000);
       }}
-      render={props => (
+      render={formikProps => (
         <View>
           <TextInput
             name="email"
-            onChangeText={props.handleChange} // this WILL NOT WORK IN RN
-            value={props.values.email}
+            onChangeText={formikProps.handleChange} // this WILL NOT WORK IN RN
+            value={formikProps.values.email}
           />
-          <Button onPress={props.handleSubmit} />
+          <Button onPress={formikProps.handleSubmit} />
         </View>
       )}
     />


### PR DESCRIPTION
Use `formikProps` instead of `props` to prevent shadowing and confusion