### PR TITLE
Remove duplicated interfaces

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,5 @@
 import * as React from 'react';
 
-export type CompositeComponent<P> =
-  | React.ComponentClass<P>
-  | React.StatelessComponent<P>;
-
-export interface ComponentDecorator<TOwnProps, TMergedProps> {
-  (component: CompositeComponent<TMergedProps>): React.ComponentClass<
-    TOwnProps
-  >;
-}
-
-export interface InferableComponentDecorator<TOwnProps> {
-  <T extends CompositeComponent<TOwnProps>>(component: T): T;
-}
-
 export interface SharedRenderProps<T> {
   /**
    * Field component to render. Can either be a string like 'select' or a component.


### PR DESCRIPTION
Hello maintainers, thanks for the great library.

This PR removes some duplicated interfaces that I found while reading formik's code.

Those interfaces are added in https://github.com/jaredpalmer/formik/pull/141 and still remains, but they exist in `withFormik.ts` as well.

https://github.com/jaredpalmer/formik/blob/095e915ef18cdb557be09f01e5fa9e7ba2a6d19d/src/withFormik.tsx#L72-L82

