### PR TITLE
Allow function to handle reinitialization in Formik mode

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -184,6 +184,14 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   initialValues: Values;
 
   /**
+   * Reinitialize handler
+   */
+  onReinitialize?: (
+    values: Values,
+    formikActions: FormikActions<Values>
+  ) => void;
+
+  /**
    * Reset handler
    */
   onReset?: (values: Values, formikActions: FormikActions<Values>) => void;
@@ -257,6 +265,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     render: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     enableReinitialize: PropTypes.bool,
+    onReinitialize: PropTypes.func,
   };
 
   static childContextTypes = {
@@ -313,7 +322,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       !isEqual(nextProps.initialValues, this.props.initialValues)
     ) {
       this.initialValues = nextProps.initialValues;
-      this.resetForm(nextProps.initialValues);
+      this.props.onReinitialize
+        ? this.props.onReinitialize(this.state.values, this.getFormikActions())
+        : this.resetForm(nextProps.initialValues);
     }
   }
 


### PR DESCRIPTION
tl;dr

Right now the args passed to the render prop include the imperative functions to interact with Formik's internal state (such as `setFieldValue`). These are not useful there since they will cause side effects directly in the render. However, there is a use case to use them, and it would be nice to do so without HoC.

Explanation

I greatly appreciate this library and especially embracing "new" things like render props. I was attempting to convert some old code to render props and found an issue that I was unable to get around without some changes.

The gist is that I have a form with 2 fields, both with blank values as the form initializes. The first field is used to infer a value for the second, but not directly. The first field's value change will cause an async operation to figure out a likely value for the second field to help the user fill out the form. So my `<Form>` component that is using `<Formik>` with a children as function render prop will get the information it needs via props from `redux` to decide a value for the second field.

This is where I ran into problems because none of the imperative (e.g. `setFieldValue`) can be used within the `render`. I needed a way to tell `Formik` that I have some useful information now and I need to use its current information, along with my information, to interact with it imperatively.

Anyway, the only tool available in the current API (that I see) is `enableReinitialize` and it is a pretty blunt instrument that resets everything. I wanted a targeted `setFieldValue`.

This PR adds a new prop to `<Formik>` (its not really useful for HoC) of `onReinitialize`. It is a function that is called **instead** of reset when Formik detects `initialValues` has changed. If necessary you can abuse `initialValues` with references that change not directly related to form state to let Formik know it needs to run `onReinitialize`.

It's not the most cohesive thing, I am open to other suggestions for this use case.

If this is an accepted option into the library I can write doc and tests.