### PR TITLE
Fix #368. Relax types for FormikTouched 

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "tsc-watch": "1.0.7",
     "tslint": "5.5.0",
     "tslint-react": "3.2.0",
-    "typescript": "2.6.2",
+    "typescript": "^2.7.1",
     "yup": "0.21.3"
   },
   "lint-staged": {

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -35,13 +35,17 @@ export interface FormikValues {
 /**
  * An object containing error messages whose keys correspond to FormikValues.
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
+ *
+ * @todo Remove any in TypeScript 2.8
  */
 export type FormikErrors<Values> = { [field in keyof Values]?: any };
 
 /**
  * An object containing touched state of the form whose keys correspond to FormikValues.
+ *
+ * @todo Remove any in TypeScript 2.8
  */
-export type FormikTouched<Values> = { [field in keyof Values]: boolean };
+export type FormikTouched<Values> = { [field in keyof Values]?: any };
 
 /**
  * Formik state tree

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -45,7 +45,9 @@ export type FormikErrors<Values> = { [field in keyof Values]?: any };
  *
  * @todo Remove any in TypeScript 2.8
  */
-export type FormikTouched<Values> = { [field in keyof Values]?: any };
+export type FormikTouched<Values> = {
+  [field in keyof Values]?: boolean & FormikTouched<Values[field]>
+};
 
 /**
  * Formik state tree

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,9 +3752,13 @@ type-name@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/type-name/-/type-name-2.0.2.tgz#efe7d4123d8ac52afff7f40c7e4dec5266008fb4"
 
-typescript@*, typescript@2.6.2:
+typescript@*:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
#368 #413 Adds TypeScript support for nth nested paths in FormikTouched

@weswigham Is there a better way to do this?

We would need some sort of recursive mapped type (i think)