### PR TITLE
do not touch array on FieldArray.changeValue

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -38,11 +38,10 @@ export class FieldArray extends React.Component<
   };
 
   changeValue = (fn: Function) => {
-    const { setFieldValue, setFieldTouched, values } = this.context.formik;
+    const { setFieldValue, values } = this.context.formik;
     const { name } = this.props;
     const val = fn(dlv(values, name));
     setFieldValue(name, val);
-    setFieldTouched(name, true);
   };
 
   push = (value: any) => this.changeValue((array: any[]) => [...array, value]);


### PR DESCRIPTION
Touching the array field changes the structure of `touched` to not match `values` anymore. I ran into this bug when adding new objects into my array.

Given `values`:
```
{
  items: [
    { foo: 'foo0', bar: 'bar0' },
    { foo: 'foo1', bar: 'bar1' },
  ]
}
```
I expect `touched` to look something like:
```
{
  items: [
    { foo: false, bar: false },
    { foo: false, bar: false },
  ]
}
```

Instead, by touching the array field on every `FieldArray.changeValue`, the current behavior turns touched into this: 
```
{
  items: true
}
```