### PR TITLE
Provide error and touched to component wrapped by Field

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -167,6 +167,8 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
           ? props.value // React uses checked={} for these inputs
           : getIn(formik.values, name),
       name,
+      error: getIn(formik.errors, name),
+      touched: getIn(formik.touched, name),
       onChange: validate ? this.handleChange : formik.handleChange,
       onBlur: validate ? this.handleBlur : formik.handleBlur,
     };

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -213,6 +213,10 @@ describe('A <Field />', () => {
                 const { handleBlur, handleChange } = formikProps;
                 expect(field.name).toBe('name');
                 expect(field.value).toBe('jared');
+                expect(field.hasOwnProperty('error')).toBe(true);
+                expect(field.hasOwnProperty('touched')).toBe(true);
+                expect(field.error).toBe(undefined);
+                expect(field.touched).toBe(undefined);
                 expect(field.onChange).toBe(handleChange);
                 expect(field.onBlur).toBe(handleBlur);
                 expect(form).toEqual(formikProps);


### PR DESCRIPTION
Sorry for the unsolicited PR!

I often find myself using the render prop in `Field` like this:

```
<Field
  name="fieldName"
  render={({field, form}) => (
    <CustomInputProp
      {...field}
      error={getIn(form.errors, field.name)}
      touched={getIn(form.touched, field.name)}
      label="Field Label"
      customProp={123}
    />
  )}
/>
```

I have to type out the `error` and `touched` props each time, which gets a bit repetitive. This is something that could be easily computed by formik's `Field` component and passed down to the render prop function the same way that `value` is passed down.

Is there a reason this isn't already done? Please let me know if I'm missing something or if there's any thing to change in the PR. This only took a few minutes to throw together, so feel free to close this if the PR is way off base :)