### PR TITLE
Fix issue where storing Immutable values in form values causes browser hangs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.5.0",
-    "lodash.clonedeep": "^4.5.0",
     "lodash.topath": "4.5.2",
     "prop-types": "^15.5.10",
     "react-fast-compare": "^1.0.0",
@@ -52,7 +51,6 @@
     "@types/enzyme": "3.1.5",
     "@types/enzyme-adapter-react-16": "1.0.1",
     "@types/jest": "20.0.6",
-    "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.topath": "4.5.3",
     "@types/prop-types": "^15.5.2",
     "@types/react": "16.0.28",

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -177,6 +177,13 @@ describe('utils', () => {
       expect(newObj).toEqual({ x: 'y', nested: ['a', 'b'] });
     });
 
+    it('updates deep nested array value', () => {
+      const obj = { x: 'y', nested: [['a']] };
+      const newObj = setIn(obj, 'nested[0][1]', 'b');
+      expect(obj).toEqual({ x: 'y', nested: [['a']] });
+      expect(newObj).toEqual({ x: 'y', nested: [['a', 'b']] });
+    });
+
     it('sticks to object with int key when defined', () => {
       const obj = { x: 'y', nested: { 0: 'a' } };
       const newObj = setIn(obj, 'nested.0', 'b');

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,12 +30,6 @@
   version "20.0.6"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.6.tgz#7e0ba76ddfacb42ee9bb0d8833e5208cf0680431"
 
-"@types/lodash.clonedeep@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.3.tgz#d42cfba3d929a4e1177a775142ce2a9444e384cf"
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.topath@4.5.3":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@types/lodash.topath/-/lodash.topath-4.5.3.tgz#87de9823f4b8702a77ac927954c0dd4cafa496b5"
@@ -3579,10 +3573,6 @@ lodash.camelcase@^4.3.0:
 lodash.chunk@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
-
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
# Bug
Having [Slate.js](https://github.com/ianstormtaylor/slate) `Value` objects in a nested `values` object leads to browser hangs.

# Current Behaviour
I have set up a `Field` for Slate.js editors that works in the same way that is demonstrated in the demo for integrating Draft.js - [Working with 3rd-party inputs #2: Draft.js](https://codesandbox.io/s/QW1rqjBLl).

The `initialValues` I send to the `Formik` component look like this:

```js
import { Value } from "slate"

const initialValues = {
    formSectionOne: {
        name: "Bob Renwick"
    },
    formSectionTwo: {
        bugReport: Value.fromJSON({}), // Actual value removed as irrelevant
    }
};
```
But the first time that Slate.js calls the `onChange` callback, and my `Field` updates the form via `setFieldValue("formSectionTwo.bugReport", change.value)` then Formik hangs at the `setIn` call because it calls `cloneDeep` on `values.formSectionTwo`, which then tries to clone the immutable object.

# Desired Behaviour
No hanging

# Solution
I replaced `cloneDeep` with a custom cloning technique to avoid deep cloning Immutable objects. This supports having Immutable object as leaves, anywhere in the values object, while retaining all the properties of the old implementation.

Formik Version: 0.11.11
React Version: 16.2.0
OS: OS X 10.11.6
Node Version: 9.11.1
Package Manager and Version: npm@5.6.0
