### PR TITLE
Change layout of generics in main Formik class to allow better inference

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -179,10 +179,10 @@ export type FormikProps<Values> = FormikState<Values> &
   FormikHandlers &
   FormikComputedProps<Values>;
 
-export class Formik<
-  Props extends FormikConfig<Values> = FormikConfig<Values>,
-  Values = object
-> extends React.Component<Props, FormikState<any>> {
+export class Formik<ExtraProps = {}, Values = object> extends React.Component<
+  FormikConfig<Values> & ExtraProps,
+  FormikState<any>
+> {
   static defaultProps = {
     validateOnChange: true,
     validateOnBlur: true,
@@ -221,7 +221,7 @@ export class Formik<
           ? this.state.errors && Object.keys(this.state.errors).length === 0
           : this.props.isInitialValid !== false &&
             isFunction(this.props.isInitialValid)
-            ? (this.props.isInitialValid as (props: Props) => boolean)(
+            ? (this.props.isInitialValid as (props: this['props']) => boolean)(
                 this.props
               )
             : (this.props.isInitialValid as boolean),
@@ -245,7 +245,7 @@ export class Formik<
     };
   }
 
-  constructor(props: Props) {
+  constructor(props: FormikConfig<Values> & ExtraProps) {
     super(props);
     this.state = {
       values: props.initialValues || ({} as any),
@@ -257,7 +257,9 @@ export class Formik<
     this.initialValues = props.initialValues || ({} as any);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(
+    nextProps: Readonly<FormikConfig<Values> & ExtraProps>
+  ) {
     // If the initialValues change, reset the form
     if (
       this.props.enableReinitialize &&
@@ -579,7 +581,7 @@ export class Formik<
       isValid: dirty
         ? this.state.errors && Object.keys(this.state.errors).length === 0
         : isInitialValid !== false && isFunction(isInitialValid)
-          ? (isInitialValid as (props: Props) => boolean)(this.props)
+          ? (isInitialValid as (props: this['props']) => boolean)(this.props)
           : (isInitialValid as boolean),
       handleBlur: this.handleBlur,
       handleChange: this.handleChange,
@@ -622,15 +624,11 @@ function warnAboutMissingIdentifier({
   handlerName: string;
 }) {
   console.error(
-    `Warning: \`${
-      handlerName
-    }\` has triggered and you forgot to pass an \`id\` or \`name\` attribute to your input:
+    `Warning: \`${handlerName}\` has triggered and you forgot to pass an \`id\` or \`name\` attribute to your input:
 
     ${htmlContent}
 
-    Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#${
-      documentationAnchorLink
-    }
+    Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#${documentationAnchorLink}
   `
   );
 }


### PR DESCRIPTION
The generics as used before were not inferrable, so provided no security for users outside the class. (meaning they could annotate conflicting types for `initialValues` and an `onChange` handler, and not much would change).

To elaborate, previously formik's constructor had a signature similar to 
```ts
new <Props extends FormikConfig<Values> = FormikConfig<Values>, Values = object>(props: Props): React.Component<Props> & { initialValues: Values, onChange?: (props: Values) => void }
```
When TS does inference on such a signature (as we will now do for JSX as of TS 2.7; it's been missing from JSX for awhile), and you pass in an argument type like `{ initialValues: { x: 0 }, onChange: p => undefined }` inference works in this way: We infer the positional arguments between the callsite and the original signature pairwise, so we infer from `{ initialValues: { x: 0 }, onChange: p => undefined }` to `Props`. `Props` is a type parameter, so we assign it the source type as the inference and move on to other parameters. There are no other paramaters, and `Values` has yet to be assigned an inference, so it is assigned its default, `object`. The lack of a real inference on `Values` causes us not to establish a link between the contextual type on the argument position of the callback and the value of the `initialValues` member of the argument type, so it just gets the type of the default in the end, too.

By changing the signature to (effectively) 
```ts
new <ExtraProps = {}, Values = object>(props: FormikConfig<Values> & ExtraProps): React.Component<FormikConfig<Values> & ExtraProps> & { initialValues: Values, onChange?: (props: Values) => void }
```
we restructure the parameter such that it has type has positions from which to infer both `Props` (by redefining it as the combination of `FormikConfig<Values>` and some set of extra props) and `Values` (through its' presence in the type `FormikConfig<Values>`).

This should fix #314 when paired with [this fix](https://github.com/Microsoft/TypeScript/pull/21383) on the TS side (which is fixing a bug relating to us doing something incorrectly with respect to assigning contextual types on jsx attributes).

The changes to the `console.error` lines are because `prettier` reformatted them on commit. I assume that means that the change on them is desirable, if unrelated.