### PR TITLE
Add Field & FastField meta props

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -263,6 +263,7 @@ export class FastField<
     } = this.props as FieldConfig;
 
     const { formik } = this.context;
+
     const field = {
       value:
         props.type === 'radio' || props.type === 'checkbox'
@@ -272,18 +273,21 @@ export class FastField<
       onChange: this.handleChange,
       onBlur: this.handleBlur,
     };
+
+    const meta = {
+      touched: getIn(formik.touched, name),
+      error: this.state.error,
+      initialValue: getIn(formik.initialValues, name),
+    };
+
     const bag = {
       field,
       form: formik,
-      meta: { touched: getIn(formik.touched, name), error: this.state.error },
+      meta,
     };
 
     if (render) {
-      return (render as (
-        props: FieldProps<any> & {
-          meta: { error?: string; touched?: boolean };
-        }
-      ) => React.ReactNode)(bag);
+      return (render as (props: FieldProps<any>) => React.ReactNode)(bag);
     }
 
     if (isFunction(children)) {

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -37,6 +37,14 @@ export interface FieldProps<V = any> {
     name: string;
   };
   form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
+  meta: {
+    /** Field is touched */
+    touched?: boolean;
+    /** Field has errror */
+    error?: string;
+    /** Field initial value */
+    initialValue?: string;
+  };
 }
 
 export interface FieldConfig {
@@ -161,6 +169,7 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
     } = this.props as FieldConfig;
 
     const { formik } = this.context;
+
     const field = {
       value:
         props.type === 'radio' || props.type === 'checkbox'
@@ -170,10 +179,21 @@ export class Field<Props extends FieldAttributes = any> extends React.Component<
       onChange: validate ? this.handleChange : formik.handleChange,
       onBlur: validate ? this.handleBlur : formik.handleBlur,
     };
-    const bag = { field, form: formik };
+
+    const meta = {
+      touched: getIn(formik.touched, name),
+      error: getIn(formik.errors, name),
+      initialValue: getIn(formik.initialValues, name),
+    };
+
+    const bag = {
+      field,
+      meta,
+      form: formik,
+    };
 
     if (render) {
-      return (render as any)(bag);
+      return (render as (props: FieldProps<any>) => React.ReactNode)(bag);
     }
 
     if (isFunction(children)) {

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -149,7 +149,7 @@ describe('A <Field />', () => {
       expect((node.firstChild as HTMLTextAreaElement).name).toBe('name');
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       let actual: any; /** FieldProps<any> ;) */
       let injected: any; /** FieldProps<any> ;) */
       const Component: React.SFC<FieldProps<any>> = props =>
@@ -168,7 +168,36 @@ describe('A <Field />', () => {
 
       expect(actual.field.name).toBe('name');
       expect(actual.field.value).toBe('jared');
+
+      expect(actual.meta.initialValue).toBe('jared');
+      expect(actual.meta.touched).toBeUndefined();
+      expect(actual.meta.error).toBeUndefined();
+
       expect(actual.form).toEqual(injected);
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          render={() => (
+            <Field
+              name="name"
+              component={Component}
+              validate={() => 'Some Error'}
+            />
+          )}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
   });
 
@@ -192,7 +221,7 @@ describe('A <Field />', () => {
       expect(node.innerHTML).toContain(TEXT);
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       ReactDOM.render(
         <TestForm
           render={(formikProps: FormikProps<TestFormValues>) => (
@@ -200,9 +229,14 @@ describe('A <Field />', () => {
               placeholder={placeholder}
               name="name"
               testingAnArbitraryProp="thing"
-              render={({ field, form }: FieldProps<any>) => {
+              render={({ field, meta, form }: FieldProps<any>) => {
                 expect(field.name).toBe('name');
                 expect(field.value).toBe('jared');
+
+                expect(meta.initialValue).toBe('jared');
+                expect(meta.touched).toBeUndefined();
+                expect(meta.error).toBeUndefined();
+
                 expect(form).toEqual(formikProps);
 
                 return null;
@@ -212,6 +246,30 @@ describe('A <Field />', () => {
         />,
         node
       );
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          render={() => (
+            <Field
+              name="name"
+              component={Component}
+              validate={() => 'Some Error'}
+            />
+          )}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
   });
 
@@ -389,7 +447,7 @@ describe('A <Field />', () => {
       expect(node.innerHTML).toContain(TEXT);
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       let actual: any;
       let injected: any;
       const Component: React.SFC<FieldProps<any>> = props =>
@@ -407,7 +465,36 @@ describe('A <Field />', () => {
       );
       expect(actual.field.name).toBe('name');
       expect(actual.field.value).toBe('jared');
+
+      expect(actual.meta.initialValue).toBe('jared');
+      expect(actual.meta.touched).toBeUndefined();
+      expect(actual.meta.error).toBeUndefined();
+
       expect(actual.form).toEqual(injected);
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          render={() => (
+            <Field
+              name="name"
+              component={Component}
+              validate={() => 'Some Error'}
+            />
+          )}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
 
     it('can resolve bracket paths', () => {

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -156,7 +156,7 @@ describe('A <Field />', () => {
       expect((node.firstChild as HTMLTextAreaElement).name).toBe('name');
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       let actual: any; /** FieldProps ;) */
       let injected: any; /** FieldProps ;) */
       const Component: React.SFC<FieldProps> = props =>
@@ -172,12 +172,37 @@ describe('A <Field />', () => {
         />,
         node
       );
+
       const { handleBlur, handleChange } = injected;
       expect(actual.field.name).toBe('name');
       expect(actual.field.value).toBe('jared');
       expect(actual.field.onChange).toBe(handleChange);
       expect(actual.field.onBlur).toBe(handleBlur);
+
+      expect(actual.meta.initialValue).toBe('jared');
+      expect(actual.meta.touched).toBeUndefined();
+      expect(actual.meta.error).toBeUndefined();
+
       expect(actual.form).toEqual(injected);
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          validate={() => ({ name: 'Some Error' })}
+          render={() => <Field name="name" component={Component} />}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
   });
 
@@ -201,7 +226,7 @@ describe('A <Field />', () => {
       expect(node.innerHTML).toContain(TEXT);
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       ReactDOM.render(
         <TestForm
           render={(formikProps: FormikProps<TestFormValues>) => (
@@ -209,12 +234,17 @@ describe('A <Field />', () => {
               placeholder={placeholder}
               name="name"
               testingAnArbitraryProp="thing"
-              render={({ field, form }: FieldProps) => {
+              render={({ field, meta, form }: FieldProps) => {
                 const { handleBlur, handleChange } = formikProps;
                 expect(field.name).toBe('name');
                 expect(field.value).toBe('jared');
                 expect(field.onChange).toBe(handleChange);
                 expect(field.onBlur).toBe(handleBlur);
+
+                expect(meta.initialValue).toBe('jared');
+                expect(meta.touched).toBeUndefined();
+                expect(meta.error).toBeUndefined();
+
                 expect(form).toEqual(formikProps);
 
                 return null;
@@ -224,6 +254,25 @@ describe('A <Field />', () => {
         />,
         node
       );
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          validate={() => ({ name: 'Some Error' })}
+          render={() => <Field name="name" component={Component} />}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
   });
 
@@ -401,7 +450,7 @@ describe('A <Field />', () => {
       expect(node.innerHTML).toContain(TEXT);
     });
 
-    it('receives { field, form } props', () => {
+    it('receives { field, meta, form } props', () => {
       let actual: any;
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
@@ -422,7 +471,31 @@ describe('A <Field />', () => {
       expect(actual.field.onChange).toBe(handleChange);
       expect(actual.field.onBlur).toBe(handleBlur);
       expect(actual.field.value).toBe('jared');
+
+      expect(actual.meta.initialValue).toBe('jared');
+      expect(actual.meta.touched).toBeUndefined();
+      expect(actual.meta.error).toBeUndefined();
+
       expect(actual.form).toEqual(injected);
+    });
+
+    it('receives defined touched & error meta prop', () => {
+      let actual: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestForm
+          validate={() => ({ name: 'Some Error' })}
+          render={() => <Field name="name" component={Component} />}
+        />,
+        node
+      );
+
+      actual.field.onBlur({ target: { name: 'name' }, persist: jest.fn() });
+
+      expect(actual.meta.touched).toBeTruthy();
+      expect(actual.meta.error).toBeTruthy();
     });
 
     it('can resolve bracket paths', () => {


### PR DESCRIPTION
Dividing this PR https://github.com/jaredpalmer/formik/pull/476 into two parts.

PR adds meta object to Field bag to ease getting of different states. Currently meta object consists of:
* `error`
* `touched`
* `initialValue`
