### PR TITLE
Pass though props to wrapped component

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -170,6 +170,8 @@ export interface FormikSharedConfig {
   isInitialValid?: boolean | ((props: object) => boolean | undefined);
   /** Should Formik reset the form when new initialValues change */
   enableReinitialize?: boolean;
+
+  otherProps?: object;
 }
 
 /**
@@ -240,6 +242,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     validateOnBlur: true,
     isInitialValid: false,
     enableReinitialize: false,
+    otherProps: {},
   };
 
   static propTypes = {
@@ -255,6 +258,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     render: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     enableReinitialize: PropTypes.bool,
+    otherProps: PropTypes.object,
   };
 
   static childContextTypes = {
@@ -687,6 +691,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       handleSubmit: this.handleSubmit,
       validateOnChange: this.props.validateOnChange,
       validateOnBlur: this.props.validateOnBlur,
+      otherProps: this.props.otherProps,
     };
   };
 

--- a/test/formik.test.tsx
+++ b/test/formik.test.tsx
@@ -37,7 +37,12 @@ const Form: React.SFC<FormikProps<Values>> = ({
 };
 
 const BasicForm = (
-  <Formik initialValues={{ name: 'jared' }} onSubmit={noop} component={Form} />
+  <Formik
+    otherProps={{ test: 'test' }}
+    initialValues={{ name: 'jared' }}
+    onSubmit={noop}
+    component={Form}
+  />
 );
 
 class WithState extends React.Component<{}, { data: { name: string } }> {
@@ -68,6 +73,7 @@ describe('<Formik>', () => {
     expect(tree.find(Form).props().errors).toEqual({});
     expect(tree.find(Form).props().dirty).toBe(false);
     expect(tree.find(Form).props().isValid).toBe(false);
+    expect(tree.find(Form).props().otherProps).toEqual({ test: 'test' });
   });
 
   describe('FormikHandlers', () => {


### PR DESCRIPTION
I have run into a problem on my current project while using Formik where we want to pass props to the component Formik is wrapping, while keeping the component pure for easy testing. Currently our solution has been to do the following.

```
const renderComp = otherProps => formikProps => (<div> ...</div>)

<Formik render(renderComp({test: 'test'})) />

```

This is something we do often on the project, but is not as clean as Formik doing this itself. I have added `otherProps` to the Formik bag. It is possible to pass the props though normally, although I am no sure how intuitive that is.