### PR TITLE
Fix typings for FieldConfig['component']

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -48,7 +48,7 @@ export interface FieldConfig {
   /**
    * Field component to render. Can either be a string like 'select' or a component.
    */
-  component?: string | React.ComponentType<FieldProps<any> | void>;
+  component?: string | React.ComponentType<FieldProps<any>> | React.ComponentType<void>;
 
   /**
    * Render prop (works like React router's <Route render={props =>} />)


### PR DESCRIPTION
The current typings weren't working for me at all, but this seems to work fine.