### PR TITLE
Feature: Upgrade typescript v2.8 + FormikTouched upgrade to be recursive

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rollup-plugin-sourcemaps": "0.4.2",
     "rollup-plugin-uglify": "^3.0.0",
     "ts-jest": "^21.2.4",
-    "tsc-watch": "1.0.7",
+    "tsc-watch": "1.0.17",
     "tslint": "5.5.0",
     "tslint-react": "3.2.0",
     "typescript": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "tsc-watch": "1.0.7",
     "tslint": "5.5.0",
     "tslint-react": "3.2.0",
-    "typescript": "^2.7.1",
+    "typescript": "2.8.1",
     "yup": "0.21.3"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
     "lint-staged": "4.0.2",
-    "prettier": "^1.8.2",
+    "prettier": "1.11.1",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "rimraf": "^2.6.2",

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -28,14 +28,11 @@ export type FormikErrors<Values> = { [field in keyof Values]?: any };
 
 /**
  * An object containing touched state of the form whose keys correspond to FormikValues.
- *
- * @todo Remove any in TypeScript 2.8
  */
-export type FormikTouched<T> = T extends object
-  ? FormikTouchedObject<T>
-  : boolean;
-export type FormikTouchedObject<T extends object> = {
-  [K in keyof T]?: FormikTouched<T[K]>
+export type FormikTouched<Values> = {
+  [K in keyof Values]?: Values[K] extends object
+    ? FormikTouched<Values[K]>
+    : boolean
 };
 
 /**

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -21,10 +21,10 @@ export interface FormikValues {
 /**
  * An object containing error messages whose keys correspond to FormikValues.
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
- *
- * @todo Remove any in TypeScript 2.8
  */
-export type FormikErrors<Values> = { [field in keyof Values]?: any };
+export type FormikErrors<Values> = {
+  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : {}
+};
 
 /**
  * An object containing touched state of the form whose keys correspond to FormikValues.

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -31,8 +31,11 @@ export type FormikErrors<Values> = { [field in keyof Values]?: any };
  *
  * @todo Remove any in TypeScript 2.8
  */
-export type FormikTouched<Values> = {
-  [field in keyof Values]?: boolean & FormikTouched<Values[field]>
+export type FormikTouched<T> = T extends object
+  ? FormikTouchedObject<T>
+  : boolean;
+export type FormikTouchedObject<T extends object> = {
+  [K in keyof T]?: FormikTouched<T[K]>
 };
 
 /**

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -261,7 +261,11 @@ describe('<Formik>', () => {
         const FormNoEvent = (
           <Formik initialValues={{ name: 'jared' }} onSubmit={noop}>
             {({ handleSubmit }) => (
-              <button onClick={() => handleSubmit(/* undefined event */)} />
+              <button
+                onClick={() =>
+                  handleSubmit(undefined as any /* undefined event */)
+                }
+              />
             )}
           </Formik>
         );
@@ -277,7 +281,7 @@ describe('<Formik>', () => {
           <Formik initialValues={{ name: 'jared' }} onSubmit={noop}>
             {({ handleSubmit }) => (
               <button
-                onClick={() => handleSubmit({} /* no preventDefault */)}
+                onClick={() => handleSubmit({} as any /* no preventDefault */)}
               />
             )}
           </Formik>

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -9,6 +9,7 @@ interface Values {
 
 const Form: React.SFC<FormikProps<Values>> = ({
   values,
+  touched,
   handleSubmit,
   handleChange,
   handleBlur,
@@ -25,7 +26,7 @@ const Form: React.SFC<FormikProps<Values>> = ({
         value={values.name}
         name="name"
       />
-      {errors.name && <div id="feedback">{errors.name}</div>}
+      {touched.name && errors.name && <div id="feedback">{errors.name}</div>}
       {isSubmitting && <div id="submitting">Submitting</div>}
       {status &&
         !!status.myStatusMessage && (

--- a/test/types.test.tsx
+++ b/test/types.test.tsx
@@ -1,4 +1,4 @@
-import { FormikTouched } from '../src';
+import { FormikTouched, FormikErrors } from '../src';
 
 describe('Formik Types', () => {
   describe('FormikTouched', () => {
@@ -9,8 +9,11 @@ describe('Formik Types', () => {
       };
     };
 
-    it('it should correctly infer type of touched property from Values', async () => {
-      const touched: FormikTouched<Values> = {};
+    it('it should infer nested object structure of touched property from Values', () => {
+      const touched: FormikTouched<Values> = {
+        id: true,
+        social: { facebook: true },
+      };
       // type touched = {
       //    id?: boolean | undefined;
       //    social?: {
@@ -18,10 +21,26 @@ describe('Formik Types', () => {
       //    } | undefined;
       // }
       const id: boolean | undefined = touched.id;
-      expect(id).toBeUndefined();
-      const social: { facebook?: boolean | undefined } | undefined =
-        touched.social;
-      expect(social).toBeUndefined();
+      expect(id).toBe(true);
+      const facebook: boolean | undefined = touched.social!.facebook;
+      expect(facebook).toBe(true);
+    });
+
+    it('it should infer nested object structure of error property from Values', () => {
+      const errors: FormikErrors<Values> = {
+        id: 'error',
+        social: { facebook: 'error' },
+      };
+      // type touched = {
+      //    id?: {} | undefined;
+      //    social?: {
+      //        facebook?: {} | undefined;
+      //    } | undefined;
+      // }
+      const id: {} | undefined = errors.id;
+      expect(id).toBe('error');
+      const facebook: {} | undefined = errors.social!.facebook;
+      expect(facebook).toBe('error');
     });
   });
 });

--- a/test/types.test.tsx
+++ b/test/types.test.tsx
@@ -1,0 +1,57 @@
+import { FormikTouched } from '../src';
+
+// const Form: React.SFC<FormikProps<Values>> = ({
+//   values,
+//   touched,
+//   handleSubmit,
+//   handleChange,
+//   handleBlur,
+//   status,
+//   errors,
+//   isSubmitting,
+// }) => {
+//   return (
+//     <form onSubmit={handleSubmit}>
+//       <input
+//         type="text"
+//         onChange={handleChange}
+//         onBlur={handleBlur}
+//         value={values.name}
+//         name="name"
+//       />
+//       {touched.name && errors.name && <div id="feedback">{errors.name}</div>}
+//       {isSubmitting && <div id="submitting">Submitting</div>}
+//       {status &&
+//         !!status.myStatusMessage && (
+//           <div id="statusMessage">{status.myStatusMessage}</div>
+//         )}
+//       <button type="submit">Submit</button>
+//     </form>
+//   );
+// };
+
+describe('Formik Types', () => {
+  describe('FormikTouched', () => {
+    type Values = {
+      id: string;
+      social: {
+        facebook: string;
+      };
+    };
+
+    it('it should correctly infer type of touched property from Values', async () => {
+      const touched: FormikTouched<Values> = {};
+      // type touched = {
+      //    id?: boolean | undefined;
+      //    social?: {
+      //        facebook?: boolean | undefined;
+      //    } | undefined;
+      // }
+      const id: boolean | undefined = touched.id;
+      expect(id).toBeUndefined();
+      const social: { facebook?: boolean | undefined } | undefined =
+        touched.social;
+      expect(social).toBeUndefined();
+    });
+  });
+});

--- a/test/types.test.tsx
+++ b/test/types.test.tsx
@@ -1,35 +1,5 @@
 import { FormikTouched } from '../src';
 
-// const Form: React.SFC<FormikProps<Values>> = ({
-//   values,
-//   touched,
-//   handleSubmit,
-//   handleChange,
-//   handleBlur,
-//   status,
-//   errors,
-//   isSubmitting,
-// }) => {
-//   return (
-//     <form onSubmit={handleSubmit}>
-//       <input
-//         type="text"
-//         onChange={handleChange}
-//         onBlur={handleBlur}
-//         value={values.name}
-//         name="name"
-//       />
-//       {touched.name && errors.name && <div id="feedback">{errors.name}</div>}
-//       {isSubmitting && <div id="submitting">Submitting</div>}
-//       {status &&
-//         !!status.myStatusMessage && (
-//           <div id="statusMessage">{status.myStatusMessage}</div>
-//         )}
-//       <button type="submit">Submit</button>
-//     </form>
-//   );
-// };
-
 describe('Formik Types', () => {
   describe('FormikTouched', () => {
     type Values = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,9 +2858,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.8.2:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.1.tgz#41638a0d47c1efbd1b7d5a742aaa5548eab86d70"
+prettier@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
 pretty-format@^21.2.1:
   version "21.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,7 +1105,7 @@ esutils@^2.0.2:
 
 event-stream@~3.3.0:
   version "3.3.4"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
     duplexer "~0.1.1"
     from "~0"
@@ -3697,18 +3697,18 @@ ts-jest@^21.2.4:
     source-map-support "^0.5.0"
     yargs "^10.0.3"
 
-tsc-watch@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-1.0.7.tgz#f540d312a82d8bf42f9b037f6b077a856df18cf2"
+tsc-watch@1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-1.0.17.tgz#c33e564aba93617823b17996f2dd999cefb7a0b9"
   dependencies:
-    chalk "^1.1.3"
+    chalk "^2.3.0"
     cross-spawn "^5.1.0"
     ps-tree "^1.1.0"
     typescript "*"
 
-tslib@^1.7.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+tslib@^1.7.1, tslib@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
 tslint-react@3.2.0:
   version "3.2.0"
@@ -3732,10 +3732,10 @@ tslint@5.5.0:
     tsutils "^2.5.1"
 
 tsutils@^2.5.1, tsutils@^2.8.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.13.0.tgz#0f52b6aabbc4216e72796b66db028c6cf173e144"
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.25.0.tgz#14d616ef59224a3c9fb7eb483e1c182b6665ae5e"
   dependencies:
-    tslib "^1.7.1"
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3757,11 +3757,7 @@ type-name@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/type-name/-/type-name-2.0.2.tgz#efe7d4123d8ac52afff7f40c7e4dec5266008fb4"
 
-typescript@*:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
-
-typescript@2.8.1:
+typescript@*, typescript@2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3761,9 +3761,9 @@ typescript@*:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-typescript@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Hello @jaredpalmer 
Here comes the upgrade to TypeScript and the type improvements for touched. 
Below all the necessary changes:
- upgraded TS to v2.8.1 - necessary for conditional types (there was 2 small errors coming from upgrade I needed to fix -> 80ceaef)
- upgraded prettier - because it was showing errors related to a new conditional types syntax
- updated FormikTouched type to become recursive for nested objects
- added new test file containing type tests (I included some test example for new FormikTouched, but it should be the base to add other Generic Types tests as well to prevent regression in types)

Please tell me what you think. I'll be glad to refine some more types after this is merged.