### PR TITLE
Fix example for Field#validate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,9 +1267,9 @@ You can run independent field-level validations by passing a function to the
 
 ```js
 // Synchronous validation for Field
-const validate = values => {
+const validate = value => {
   let errorMessage;
-  if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {
+  if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)) {
     errorMessage = 'Invalid email address';
   }
   return errorMessage;


### PR DESCRIPTION
The example for Field#validate in the README.md has a little error, as it doesn't reflect the API that it demos.  

This MR fixes that.