### PR TITLE
Add handler for submit with invalid form data

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -429,6 +429,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       if (isValid) {
         this.executeSubmit();
       } else {
+        this.executeSubmitWithInvalidData(combinedErrors);
         this.setState({ isSubmitting: false });
       }
     });
@@ -436,6 +437,16 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
 
   executeSubmit = () => {
     this.props.onSubmit(this.state.values, this.getFormikActions());
+  };
+
+  executeSubmitWithInvalidData = (errors: FormikErrors<Values>) => {
+    if (typeof this.props.onSubmitWithInvalidData === 'function') {
+      this.props.onSubmitWithInvalidData(
+        this.state.values,
+        this.getFormikActions(),
+        errors
+      );
+    }
   };
 
   handleBlur = (eventOrString: any): void | ((e: any) => void) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -184,6 +184,15 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   onSubmit: (values: Values, formikActions: FormikActions<Values>) => void;
 
   /**
+   * Submission handler when the form data is invalid
+   */
+  onSubmitWithInvalidData?: (
+    values: Values,
+    formikActions: FormikActions<Values>,
+    errors: FormikErrors<Values>
+  ) => void;
+
+  /**
    * Form component to render
    */
   component?: React.ComponentType<FormikProps<Values>> | React.ReactNode;

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -9,6 +9,7 @@ import {
   FormikSharedConfig,
   FormikState,
   FormikValues,
+  FormikErrors,
 } from './types';
 import { isFunction } from './utils';
 
@@ -44,6 +45,15 @@ export interface WithFormikConfig<
    * Submission handler
    */
   handleSubmit: (values: Values, formikBag: FormikBag<Props, Values>) => void;
+
+  /**
+   * Submission handler when the form data is invalid
+   */
+  handleSubmitWithInvalidData?: (
+    values: Values,
+    formikBag: FormikBag<Props, Values>,
+    errors: FormikErrors<Values>
+  ) => void;
 
   /**
    * Map props to the form values
@@ -136,6 +146,21 @@ export function withFormik<
         });
       };
 
+      handleSubmitWithInvalidData = (
+        values: Values,
+        actions: FormikActions<Values>,
+        errors: FormikErrors<Values>
+      ) => {
+        return config.handleSubmitWithInvalidData!(
+          values,
+          {
+            ...actions,
+            props: this.props,
+          },
+          errors
+        );
+      };
+
       /**
        * Just avoiding a render callback for perf here
        */
@@ -152,6 +177,10 @@ export function withFormik<
             validationSchema={config.validationSchema && this.validationSchema}
             initialValues={mapPropsToValues(this.props)}
             onSubmit={this.handleSubmit as any}
+            onSubmitWithInvalidData={
+              config.handleSubmitWithInvalidData &&
+              this.handleSubmitWithInvalidData
+            }
             render={this.renderFormComponent}
           />
         );


### PR DESCRIPTION
This PR introduces a new config option which allows you to handle the case where a user tries to submit a form with invalid data.

Our use case is tracking what errors our users make so we can improve our forms, but I'm sure there are other interesting use cases for this feature.

I'm curious about your opinion one something. I'm not sure which function signature I prefer:

*Option A*
```typescript
onSubmitWithInvalidData?: (
  values: Values,
  formikActions: FormikActions<Values>,
  errors: FormikErrors<Values>
) => void;
```

or

*Option B*
```typescript
onSubmitWithInvalidData?: (
  errors: FormikErrors<Values>,
  values: Values,
  formikActions: FormikActions<Values>
) => void;
```

I went with option A for now, as it is consistent with `onSubmit`. But the most interesting thing in this callback are probably the errors. What do you think?