### PR TITLE
Correct react-native example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Then you could just use this custom input as follows:
 ```tsx
 // MyReactNativeForm.js
 import { View, Button } from 'react-native';
-import { FormikReactNativeTextInput as TextInput } from './FormikReactNativeTextInput';
+import TextInput from './FormikReactNativeTextInput';
 import { Formik } from 'formik';
 
 const MyReactNativeForm = props => (
@@ -700,7 +700,7 @@ const MyReactNativeForm = props => (
             onChangeText={props.setFieldValue}
             value={props.values.email}
           />
-          <Button onPress={props.handleSubmit} />
+          <Button title="submit" onPress={props.handleSubmit} />
         </View>
       )}
     />


### PR DESCRIPTION
The export from `FormikReactNativeTextInput.js` was a default export, so when imported it is an alias by default. Using `as` with a named export doesn't work with a default export.

[`title`](https://facebook.github.io/react-native/docs/button.html#title) is a required prop of the `react-native` `Button` component (v0.53-RC).