### PR TITLE
Pass in next initialValues into FastField's reset function

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -43,11 +43,12 @@ export class FastField<
       error: getIn(context.formik.errors, props.name),
     };
 
-    this.reset = () =>
+    this.reset = (nextValues?: any) => {
       this.setState({
-        value: getIn(context.formik.values, props.name),
+        value: getIn(nextValues, props.name),
         error: getIn(context.formik.errors, props.name),
       });
+    };
 
     context.formik.registerField(props.name, this.reset);
   }

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -269,7 +269,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   hbCache: {
     [key: string]: (e: any) => void;
   } = {};
-  fields: { [field: string]: () => void };
+  fields: { [field: string]: (nextValues?: any) => void };
 
   getChildContext() {
     return {
@@ -293,7 +293,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     this.initialValues = props.initialValues || ({} as any);
   }
 
-  registerField = (name: string, resetFn: () => void) => {
+  registerField = (name: string, resetFn: (nextValues?: any) => void) => {
     this.fields[name] = resetFn;
   };
 
@@ -616,8 +616,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       status: undefined,
       values,
     });
-
-    Object.keys(this.fields).map(f => this.fields[f]());
+    Object.keys(this.fields).map(f => this.fields[f](values));
   };
 
   handleReset = () => {


### PR DESCRIPTION
Fixes #461 

**GIF showing fix results:**
![formik_fastfield_fix](https://user-images.githubusercontent.com/12619633/36657781-870df2ae-1a93-11e8-9ae7-666244081dd0.gif)

I don't have much experience with typescript so there may be bad practices. I'm also not too sure on what to do with the context.formik.errors.
