### PR TITLE
Fix FormikTouched type

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -32,9 +32,7 @@ export type FormikErrors<Values> = { [field in keyof Values]?: any };
  *
  * @todo Remove any in TypeScript 2.8
  */
-export type FormikTouched<Values> = {
-  [field in keyof Values]?: boolean & FormikTouched<Values[field]>
-};
+export type FormikTouched<Values> = { [field in keyof Values]?: boolean };
 
 /**
  * Formik state tree


### PR DESCRIPTION
Fixes #439 

`FormikTouched` should only accept boolean values.

I don't think the `& FormikTouched<Values[field]>` is necessary. Another solution would be to set FormikTouched as:
```ts
export declare type FormikTouched<Values> = {
    [field in keyof Values]?: boolean | FormikTouched<Values[field]>;
};
```

Let me know what you think.