### PR TITLE
fixed #420 changed onReset to provide formikBag instead of formikActions

### DIFF
--- a/src/formik.tsx
+++ b/src/formik.tsx
@@ -193,7 +193,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Reset handler
    */
-  onReset?: (values: Values, formikActions: FormikActions<Values>) => void;
+  onReset?: (values: Values, formikActions: FormikProps<Values>) => void;
 
   /**
    * Submission handler
@@ -589,7 +589,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     if (this.props.onReset) {
       const maybePromisedOnReset = (this.props.onReset as any)(
         this.state.values,
-        this.getFormikActions()
+        this.getFormikBag()
       );
 
       if (isPromise(maybePromisedOnReset)) {


### PR DESCRIPTION
This PR should fix the inconsistency between the docs and implementation for onReset function. With this change the onReset function will supply complete formikBag(formikProps) instead of just formikActions.

Please let me know if you think this will break anything else. Tests ran fine after this change.