### PR TITLE
Remove unused private method: isReactNative

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,13 +81,6 @@ export function setNestedObjectValues<T>(
 
 // Assertions
 
-/** @private is running React Native?  */
-export const isReactNative =
-  typeof window !== 'undefined' &&
-  window.navigator &&
-  window.navigator.product &&
-  window.navigator.product === 'ReactNative';
-
 /** @private is the given object a Function? */
 export const isFunction = (obj: any) => 'function' === typeof obj;
 


### PR DESCRIPTION
I came across an unused method.

Please feel free to close if you imagine that you would use this method in the future.

- The method is introduced by https://github.com/jaredpalmer/formik/pull/53
- Then it got unused by https://github.com/jaredpalmer/formik/pull/521