### PR TITLE
Use lodash.isnan instead of Number.isNaN

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "hoist-non-react-statics": "^2.5.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "4.5.0",
+    "lodash.isnan": "^3.0.2",
     "lodash.topath": "4.5.2",
     "prop-types": "^15.5.10",
     "warning": "^3.0.0"
@@ -55,6 +56,7 @@
     "@types/jest": "20.0.6",
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.isequal": "4.5.2",
+    "@types/lodash.isnan": "^3.0.3",
     "@types/lodash.topath": "4.5.3",
     "@types/prop-types": "^15.5.2",
     "@types/react": "16.0.28",

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -1,6 +1,7 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import isEqual from 'lodash.isequal';
+import isNaN from 'lodash.isnan';
 import warning from 'warning';
 import {
   isFunction,
@@ -463,7 +464,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
           });
         }
         val = /number|range/.test(type)
-          ? ((parsed = parseFloat(value)), Number.isNaN(parsed) ? '' : parsed)
+          ? ((parsed = parseFloat(value)), isNaN(parsed) ? '' : parsed)
           : /checkbox/.test(type) ? checked : value;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,12 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.isnan@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isnan/-/lodash.isnan-3.0.3.tgz#65ce1f6ba1039d8318af383167bbf714a25cf204"
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.topath@4.5.3":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@types/lodash.topath/-/lodash.topath-4.5.3.tgz#87de9823f4b8702a77ac927954c0dd4cafa496b5"
@@ -3597,6 +3603,10 @@ lodash.flattendeep@^4.4.0:
 lodash.isequal@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.isnan@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isnan/-/lodash.isnan-3.0.2.tgz#82ed04a5f9ea8bd6226d0c26af0cac32f4507745"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Hello, maintainers.

I'm trying to solve https://github.com/jaredpalmer/formik/issues/559 with this PR by adding `lodash.isnan` as a dependency since IE doesn't support `Number.isNaN`.

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN

But I'm not sure whether this is the best approach to make polyfill for this project, so if you have a better solution in your mind I'll comply it.