### PR TITLE
Set state of value and error after validateYupSchema sync

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -177,6 +177,10 @@ export class FastField<
         // try to validate with yup synchronously if possible...saves a render.
         try {
           validateYupSchema(mergedValues, schema, true);
+          this.setState({
+            value: val,
+            error: undefined,
+          });
         } catch (e) {
           if (e.name === 'ValidationError') {
             this.setState({

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -494,12 +494,6 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     if (e && e.preventDefault) {
       e.preventDefault();
     }
-    if (
-      document.activeElement &&
-      document.activeElement instanceof HTMLElement
-    ) {
-      document.activeElement.blur();
-    }
     this.submitForm();
   };
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -494,6 +494,12 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     if (e && e.preventDefault) {
       e.preventDefault();
     }
+    if (
+      document.activeElement &&
+      document.activeElement instanceof HTMLElement
+    ) {
+      document.activeElement.blur();
+    }
     this.submitForm();
   };
 


### PR DESCRIPTION
Fixes #455. Sets the state of value to val and error to undefined after the synchronous version of validateYupSchema is called and passes.
