### PR TITLE
Add setFormikState and validateForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,9 +1004,9 @@ Your form's values. Will have the shape of the result of [`mapPropsToValues`]
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-##### `validateForm: (values?: Values) => void`
+##### `validateForm: (values?: any) => void`
 
-Imperatively call your [`validate`] or [`validateSchema`]. You can optionally pass values to validate against said values and modify Formik state accordingly, otherwise this will use the current `values`.
+Imperatively call your [`validate`] or [`validateSchema`] depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 
 #### `component`
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ can install Yup from npm...
 npm install yup --save
 ```
 
+** Table of Contents **
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -335,12 +337,13 @@ npm install yup --save
       * [`setFieldTouched: (field: string, isTouched: boolean) => void`](#setfieldtouched-field-string-istouched-boolean--void)
       * [`setFieldValue: (field: string, value: any) => void`](#setfieldvalue-field-string-value-any--void)
       * [`setStatus: (status?: any) => void`](#setstatus-status-any--void)
-      * [`setSubmitting: (boolean) => void`](#setsubmitting-boolean--void)
+      * [`setSubmitting: (isSubmitting: boolean) => void`](#setsubmitting-issubmitting-boolean--void)
       * [`setTouched: (fields: { [field: string]: boolean }) => void`](#settouched-fields--field-string-boolean---void)
       * [`setValues: (fields: { [field: string]: any }) => void`](#setvalues-fields--field-string-any---void)
       * [`status?: any`](#status-any)
       * [`touched: { [field: string]: boolean }`](#touched--field-string-boolean-)
       * [`values: { [field: string]: any }`](#values--field-string-any-)
+      * [`validateForm: (values?: any) => void`](#validateform-values-any--void)
     * [`component`](#component)
     * [`render: (props: FormikProps<Values>) => ReactNode`](#render-props-formikpropsvalues--reactnode)
     * [`children: func`](#children-func)

--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ Set a top-level [`status`] to anything you want imperatively. Useful for
 controlling arbitrary top-level state related to your form. For example, you can
 use it to pass API responses back into your component in [`handleSubmit`].
 
-##### `setSubmitting: (boolean) => void`
+##### `setSubmitting: (isSubmitting: boolean) => void`
 
 Set [`isSubmitting`] imperatively.
 
@@ -1003,6 +1003,10 @@ Touched fields. Each key corresponds to a field that has been touched/visited.
 Your form's values. Will have the shape of the result of [`mapPropsToValues`]
 (if specified) or all props that are not functions passed to your wrapped
 component.
+
+##### `validateForm: (values?: Values) => void`
+
+Imperatively call your [`validate`] or [`validateSchema`]. You can optionally pass values to validate against said values and modify Formik state accordingly, otherwise this will use the current `values`.
 
 #### `component`
 

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { dlv } from './utils';
+import { dlv, setDeep } from './utils';
 import { SharedRenderProps } from './types';
 import * as PropTypes from 'prop-types';
-import { FormikProps } from './formik';
+import { FormikProps, FormikState } from './formik';
 
 export type FieldArrayConfig = {
   /** Really the path to the array field to be updated */
@@ -68,24 +68,18 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
     alterTouched: boolean,
     alterErrors: boolean
   ) => {
-    const {
-      setFieldTouched,
-      setFieldValue,
-      setFieldError,
-      values,
-      touched,
-      errors,
-    } = this.context.formik;
+    const { setFormikState, values, touched, errors } = this.context.formik;
     const { name } = this.props;
-    setFieldValue(name, fn(dlv(values, name)));
-
-    if (alterErrors) {
-      setFieldError(name, fn(dlv(errors, name)));
-    }
-
-    if (alterTouched) {
-      setFieldTouched(name, fn(dlv(touched, name)));
-    }
+    setFormikState((prevState: FormikState<any>) => ({
+      ...prevState,
+      values: setDeep(name, fn(dlv(values, name)), prevState.values),
+      errors: alterErrors
+        ? setDeep(name, fn(dlv(errors, name)), prevState.errors)
+        : prevState.errors,
+      touched: alterTouched
+        ? setDeep(name, fn(dlv(touched, name)), prevState.touched)
+        : prevState.touched,
+    }));
   };
 
   push = (value: any) =>

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -68,30 +68,55 @@ export interface FormikComputedProps<Values> {
  */
 export interface FormikActions<Values> {
   /** Manually set top level status. */
-  setStatus: (status?: any) => void;
+  setStatus(status?: any): void;
   /**
    * Manually set top level error
    * @deprecated since 0.8.0
    */
-  setError: (e: any) => void;
+  setError(e: any): void;
   /** Manually set errors object */
-  setErrors: (errors: FormikErrors<Values>) => void;
+  setErrors(errors: FormikErrors<Values>): void;
   /** Manually set isSubmitting */
-  setSubmitting: (isSubmitting: boolean) => void;
+  setSubmitting(isSubmitting: boolean): void;
   /** Manually set touched object */
-  setTouched: (touched: FormikTouched<Values>) => void;
+  setTouched(touched: FormikTouched<Values>): void;
   /** Manually set values object  */
-  setValues: (values: Values) => void;
+  setValues(values: Values): void;
   /** Set value of form field directly */
-  setFieldValue: (field: keyof Values, value: any) => void;
+  setFieldValue(field: keyof Values, value: any): void;
   /** Set error message of a form field directly */
-  setFieldError: (field: keyof Values, message: string) => void;
+  setFieldError(field: keyof Values, message: string): void;
   /** Set whether field has been touched directly */
-  setFieldTouched: (field: keyof Values, isTouched?: boolean) => void;
+  setFieldTouched(field: keyof Values, isTouched?: boolean): void;
+  /** Validate form values */
+  validateForm(values?: any): void;
   /** Reset form */
-  resetForm: (nextValues?: any) => void;
+  resetForm(nextValues?: any): void;
   /** Submit the form imperatively */
-  submitForm: () => void;
+  submitForm(): void;
+  /** Set Formik state, careful! */
+  setFormikState<K extends keyof FormikState<Values>>(
+    f: (
+      prevState: Readonly<FormikState<Values>>,
+      props: any
+    ) => Pick<FormikState<Values>, K>,
+    callback?: () => any
+  ): void;
+}
+
+/** Overloded methods / types */
+export interface FormikActions<Values> {
+  /** Set value of form field directly */
+  setFieldValue(field: string, value: any): void;
+  /** Set error message of a form field directly */
+  setFieldError(field: string, message: string): void;
+  /** Set whether field has been touched directly */
+  setFieldTouched(field: string, isTouched?: boolean): void;
+  /** Set Formik state, careful! */
+  setFormikState<K extends keyof FormikState<Values>>(
+    state: Pick<FormikState<Values>, K>,
+    callback?: () => any
+  ): void;
 }
 
 /**
@@ -329,7 +354,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   /**
    * Run validations and update state accordingly
    */
-  runValidations = (values: FormikValues) => {
+  runValidations = (values: FormikValues = this.state.values) => {
     if (this.props.validationSchema) {
       this.runValidationSchema(values);
     }
@@ -534,9 +559,14 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     }
   };
 
+  setFormikState = (s: any, callback?: (() => void)) =>
+    this.setState(s, callback);
+
   getFormikActions = (): FormikActions<Values> => {
     return {
       resetForm: this.resetForm,
+      submitForm: this.submitForm,
+      validateForm: this.runValidations,
       setError: this.setError,
       setErrors: this.setErrors,
       setFieldError: this.setFieldError,
@@ -546,7 +576,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       setSubmitting: this.setSubmitting,
       setTouched: this.setTouched,
       setValues: this.setValues,
-      submitForm: this.submitForm,
+      setFormikState: this.setFormikState,
     };
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,11 +57,11 @@ export function setDeep(path: string, value: any, obj: any): any {
 export function setNestedObjectValues<T>(
   object: any,
   value: any,
-  visited: any = null,
-  response: any = null
+  visited?: any,
+  response?: any
 ): T {
-  visited = visited === null ? new WeakMap() : visited;
-  response = response === null ? {} : response;
+  visited = visited || new WeakMap();
+  response = response || {};
 
   for (let k of Object.keys(object)) {
     const val = object[k];


### PR DESCRIPTION
- #367 Adds an undocumented `setFormikState` to FormikActions / Bag so that `FieldArray` and `FormikPersist` can make atomic state updates. This may be renamed to `unstable_setFormikState` as it really should not be used outside of library authors. 
- #51 Adds `validateForm: (values?: any) => void` to FormikActions / Bag. 