### PR TITLE
#385 Add overloads to handleBlur and handleChange

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -418,6 +418,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   handleChange = (
     eventOrString: any
   ): void | ((e: React.ChangeEvent<any>) => void) => {
+    // @todo someone make this less disgusting.
     const executeChange = (e: React.ChangeEvent<any>, path?: string) => {
       e.persist();
       let field = path;
@@ -449,7 +450,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         }
       } else {
         console.warn(
-          'Formik could not determine which field to update in your input.'
+          'Formik could not determine which field to update based on your input and usage of `handleChange`'
         );
       }
     };

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -157,6 +157,8 @@ export interface FormikActions<Values> {
  * Formik form event handlers
  */
 export interface FormikHandlers {
+  /** Form submit handler */
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   /** Reset form event handler  */
   handleReset: () => void;
   /** Classic React blur handler, keyed by input name */

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -9,6 +9,7 @@ import {
   isEmptyChildren,
   setIn,
   setNestedObjectValues,
+  isReactNative,
 } from './utils';
 
 /**
@@ -437,6 +438,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       e.persist();
       let field = path;
       let val = e;
+      let parsed;
       if (!isReactNative) {
         const { type, name, id, value, checked, outerHTML } = e.target;
         field = path ? path : name ? name : id;
@@ -456,7 +458,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         // Set form fields by name
         this.setState(prevState => ({
           ...prevState,
-          values: setIn( prevState.values, field!, val,),
+          values: setIn(prevState.values, field!, val),
         }));
 
         if (this.props.validateOnChange) {
@@ -563,10 +565,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         });
       }
 
-
-     this.setState(prevState => ({
-      touched: setIn(prevState.touched, field, true),
-     }));
+      this.setState(prevState => ({
+        touched: setIn(prevState.touched, field, true),
+      }));
 
       if (this.props.validateOnBlur) {
         this.runValidations(this.state.values);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,10 @@ export const isObject = (obj: any) => obj !== null && typeof obj === 'object';
 /** @private is the given object an integer  */
 export const isInteger = (obj: any) => String(Math.floor(Number(obj))) === obj;
 
+/** @private is the given object a string  */
+export const isString = (obj: any) =>
+  Object.prototype.toString.call(obj) === '[object String]';
+
 /** @private Does a React component have exactly 0 children? */
 export const isEmptyChildren = (children: any) =>
   React.Children.count(children) === 0;

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -10,13 +10,11 @@ interface Values {
 
 const Form: React.SFC<FormikProps<Values>> = ({
   values,
-  handleReset,
   handleSubmit,
   handleChange,
   handleBlur,
   status,
   errors,
-  dirty,
   isSubmitting,
 }) => {
   return (
@@ -898,7 +896,7 @@ describe('<Formik>', () => {
 
       const tree = shallow(
         <Formik
-          initialValues={{ foo: 'bar', bar: 'foo' }}
+          initialValues={{ name: 'jared' }}
           onSubmit={jest.fn()}
           onReset={onReset}
           component={Form}
@@ -910,7 +908,7 @@ describe('<Formik>', () => {
         .handleReset();
 
       expect(onReset).toHaveBeenCalledWith(
-        { foo: 'bar', bar: 'foo' },
+        { name: 'jared' },
         expect.objectContaining({
           resetForm: expect.any(Function),
           setError: expect.any(Function),
@@ -932,7 +930,7 @@ describe('<Formik>', () => {
 
       const tree = shallow(
         <Formik
-          initialValues={{ foo: 'bar' }}
+          initialValues={{ name: 'bar' }}
           onSubmit={onSubmit}
           component={Form}
         />
@@ -950,7 +948,7 @@ describe('<Formik>', () => {
 
       const tree = shallow(
         <Formik
-          initialValues={{ foo: 'bar', bar: 'foo' }}
+          initialValues={{ name: 'jared' }}
           onSubmit={jest.fn()}
           onReset={onReset}
           component={Form}
@@ -965,7 +963,7 @@ describe('<Formik>', () => {
         .handleReset();
 
       expect(onReset).toHaveBeenCalledWith(
-        { foo: 'bar', bar: 'foo' },
+        { name: 'jared' },
         expect.objectContaining({
           resetForm: expect.any(Function),
           setError: expect.any(Function),


### PR DESCRIPTION
#385  Adds the ability to pass a string to `handleChange` and `handleBlur` like Preact's `linkState` helper. 

## Before
```
<input onChange={handleChange} name="firstName" values={values.firstName} />
```

## After

```
// Still works!
<input onChange={handleChange} name="firstName" values={values.firstName} />

// New 
<input onChange={handleChange('firstName')} values={values.firstName} />

// and more importantly in React Native
<TextInput onChangeText={handleChange('firstName')} />
```
