### PR TITLE
fix issue when the object has a key that is one of the path's parts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export function setIn(obj: any, path: string, value: any): any {
 
   for (; i < pathArray.length - 1; i++) {
     const currentPath: string = pathArray[i];
-    let currentObj: any = obj[currentPath];
+    let currentObj: any = getIn(obj, pathArray.slice(0, i + 1));
 
     if (resVal[currentPath]) {
       resVal = resVal[currentPath];

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -190,6 +190,13 @@ describe('utils', () => {
       expect(obj).toEqual({ x: 'y' });
       expect(newObj).toEqual({ x: 'y', nested: ['value'] });
     });
+
+    it('supports path containing key of the object', () => {
+      const obj = { x: 'y' };
+      const newObj = setIn(obj, 'a.x.c', 'value');
+      expect(obj).toEqual({ x: 'y' });
+      expect(newObj).toEqual({ x: 'y', a: { x: { c: 'value' } } });
+    });
   });
 
   describe('isPromise', () => {


### PR DESCRIPTION
There is currently an issue with the `setIn` method that happens when the original object has a key
that is part of the provided path
```js
setIn({x: true}, 'a.x.c', false);
```
and at some point in the `setIn` function, the `currentObj` is set to the `originalObject[partOfPath]`
and if the `originalObject` has a value for that the `currentObj` will be set to that value
```js
    const currentPath: string = pathArray[i];
    let currentObj: any = obj[currentPath];
```
and then `resVal` will be set to this value
```js
    //...
    } else if (currentObj) {
      resVal = resVal[currentPath] = cloneDeep(currentObj);
    } else {
    //...
```
and after the loop wee add a property to this value, which will raise an error
```js
 resVal[pathArray[i]] = value;
```

I've added this test which will validate this issue
```js
    it('supports path containing key of the object', () => {
      const obj = { x: 'y' };
      const newObj = setIn(obj, 'a.x.c', 'value');
      expect(obj).toEqual({ x: 'y' });
      expect(newObj).toEqual({ x: 'y', a: { x: { c: 'value' } } });
    });
```
which will faill
```
TypeError: Cannot create property 'c' on string 'y'