### PR TITLE
Fix <Field type=checkbox /> initial value

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -37,7 +37,7 @@ export interface FieldProps<V = any> {
     /** Mark input as touched */
     onBlur: (e: any) => void;
     /** Value of the input */
-    value: any;
+    [x: string]: any; // 'value' or 'checked' field
     /* name of the input */
     name: string;
   };
@@ -167,10 +167,9 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
 
     const { formik } = this.context;
     const field = {
-      value:
-        props.type === 'radio' || props.type === 'checkbox'
-          ? props.value // React uses checked={} for these inputs
-          : getIn(formik.values, name),
+      [props.type === 'radio' || props.type === 'checkbox'
+        ? 'checked'
+        : 'value']: getIn(formik.values, name),
       name,
       onChange: validate ? this.handleChange : formik.handleChange,
       onBlur: validate ? this.handleBlur : formik.handleBlur,


### PR DESCRIPTION
When you set initial value in `mapPropsToValues` for checkbox and use Formik's Field component – it doesn't set `checked` property