### PR TITLE
Fix #284 and #258 - Empty input type=number results in NaN

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -420,8 +420,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     e.persist();
     const { type, name, id, value, checked, outerHTML } = e.target;
     const field = name ? name : id;
+    let parsed;
     const val = /number|range/.test(type)
-      ? parseFloat(value)
+      ? ((parsed = parseFloat(value)), Number.isNaN(parsed) ? '' : parsed)
       : /checkbox/.test(type) ? checked : value;
 
     if (!field && process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
Fixes issues #284 and #258, when emptying input with type="number" causes error "Received NaN for the `value` attribute. If this is expected, cast the value to a string."