### PR TITLE
Blur active element before submitting form

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -494,7 +494,16 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     if (e && e.preventDefault) {
       e.preventDefault();
     }
-    this.submitForm();
+    if (
+      document.activeElement &&
+      document.activeElement instanceof HTMLElement
+    ) {
+      document.activeElement.blur();
+    }
+    // Queues this.submitForm so that it's called after the active element's blur event's code
+    setTimeout(() => {
+      this.submitForm();
+    }, 0);
   };
 
   submitForm = () => {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -494,19 +494,18 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     if (e && e.preventDefault) {
       e.preventDefault();
     }
+    this.submitForm();
+  };
+
+  submitForm = () => {
+    //Blur active element first
     if (
       document.activeElement &&
       document.activeElement instanceof HTMLElement
     ) {
       document.activeElement.blur();
     }
-    // Queues this.submitForm so that it's called after the active element's blur event's code
-    setTimeout(() => {
-      this.submitForm();
-    }, 0);
-  };
 
-  submitForm = () => {
     // Recursively set all values to `true`.
     this.setState({
       touched: setNestedObjectValues<FormikTouched<Values>>(


### PR DESCRIPTION
Blurs the active element so it's blur event can be ran then submits the form.

Currently, if a user types in a `<FastField/>` then submits a form without blurring the field, the updated value doesn't get passed into `formik`'s state. So the submitted values don't include whatever the user recently typed. Validation for the field also fails to update since it receives the old value.