### PR TITLE
Optionalize `FormikErrors`

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -23,7 +23,7 @@ export interface FormikValues {
  * An object containing error messages whose keys correspond to FormikValues.
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
-export type FormikErrors<Values> = { [field in keyof Values]: any };
+export type FormikErrors<Values> = { [field in keyof Values]?: any };
 
 /**
  * An object containing touched state of the form whose keys correspond to FormikValues.


### PR DESCRIPTION
In the examples given in JS in the docs, a function that is expected to return a `FormikErrors` object creates one with `const errors = {}`, and then conditionally adds only some members with keys of `Values` to it. This indicates that these members should be optional, which is critical for correct checking in consumer code under `strictNullChecks` mode in typescript.