### PR TITLE
Support 'children as a function' for FieldArray

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { dlv, setDeep } from './utils';
+import { dlv, setDeep, isEmptyChildren } from './utils';
 import { SharedRenderProps } from './types';
 import * as PropTypes from 'prop-types';
 import { FormikProps, FormikState } from './formik';
@@ -169,13 +169,17 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
       remove: this.remove,
     };
 
-    const { component, render } = this.props;
+    const { component, render, children } = this.props;
     const props = { ...arrayHelpers, form: this.context.formik };
 
-    if (component) {
-      return React.createElement(component as any, props);
-    }
-
-    return render ? (render as any)(props) : null;
+    return component
+      ? React.createElement(component as any, props)
+      : render
+        ? (render as any)(props)
+        : children // children come last, always called
+          ? typeof children === 'function'
+            ? (children as any)(props)
+            : !isEmptyChildren(children) ? React.Children.only(children) : null
+          : null;
   }
 }

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -55,6 +55,22 @@ describe('<FieldArray />', () => {
     );
   });
 
+  it('renders with "children as a function" with array helpers as props', () => {
+    ReactDOM.render(
+      <TestForm
+        render={() => (
+          <FieldArray name="friends">
+            {arrayProps => {
+              expect(isFunction(arrayProps.push)).toBeTruthy();
+              return null;
+            }}
+          </FieldArray>
+        )}
+      />,
+      node
+    );
+  });
+
   describe('props.push()', () => {
     it('should add a value to the end of the field array', () => {
       let formikBag: any;


### PR DESCRIPTION
The FieldArray component advertises that it can handle a children function but previously did not implement it. This fixes that.