### PR TITLE
onChange prop

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -693,8 +693,16 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       handleBlur: this.handleBlur,
       handleChange: !this.props.onChange
         ? this.handleChange
-        : (e: React.ChangeEvent<any>) => {
-            this.props.onChange!(e, this.getFormikActions());
+        : (eventOrString: any) => {
+            const result = this.handleChange(eventOrString);
+            if (typeof result === 'function') {
+              return (e: React.ChangeEvent<any>) => {
+                result(e);
+                this.props.onChange!(e, this.getFormikActions());
+              };
+            }
+            this.props.onChange!(eventOrString, this.getFormikActions());
+            return;
           },
       handleReset: this.handleReset,
       handleSubmit: this.handleSubmit,

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -182,6 +182,14 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   initialValues: Values;
 
   /**
+   * Change handler
+   */
+  onChange?: (
+    e: React.ChangeEvent<any>,
+    formikActions: FormikActions<Values>
+  ) => void;
+
+  /**
    * Reset handler
    */
   onReset?: (values: Values, formikActions: FormikActions<Values>) => void;
@@ -247,6 +255,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     validateOnBlur: PropTypes.bool,
     isInitialValid: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     initialValues: PropTypes.object,
+    onChange: PropTypes.func,
     onReset: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     validationSchema: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -682,7 +691,11 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       registerField: this.registerField,
       unregisterField: this.unregisterField,
       handleBlur: this.handleBlur,
-      handleChange: this.handleChange,
+      handleChange: !this.props.onChange
+        ? this.handleChange
+        : (e: React.ChangeEvent<any>) => {
+            this.props.onChange!(e, this.getFormikActions());
+          },
       handleReset: this.handleReset,
       handleSubmit: this.handleSubmit,
       validateOnChange: this.props.validateOnChange,


### PR DESCRIPTION
This adds an `onChange` prop to the `Formik` component that, when defined, replaces the `handleChange` function returned from `getFormikBag`. This means this new `handleChange` will be available on both the render props and any child components obtaining the formik bag from its context.

My use-case for this is I have a series of forms across several "steps" where Formik's validations are run when I hit the *next* button on each step. The values for all these forms are being sent to Redux where a persisting middleware is saving everything to the `sessionStorage`. I was previously persisting to Redux during my submit handler (next button), but I need to persist on every change even *before* hitting *next* for a better user experience. I do not mind persisting invalid data since I can't advance to the next step until everything is valid and I don't want to lose any values when reloading or hitting *back* (which doesn't do validation).

Anyways, this is especially useful to me since I have a custom `Field` component that is grabbing `handleChange` from the context and I want it to be consistent with the one provided via render props.

This is how I am using it:

```js
render() {
  return (
    <Formik
      initialValues={form}
      onChange={(event, { setFieldValue }) => {
        const { name, value } = event.target
        setFieldValue(name, value)
        this.props.update({ [name]: value }) // redux
      }}
      onSubmit={this.handleSubmit}
      render={({
        handleChange, // from above
        handleSubmit
      }) => ...}
    />
  )
}
```

