### PR TITLE
Add <FastField />

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.isequal": "4.5.2",
     "@types/lodash.topath": "4.5.3",
-    "@types/prop-types": "15.5.1",
+    "@types/prop-types": "^15.5.2",
     "@types/react": "16.0.28",
     "@types/react-dom": "^16.0.3",
     "@types/react-native": "^0.52.8",

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -14,7 +14,8 @@ export interface FastFieldState {
   touched: boolean;
 }
 
-function diffObjectsExceptForKey(a: any, b: any, path: string) {
+/** @private Returns whether two objects are deeply equal **excluding** a key / dot path */
+function isEqualExceptForKey(a: any, b: any, path: string) {
   return isEqual(setIn(a, path, undefined), setIn(b, path, undefined));
 }
 
@@ -87,6 +88,7 @@ export class FastField<
       values,
       validationSchema,
       errors,
+      setFormikState,
     } = this.context.formik;
     const { type, value, checked } = e.target;
     const val = /number|range/.test(type)
@@ -95,7 +97,6 @@ export class FastField<
     if (validateOnChange) {
       // Field-level validation
       if (this.props.validate) {
-        console.log('field-validate');
         const maybePromise = (this.props.validate as any)(value);
         if (isPromise(maybePromise)) {
           this.setState({ value: val });
@@ -111,25 +112,44 @@ export class FastField<
         const maybePromise = (validate as any)(
           setIn(values, this.props.name, val)
         );
-        console.log('validate');
-        console.log(
-          diffObjectsExceptForKey(maybePromise, errors, this.props.name)
-        );
+
         if (isPromise(maybePromise)) {
           this.setState({ value: val });
           (maybePromise as any).then(
             () => this.setState({ error: undefined }),
-            (error: any) =>
-              this.setState({ error: getIn(error, this.props.name) })
+            (error: any) => {
+              // Here we diff the errors object relative to Formik parents except for
+              // the Field's key. If they are equal, the field's validation function is
+              // has no inter-field side-effects and we only need to update local state
+              // otherwise we need to lift up the update to the parent (causing a full form render)
+              if (isEqualExceptForKey(maybePromise, errors, this.props.name)) {
+                this.setState({ error: getIn(error, this.props.name) });
+              } else {
+                setFormikState((prevState: any) => ({
+                  ...prevState,
+                  errors: error,
+                  // touched: setIn(prevState.touched, name, true),
+                }));
+              }
+            }
           );
         } else {
-          console.log(
-            diffObjectsExceptForKey(maybePromise, errors, this.props.name)
-          );
-          this.setState({
-            value: val,
-            error: getIn(maybePromise, this.props.name),
-          });
+          // Handle the same diff situation
+          // @todo refactor
+          if (isEqualExceptForKey(maybePromise, errors, this.props.name)) {
+            this.setState({
+              value: val,
+              error: getIn(maybePromise, this.props.name),
+            });
+          } else {
+            this.setState({
+              value: val,
+            });
+            setFormikState((prevState: any) => ({
+              ...prevState,
+              errors: maybePromise,
+            }));
+          }
         }
       } else if (validationSchema) {
         // Top-level validationsSchema
@@ -241,7 +261,11 @@ export class FastField<
     };
 
     if (render) {
-      return (render as any)(bag);
+      return (render as (
+        props: FieldProps<any> & {
+          meta: { error?: string; touched?: boolean };
+        }
+      ) => React.ReactNode)(bag);
     }
 
     if (isFunction(children)) {

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -256,7 +256,6 @@ export class FastField<
     const bag = {
       field,
       form: formik,
-      // @todo add types
       meta: { touched: getIn(formik.touched, name), error: this.state.error },
     };
 

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -26,7 +26,7 @@ import { GenericFieldHTMLAttributes } from './types';
  *     {form.touched[field.name] && form.errors[field.name]}
  *   </div>
  */
-export interface FieldProps<V = any> {
+export interface FastFieldProps<V = any> {
   field: {
     /** Classic React change handler, keyed by input name */
     onChange: (e: React.ChangeEvent<any>) => void;
@@ -40,24 +40,24 @@ export interface FieldProps<V = any> {
   form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
 }
 
-export interface FieldConfig {
+export interface FastFieldConfig {
   /**
    * Field component to render. Can either be a string like 'select' or a component.
    */
   component?:
     | string
-    | React.ComponentType<FieldProps<any>>
+    | React.ComponentType<FastFieldProps<any>>
     | React.ComponentType<void>;
 
   /**
    * Render prop (works like React router's <Route render={props =>} />)
    */
-  render?: ((props: FieldProps<any>) => React.ReactNode);
+  render?: ((props: FastFieldProps<any>) => React.ReactNode);
 
   /**
    * Children render function <Field name>{props => ...}</Field>)
    */
-  children?: ((props: FieldProps<any>) => React.ReactNode);
+  children?: ((props: FastFieldProps<any>) => React.ReactNode);
 
   /**
    * Validate a single field value independently
@@ -76,17 +76,16 @@ export interface FieldConfig {
   value?: any;
 }
 
-export type FieldAttributes = GenericFieldHTMLAttributes & FieldConfig;
+export type FastFieldAttributes = GenericFieldHTMLAttributes & FastFieldConfig;
 
 /**
  * Custom Field component for quickly hooking into Formik
  * context and wiring up forms.
  */
 
-export class Field<Props extends FieldAttributes = any> extends React.Component<
-  Props,
-  {}
-> {
+export class FastField<
+  Props extends FastFieldAttributes = any
+> extends React.Component<Props, {}> {
   static contextTypes = {
     formik: PropTypes.object,
   };
@@ -159,7 +158,7 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
       children,
       component = 'input',
       ...props
-    } = this.props as FieldConfig;
+    } = this.props as FastFieldConfig;
 
     const { formik } = this.context;
     const field = {
@@ -178,7 +177,7 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
     }
 
     if (isFunction(children)) {
-      return (children as (props: FieldProps<any>) => React.ReactNode)(bag);
+      return (children as (props: FastFieldProps<any>) => React.ReactNode)(bag);
     }
 
     if (typeof component === 'string') {

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -656,6 +656,8 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       ...this.state,
       ...this.getFormikActions(),
       ...this.getFormikComputedProps(),
+      validationSchema: this.props.validationSchema,
+      validate: this.props.validate,
       // FastField needs to communicate with Formik during resets
       registerField: this.registerField,
       unregisterField: this.unregisterField,
@@ -721,6 +723,7 @@ export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
 export function validateYupSchema<T>(
   data: T,
   schema: any,
+  sync: boolean = false,
   context: any = {}
 ): Promise<void> {
   let validateData: any = {};
@@ -731,7 +734,10 @@ export function validateYupSchema<T>(
         (data as any)[key] !== '' ? (data as any)[key] : undefined;
     }
   }
-  return schema.validate(validateData, { abortEarly: false, context: context });
+  return schema[sync ? 'validateSync' : 'validate'](validateData, {
+    abortEarly: false,
+    context: context,
+  });
 }
 
 export * from './Field';

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -277,12 +277,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
 
   getChildContext() {
     return {
-      formik: {
-        ...this.getFormikBag(),
-        // FastField needs to communicate with Formik during resets
-        registerField: this.registerField,
-        unregisterField: this.unregisterField,
-      },
+      formik: this.getFormikBag(),
     };
   }
 
@@ -661,6 +656,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       ...this.state,
       ...this.getFormikActions(),
       ...this.getFormikComputedProps(),
+      // FastField needs to communicate with Formik during resets
+      registerField: this.registerField,
+      unregisterField: this.unregisterField,
       handleBlur: this.handleBlur,
       handleChange: this.handleChange,
       handleReset: this.handleReset,

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -725,3 +725,4 @@ export * from './Form';
 export * from './withFormik';
 export * from './FieldArray';
 export * from './utils';
+export * from './FastField';

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -277,7 +277,11 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
 
   getChildContext() {
     return {
-      formik: this.getFormikBag(),
+      formik: {
+        ...this.getFormikBag(),
+        validationSchema: this.props.validationSchema,
+        validate: this.props.validate,
+      },
     };
   }
 
@@ -656,8 +660,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       ...this.state,
       ...this.getFormikActions(),
       ...this.getFormikComputedProps(),
-      validationSchema: this.props.validationSchema,
-      validate: this.props.validate,
+
       // FastField needs to communicate with Formik during resets
       registerField: this.registerField,
       unregisterField: this.unregisterField,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,8 @@ export interface SharedRenderProps<T> {
    */
   children?: ((props: T) => React.ReactNode);
 }
+
+export type GenericFieldHTMLAttributes =
+  | React.InputHTMLAttributes<HTMLInputElement>
+  | React.SelectHTMLAttributes<HTMLSelectElement>
+  | React.TextareaHTMLAttributes<HTMLTextAreaElement>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,9 +49,9 @@
   version "8.0.57"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.57.tgz#e5d8b4dc112763e35cfc51988f4f38da3c486d99"
 
-"@types/prop-types@15.5.1":
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.1.tgz#1ecf52621299e65b855374337fb11fd2d1066fc1"
+"@types/prop-types@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
 
 "@types/react-dom@^16.0.3":
   version "16.0.3"


### PR DESCRIPTION
![kapture 2018-02-09 at 22 10 49](https://user-images.githubusercontent.com/4060187/36058047-25d9457e-0de6-11e8-8e8c-4240eb5f218d.gif)

This adds a new `<FastField>` component to Formik. It renders fields independently while keeping an identical API to `<Field />`.

### Implementation notes

- FastField keeps local field state `value`, `error`, and `touched`. (Although i think we can drop `touched` because it is redudant), it passes _local state_ to the `field` prop in render and to the input.
- In FastField's handleChange: updates local state instead of the parent Formik's state. 
- In FastField's handleBlur: sends local state up to Formik's which causes a re-render (which is desired in this case).
- Syncing Formik reset behavior: in order to make FastField's state appear to be sync'd up to the parent Formik's, FastField registers itself with the parent Formik's `this.fields: { [fieldName: string]: () => void }` object. This object's keys are just the dotpaths/names of the fastfields and the values are local reset functions. During `resetForm()`, Formik iterates through `this.fields`'s keys, and calls the reset functions. Whenever a FastField unmounts, it also unregisters itself. There might be better / safer ways to implement this.
- FastField only validates on change if passed a validate={} prop and validateOnChange is true.
- I coded this on a train, so there may be some gotchas / edge cases i didn't consider

