### PR TITLE
Add name to ArrayField

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -169,8 +169,8 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
       remove: this.remove,
     };
 
-    const { component, render, children } = this.props;
-    const props = { ...arrayHelpers, form: this.context.formik };
+    const { component, render, children, name } = this.props;
+    const props = { ...arrayHelpers, form: this.context.formik, name };
 
     return component
       ? React.createElement(component as any, props)


### PR DESCRIPTION
`ArrayField` component/render/children does not have access to `name` property from parent

**form.ts**

```
<ArrayField name={'roles'} component={ Roles } />
```

**roles.ts**
```
const Roles = ({ name, form  }) => {
   const { values, setFieldValue } = form; 
   
   return (
      <>
         { values[name].map(role => <input .... onChange={ (e) => setFieldValue(name, e.target.value) } />}
      </>
    )
}
```

Would be useful to have access to the property `name` from `ArrayField name={'roles'}` in order to avoid code duplication and avoid mistakes with names. @jaredpalmer could you review?