### PR TITLE
Attempt to move to create-react-context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .DS_Store
 next.d.ts
 legacy.d.ts
+.rpt2_cache

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "gen-docs": "all-contributors generate && doctoc README.md"
   },
   "dependencies": {
+    "create-react-context": "^0.1.6",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "4.5.0",
     "lodash.topath": "4.5.2",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.6.0",
     "warning": "^3.0.0"
   },
   "peerDependencies": {
@@ -51,7 +52,6 @@
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.isequal": "4.5.2",
     "@types/lodash.topath": "4.5.3",
-    "@types/prop-types": "15.5.1",
     "@types/react": "16.0.28",
     "@types/react-dom": "^16.0.3",
     "@types/react-test-renderer": "15.5.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
-import sourceMaps from 'rollup-plugin-sourcemaps';
+
 import uglify from 'rollup-plugin-uglify';
 
 const shared = {
@@ -10,16 +10,15 @@ const shared = {
   external: ['react', 'react-native'],
 };
 
+const prod = process.env.NODE_ENV === 'production';
+
 export default [
   Object.assign({}, shared, {
     output: {
       name: 'Formik',
       format: 'umd',
       sourcemap: true,
-      file:
-        process.env.NODE_ENV === 'production'
-          ? './dist/formik.umd.min.js'
-          : './dist/formik.umd.js',
+      file: prod ? './dist/formik.umd.min.js' : './dist/formik.umd.js',
       exports: 'named',
       globals: {
         react: 'React',
@@ -37,21 +36,10 @@ export default [
       }),
       commonjs({
         include: /node_modules/,
-        namedExports: {
-          'node_modules/prop-types/index.js': [
-            'object',
-            'oneOfType',
-            'string',
-            'node',
-            'func',
-            'bool',
-            'element',
-          ],
-        },
       }),
-      sourceMaps(),
-      process.env.NODE_ENV === 'production' && filesize(),
-      process.env.NODE_ENV === 'production' &&
+
+      prod && filesize(),
+      prod &&
         uglify({
           output: { comments: false },
           compress: {
@@ -92,19 +80,7 @@ export default [
       resolve(),
       commonjs({
         include: /node_modules/,
-        namedExports: {
-          'node_modules/prop-types/index.js': [
-            'object',
-            'oneOfType',
-            'string',
-            'node',
-            'func',
-            'bool',
-            'element',
-          ],
-        },
       }),
-      sourceMaps(),
     ],
   }),
 ];

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -85,8 +85,9 @@ export type FieldAttributes = GenericFieldHTMLAttributes & FieldConfig;
  * context and wiring up forms.
  */
 class FieldWithContext<
-  Props extends FieldAttributes = any
-> extends React.Component<Props & { formik: FormikProps<any> }, {}> {
+  Props extends FieldAttributes = any,
+  Values = {}
+> extends React.Component<Props & { formik: FormikProps<Values> }, {}> {
   componentWillMount() {
     const { render, children, component } = this.props;
 
@@ -148,7 +149,7 @@ class FieldWithContext<
       component = 'input',
       formik,
       ...props
-    } = this.props as FieldConfig & { formik: FormikProps<any> };
+    } = this.props as FieldConfig & { formik: FormikProps<Values> };
 
     const field = {
       value:

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -52,15 +52,15 @@ export const insert = (array: any[], index: number, value: any) => {
   return copy;
 };
 
-class FieldArrayWithContext extends React.Component<
-  FieldArrayConfig & { formik: FormikProps<any> },
+class FieldArrayWithContext<Values = {}> extends React.Component<
+  FieldArrayConfig & { formik: FormikProps<Values> },
   {}
 > {
   static defaultProps = {
     validateOnChange: true,
   };
 
-  constructor(props: FieldArrayConfig & { formik: FormikProps<any> }) {
+  constructor(props: FieldArrayConfig & { formik: FormikProps<Values> }) {
     super(props);
     // We need TypeScript generics on these, so we'll bind them in the constructor
     this.remove = this.remove.bind(this);

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -1,8 +1,7 @@
-import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { FormikProps, FormikState, isFunction } from './formik';
-import { isEmptyChildren, getIn, setIn } from './utils';
-import { SharedRenderProps } from './types';
+import { isFunction, isEmptyChildren, getIn, setIn } from './utils';
+import { SharedRenderProps, FormikProps, FormikState } from './types';
+import { connect } from './connect';
 
 export type FieldArrayConfig = {
   /** Really the path to the array field to be updated */
@@ -53,15 +52,15 @@ export const insert = (array: any[], index: number, value: any) => {
   return copy;
 };
 
-export class FieldArray extends React.Component<FieldArrayConfig, {}> {
+class FieldArrayWithContext extends React.Component<
+  FieldArrayConfig & { formik: FormikProps<any> },
+  {}
+> {
   static defaultProps = {
     validateOnChange: true,
   };
-  static contextTypes = {
-    formik: PropTypes.object,
-  };
 
-  constructor(props: FieldArrayConfig) {
+  constructor(props: FieldArrayConfig & { formik: FormikProps<any> }) {
     super(props);
     // We need TypeScript generics on these, so we'll bind them in the constructor
     this.remove = this.remove.bind(this);
@@ -79,7 +78,7 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
       values,
       touched,
       errors,
-    } = this.context.formik;
+    } = this.props.formik;
     const { name, validateOnChange } = this.props;
     setFormikState(
       (prevState: FormikState<any>) => ({
@@ -194,7 +193,7 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
     };
 
     const { component, render, children, name } = this.props;
-    const props = { ...arrayHelpers, form: this.context.formik, name };
+    const props = { ...arrayHelpers, form: this.props.formik, name };
 
     return component
       ? React.createElement(component as any, props)
@@ -207,3 +206,5 @@ export class FieldArray extends React.Component<FieldArrayConfig, {}> {
           : null;
   }
 }
+
+export const FieldArray = connect<FieldArrayConfig, any>(FieldArrayWithContext);

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,10 +1,6 @@
-import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import { connect } from './connect';
 
-export const Form: React.SFC<any> = (props, context) => (
-  <form onSubmit={context.formik.handleSubmit} {...props} />
-);
-
-Form.contextTypes = {
-  formik: PropTypes.object,
-};
+export const Form = connect<any>(({ formik: { handleSubmit }, ...props }) => (
+  <form onSubmit={handleSubmit} {...props} />
+));

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import createContext from 'create-react-context';
+import { FormikProps } from './types';
+
+export const FormikContext = createContext<FormikProps<any>>({} as any);
+
+/**
+ * Connect any component to Formik context, and inject as a prop called `formik`;
+ * @param Comp React Component
+ */
+export function connect<Outer, Values = {}>(
+  Comp: React.ComponentType<Outer & { formik: FormikProps<Values> }>
+) {
+  return (props: Outer) => (
+    <FormikContext.Consumer>
+      {formik => <Comp {...props} formik={formik} />}
+    </FormikContext.Consumer>
+  );
+}

--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -1,7 +1,7 @@
-import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import isEqual from 'lodash.isequal';
 import warning from 'warning';
+import { FormikContext } from './connect';
 
 import {
   isFunction,
@@ -12,233 +12,14 @@ import {
   setNestedObjectValues,
 } from './utils';
 
-/**
- * We need to fix a TypeScript x Yarn x React Native bug that occurs
- * when you try to use @types/node and @types/react-native in the
- * same project because of how react native's typings have their own
- * global declarations for require(). To fix this, Formik specifies all types
- * in tsconfig's compilerOptions explicitly (instead of TS inferring them from
- * ./node_modules/@types/**) and then must declare the only parts of @types/node it needs: process.env
- *
- * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15960
- * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15960#issuecomment-354403930 (solution)
- */
-declare const process: { env: { NODE_ENV: string } };
-
-/**
- * Values of fields in the form
- */
-export interface FormikValues {
-  [field: string]: any;
-}
-
-/**
- * An object containing error messages whose keys correspond to FormikValues.
- * Should be always be and object of strings, but any is allowed to support i18n libraries.
- *
- * @todo Remove any in TypeScript 2.8
- */
-export type FormikErrors<Values> = { [field in keyof Values]?: any };
-
-/**
- * An object containing touched state of the form whose keys correspond to FormikValues.
- *
- * @todo Remove any in TypeScript 2.8
- */
-export type FormikTouched<Values> = {
-  [field in keyof Values]?: boolean & FormikTouched<Values[field]>
-};
-
-/**
- * Formik state tree
- */
-export interface FormikState<Values> {
-  /** Form values */
-  values: Values;
-  /**
-   * Top level error, in case you need it
-   * @deprecated since 0.8.0
-   */
-  error?: any;
-  /** map of field names to specific error for that field */
-  errors: FormikErrors<Values>;
-  /** map of field names to whether the field has been touched */
-  touched: FormikTouched<Values>;
-  /** whether the form is currently submitting */
-  isSubmitting: boolean;
-  /** Top level status state, in case you need it */
-  status?: any;
-}
-
-/**
- * Formik computed properties. These are read-only.
- */
-export interface FormikComputedProps<Values> {
-  /** True if any input has been touched. False otherwise. */
-  readonly dirty: boolean;
-  /** Result of isInitiallyValid on mount, then whether true values pass validation. */
-  readonly isValid: boolean;
-  /** initialValues */
-  readonly initialValues: Values;
-}
-
-/**
- * Formik state helpers
- */
-export interface FormikActions<Values> {
-  /** Manually set top level status. */
-  setStatus(status?: any): void;
-  /**
-   * Manually set top level error
-   * @deprecated since 0.8.0
-   */
-  setError(e: any): void;
-  /** Manually set errors object */
-  setErrors(errors: FormikErrors<Values>): void;
-  /** Manually set isSubmitting */
-  setSubmitting(isSubmitting: boolean): void;
-  /** Manually set touched object */
-  setTouched(touched: FormikTouched<Values>): void;
-  /** Manually set values object  */
-  setValues(values: Values): void;
-  /** Set value of form field directly */
-  setFieldValue(
-    field: keyof Values,
-    value: any,
-    shouldValidate?: boolean
-  ): void;
-  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
-  /** Set error message of a form field directly */
-  setFieldError(field: keyof Values, message: string): void;
-  setFieldError(field: string, message: string): void;
-  /** Set whether field has been touched directly */
-  setFieldTouched(
-    field: keyof Values,
-    isTouched?: boolean,
-    shouldValidate?: boolean
-  ): void;
-  setFieldTouched(
-    field: string,
-    isTouched?: boolean,
-    shouldValidate?: boolean
-  ): void;
-  /** Validate form values */
-  validateForm(values?: any): void;
-  /** Reset form */
-  resetForm(nextValues?: any): void;
-  /** Submit the form imperatively */
-  submitForm(): void;
-  /** Set Formik state, careful! */
-  setFormikState<K extends keyof FormikState<Values>>(
-    f: (
-      prevState: Readonly<FormikState<Values>>,
-      props: any
-    ) => Pick<FormikState<Values>, K>,
-    callback?: () => any
-  ): void;
-}
-
-/** Overloded methods / types */
-export interface FormikActions<Values> {
-  /** Set value of form field directly */
-  setFieldValue(field: string, value: any): void;
-  /** Set error message of a form field directly */
-  setFieldError(field: string, message: string): void;
-  /** Set whether field has been touched directly */
-  setFieldTouched(field: string, isTouched?: boolean): void;
-  /** Set Formik state, careful! */
-  setFormikState<K extends keyof FormikState<Values>>(
-    state: Pick<FormikState<Values>, K>,
-    callback?: () => any
-  ): void;
-}
-
-/**
- * Formik form event handlers
- */
-export interface FormikHandlers {
-  /** Form submit handler */
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-  /** Classic React change handler, keyed by input name */
-  handleChange: (e: React.ChangeEvent<any>) => void;
-  /** Mark input as touched */
-  handleBlur: (e: any) => void;
-  /** Reset form event handler  */
-  handleReset: () => void;
-}
-
-/**
- * Base formik configuration/props shared between the HoC and Component.
- */
-export interface FormikSharedConfig {
-  /** Tells Formik to validate the form on each input's onChange event */
-  validateOnChange?: boolean;
-  /** Tells Formik to validate the form on each input's onBlur event */
-  validateOnBlur?: boolean;
-  /** Tell Formik if initial form values are valid or not on first render */
-  isInitialValid?: boolean | ((props: object) => boolean | undefined);
-  /** Should Formik reset the form when new initialValues change */
-  enableReinitialize?: boolean;
-}
-
-/**
- * <Formik /> props
- */
-export interface FormikConfig<Values> extends FormikSharedConfig {
-  /**
-   * Initial values of the form
-   */
-  initialValues: Values;
-
-  /**
-   * Reset handler
-   */
-  onReset?: (values: Values, formikActions: FormikActions<Values>) => void;
-
-  /**
-   * Submission handler
-   */
-  onSubmit: (values: Values, formikActions: FormikActions<Values>) => void;
-
-  /**
-   * Form component to render
-   */
-  component?: React.ComponentType<FormikProps<Values>> | React.ReactNode;
-
-  /**
-   * Render prop (works like React router's <Route render={props =>} />)
-   */
-  render?: ((props: FormikProps<Values>) => React.ReactNode);
-
-  /**
-   * A Yup Schema or a function that returns a Yup schema
-   */
-  validationSchema?: any | (() => any);
-
-  /**
-   * Validation function. Must return an error object or promise that
-   * throws an error object where that object keys map to corresponding value.
-   */
-  validate?: ((
-    values: Values
-  ) => void | object | Promise<FormikErrors<Values>>);
-
-  /**
-   * React children or child render callback
-   */
-  children?:
-    | ((props: FormikProps<Values>) => React.ReactNode)
-    | React.ReactNode;
-}
-
-/**
- * State, handlers, and helpers made available to form component or render prop
- * of <Formik/>.
- */
-export type FormikProps<Values> = FormikState<Values> &
-  FormikActions<Values> &
-  FormikHandlers &
-  FormikComputedProps<Values>;
+import {
+  FormikConfig,
+  FormikState,
+  FormikValues,
+  FormikTouched,
+  FormikErrors,
+  FormikActions,
+} from './types';
 
 export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   FormikConfig<Values> & ExtraProps,
@@ -251,32 +32,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     enableReinitialize: false,
   };
 
-  static propTypes = {
-    validateOnChange: PropTypes.bool,
-    validateOnBlur: PropTypes.bool,
-    isInitialValid: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-    initialValues: PropTypes.object,
-    onReset: PropTypes.func,
-    onSubmit: PropTypes.func.isRequired,
-    validationSchema: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    validate: PropTypes.func,
-    component: PropTypes.func,
-    render: PropTypes.func,
-    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-    enableReinitialize: PropTypes.bool,
-  };
-
-  static childContextTypes = {
-    formik: PropTypes.object,
-  };
-
   initialValues: Values;
-
-  getChildContext() {
-    return {
-      formik: this.getFormikBag(),
-    };
-  }
 
   constructor(props: FormikConfig<Values> & ExtraProps) {
     super(props);
@@ -653,15 +409,21 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   render() {
     const { component, render, children } = this.props;
     const props = this.getFormikBag();
-    return component
-      ? React.createElement(component as any, props)
-      : render
-        ? (render as any)(props)
-        : children // children come last, always called
-          ? typeof children === 'function'
-            ? (children as any)(props)
-            : !isEmptyChildren(children) ? React.Children.only(children) : null
-          : null;
+    return (
+      <FormikContext.Provider value={props}>
+        {component
+          ? React.createElement(component as any, props)
+          : render
+            ? (render as any)(props)
+            : children // children come last, always called
+              ? typeof children === 'function'
+                ? (children as any)(props)
+                : !isEmptyChildren(children)
+                  ? React.Children.only(children)
+                  : null
+              : null}
+      </FormikContext.Provider>
+    );
   }
 }
 
@@ -715,9 +477,3 @@ export function validateYupSchema<T>(
   }
   return schema.validate(validateData, { abortEarly: false, context: context });
 }
-
-export * from './Field';
-export * from './Form';
-export * from './withFormik';
-export * from './FieldArray';
-export * from './utils';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,7 @@
+export * from './Formik';
+export * from './connect';
+export * from './Field';
+export * from './Form';
+export * from './withFormik';
+export * from './FieldArray';
+export * from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,210 @@
 import * as React from 'react';
 
+/**
+ * Values of fields in the form
+ */
+export interface FormikValues {
+  [field: string]: any;
+}
+
+/**
+ * An object containing error messages whose keys correspond to FormikValues.
+ * Should be always be and object of strings, but any is allowed to support i18n libraries.
+ *
+ * @todo Remove any in TypeScript 2.8
+ */
+export type FormikErrors<Values> = { [field in keyof Values]?: any };
+
+/**
+ * An object containing touched state of the form whose keys correspond to FormikValues.
+ *
+ * @todo Remove any in TypeScript 2.8
+ */
+export type FormikTouched<Values> = {
+  [field in keyof Values]?: boolean & FormikTouched<Values[field]>
+};
+
+/**
+ * Formik state tree
+ */
+export interface FormikState<Values> {
+  /** Form values */
+  values: Values;
+  /**
+   * Top level error, in case you need it
+   * @deprecated since 0.8.0
+   */
+  error?: any;
+  /** map of field names to specific error for that field */
+  errors: FormikErrors<Values>;
+  /** map of field names to whether the field has been touched */
+  touched: FormikTouched<Values>;
+  /** whether the form is currently submitting */
+  isSubmitting: boolean;
+  /** Top level status state, in case you need it */
+  status?: any;
+}
+
+/**
+ * Formik computed properties. These are read-only.
+ */
+export interface FormikComputedProps<Values> {
+  /** True if any input has been touched. False otherwise. */
+  readonly dirty: boolean;
+  /** Result of isInitiallyValid on mount, then whether true values pass validation. */
+  readonly isValid: boolean;
+  /** initialValues */
+  readonly initialValues: Values;
+}
+
+/**
+ * Formik state helpers
+ */
+export interface FormikActions<Values> {
+  /** Manually set top level status. */
+  setStatus(status?: any): void;
+  /**
+   * Manually set top level error
+   * @deprecated since 0.8.0
+   */
+  setError(e: any): void;
+  /** Manually set errors object */
+  setErrors(errors: FormikErrors<Values>): void;
+  /** Manually set isSubmitting */
+  setSubmitting(isSubmitting: boolean): void;
+  /** Manually set touched object */
+  setTouched(touched: FormikTouched<Values>): void;
+  /** Manually set values object  */
+  setValues(values: Values): void;
+  /** Set value of form field directly */
+  setFieldValue(
+    field: keyof Values,
+    value: any,
+    shouldValidate?: boolean
+  ): void;
+  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
+  /** Set error message of a form field directly */
+  setFieldError(field: keyof Values, message?: string): void;
+  setFieldError(field: string, message?: string): void;
+  /** Set whether field has been touched directly */
+  setFieldTouched(
+    field: keyof Values,
+    isTouched?: boolean,
+    shouldValidate?: boolean
+  ): void;
+  setFieldTouched(
+    field: string,
+    isTouched?: boolean,
+    shouldValidate?: boolean
+  ): void;
+  /** Validate form values */
+  validateForm(values?: any): void;
+  /** Reset form */
+  resetForm(nextValues?: any): void;
+  /** Submit the form imperatively */
+  submitForm(): void;
+  /** Set Formik state, careful! */
+  setFormikState<K extends keyof FormikState<Values>>(
+    f: (
+      prevState: Readonly<FormikState<Values>>,
+      props: any
+    ) => Pick<FormikState<Values>, K>,
+    callback?: () => any
+  ): void;
+  setFormikState<K extends keyof FormikState<Values>>(
+    state: Pick<FormikState<Values>, K>,
+    callback?: () => any
+  ): void;
+}
+
+/**
+ * Formik form event handlers
+ */
+export interface FormikHandlers {
+  /** Form submit handler */
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  /** Classic React change handler, keyed by input name */
+  handleChange: (e: React.ChangeEvent<any>) => void;
+  /** Mark input as touched */
+  handleBlur: (e: any) => void;
+  /** Reset form event handler  */
+  handleReset: () => void;
+}
+
+/**
+ * Base formik configuration/props shared between the HoC and Component.
+ */
+export interface FormikSharedConfig {
+  /** Tells Formik to validate the form on each input's onChange event */
+  validateOnChange?: boolean;
+  /** Tells Formik to validate the form on each input's onBlur event */
+  validateOnBlur?: boolean;
+  /** Tell Formik if initial form values are valid or not on first render */
+  isInitialValid?: boolean | ((props: object) => boolean | undefined);
+  /** Should Formik reset the form when new initialValues change */
+  enableReinitialize?: boolean;
+}
+
+/**
+ * <Formik /> props
+ */
+export interface FormikConfig<Values> extends FormikSharedConfig {
+  /**
+   * Initial values of the form
+   */
+  initialValues: Values;
+
+  /**
+   * Reset handler
+   */
+  onReset?: (values: Values, formikActions: FormikActions<Values>) => void;
+
+  /**
+   * Submission handler
+   */
+  onSubmit: (values: Values, formikActions: FormikActions<Values>) => void;
+
+  /**
+   * Form component to render
+   */
+  component?: React.ComponentType<FormikProps<Values>> | React.ReactNode;
+
+  /**
+   * Render prop (works like React router's <Route render={props =>} />)
+   */
+  render?: ((props: FormikProps<Values>) => React.ReactNode);
+
+  /**
+   * A Yup Schema or a function that returns a Yup schema
+   */
+  validationSchema?: any | (() => any);
+
+  /**
+   * Validation function. Must return an error object or promise that
+   * throws an error object where that object keys map to corresponding value.
+   */
+  validate?: ((
+    values: Values
+  ) => void | object | Promise<FormikErrors<Values>>);
+
+  /**
+   * React children or child render callback
+   */
+  children?:
+    | ((props: FormikProps<Values>) => React.ReactNode)
+    | React.ReactNode;
+}
+
+/**
+ * State, handlers, and helpers made available to form component or render prop
+ * of <Formik/>.
+ */
+export type FormikProps<Values> = FormikState<Values> &
+  FormikActions<Values> &
+  FormikHandlers &
+  FormikComputedProps<Values> &
+  Pick<FormikSharedConfig, 'validateOnChange' | 'validateOnBlur'>;
+
 export type CompositeComponent<P> =
   | React.ComponentClass<P>
   | React.StatelessComponent<P>;

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import { Formik } from './Formik';
+import { hoistNonReactStatics } from './hoistStatics';
+import { isFunction } from './utils';
+import { ComponentDecorator } from './types';
 
 import {
-  Formik,
   FormikActions,
   FormikComputedProps,
   FormikHandlers,
@@ -9,10 +12,8 @@ import {
   FormikSharedConfig,
   FormikState,
   FormikValues,
-} from './formik';
-
-import { hoistNonReactStatics } from './hoistStatics';
-import { isFunction } from './utils';
+  CompositeComponent,
+} from './types';
 
 /**
  * State, handlers, and helpers injected as props into the wrapped form component.
@@ -67,18 +68,6 @@ export interface WithFormikConfig<
    * throws an error object where that object keys map to corresponding value.
    */
   validate?: (values: Values, props: Props) => void | object | Promise<any>;
-}
-
-export type CompositeComponent<P> =
-  | React.ComponentClass<P>
-  | React.StatelessComponent<P>;
-
-export interface ComponentDecorator<TOwnProps, TMergedProps> {
-  (component: CompositeComponent<TMergedProps>): React.ComponentType<TOwnProps>;
-}
-
-export interface InferableComponentDecorator<TOwnProps> {
-  <T extends CompositeComponent<TOwnProps>>(component: T): T;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,6 @@
   version "8.0.57"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.57.tgz#e5d8b4dc112763e35cfc51988f4f38da3c486d99"
 
-"@types/prop-types@15.5.1":
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.1.tgz#1ecf52621299e65b855374337fb11fd2d1066fc1"
-
 "@types/react-dom@^16.0.3":
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.3.tgz#8accad7eabdab4cca3e1a56f5ccb57de2da0ff64"
@@ -791,6 +787,10 @@ cpx@^1.5.0:
     safe-buffer "^5.0.1"
     shell-quote "^1.6.1"
     subarg "^1.0.0"
+
+create-react-context@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
 
 cross-env@5.0.5:
   version "5.0.5"


### PR DESCRIPTION
This PR attempts to removes the direct use of prop-types and instead uses create-react-context. 

Writing typed render prop components that take a generic is super awkward now. Ugh. 

To make tests pass, we will need to either use enzyme mount / or figure out something else

