### PR TITLE
Add flow support (in progress)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,12 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+
+[strict]

--- a/flow-test-examples/basic.js
+++ b/flow-test-examples/basic.js
@@ -1,0 +1,243 @@
+/* @flow */
+import * as React from 'react';
+import { Form, Formik } from '../dist/formik';
+import Mutation from './controls/Mutation';
+import Input from './controls/Input';
+import NumberInput from './controls/NumberInput';
+import bind from './bind';
+import someApiMutation from './mutations/someApiMutation';
+
+type Props = {
+  data: {|
+    +id: string,
+    +name: string,
+    +age: number,
+    +deep: {|
+      +id: number,
+      +value: string,
+    |},
+    +arr: Array<{| +title: string |}>,
+  |},
+  parentId: string,
+};
+
+// We must declare initialValues type
+const mapData = (data): $ElementType<Props, 'data'> => ({
+  ...data,
+});
+
+class BasicForm extends React.Component<Props> {
+  render() {
+    const { data, parentId } = this.props;
+
+    return (
+      <Form>
+        <Mutation mutation={someApiMutation}>
+          {({ onSubmit, error: apiError }) => (
+            <Formik
+              initialValues={mapData(data)}
+              validate={values => {
+                if (values.age < 10) {
+                  return { age: 'Too young' };
+                }
+
+                if (values.age > 20) {
+                  return { age: 'Too old' };
+                }
+
+                /* $ExpectError "Cannot create `Formik` element
+                because property `unknown` is missing in object type [1]
+                in the indexer property's key of the return value
+                of property `validate`."*/
+                return { unknown: 'xxx' };
+              }}
+              onSubmit={(values, formikActions) => {
+                // non converted values are passed to make errors
+                // can be shown in this form (api error keys can be different)
+                onSubmit({ ...values, parentId }, values, formikActions);
+
+                /* $ExpectError Cannot call `onSubmit` with object literal bound to `input`
+                because property `parentId` is missing in object literal [1] but exists in object type [2].
+                */
+                onSubmit(values, values, formikActions);
+
+                onSubmit(
+                  /* $ExpectError Cannot call `onSubmit`
+                  with object literal bound to `input`
+                  because property `hello` is missing in object type [1]
+                  but exists in object literal [2].*/
+                  { ...values, parentId, hello: 'world' },
+                  values,
+                  formikActions
+                );
+              }}
+            >
+              {formProps => {
+                const {
+                  values,
+                  errors,
+                  touched,
+                  handleChange,
+                  handleBlur,
+                  handleReset,
+                  setErrors,
+                  setTouched,
+                  dirty,
+                  isSubmitting,
+                  isValid,
+                } = formProps;
+
+                return (
+                  <React.Fragment>
+                    {apiError != null && <div>{apiError}</div>}
+
+                    <Input {...bind(formProps, 'name')} />
+
+                    <NumberInput {...bind(formProps, 'age')} />
+
+                    {/* $ExpectError Cannot create `Input` element because number
+                    [1] is incompatible with string [2] in property `value`. */}
+                    <Input {...bind(formProps, 'age')} />
+
+                    {/* Trying to bind to unknown property will cause a lot of errors so ExpectError will not help,
+                    uncomment to see effect */}
+                    {/* <Input {...bind(formProps, 'unknown')} /> */}
+
+                    <Input
+                      name={'name'}
+                      value={values.name}
+                      onChange={handleChange}
+                      // error={Boolean(touched.name === true && errors.name)}
+                    />
+
+                    <Input
+                      name={'age'}
+                      /* $ExpectError Cannot create `Input`
+                      element because number [1] is incompatible with string [2] in property `value`
+                      */
+                      value={values.age}
+                      onChange={handleChange}
+                    />
+
+                    <Input
+                      name={'unknown'}
+                      /*
+                      $ExpectError Cannot get `values.unknown` because property `unknown` is missing in object type [1].
+                      */
+                      value={values.unknown}
+                      onChange={handleChange}
+                    />
+
+                    <div>
+                      {/* Show errors, and deep errors */}
+                      {errors.name}
+                      {errors.deep && errors.deep.value}
+                      {errors.arr && errors.arr[0] && errors.arr[0].title};
+                    </div>
+
+                    <div>
+                      {/* Check touched */}
+                      {touched.name && 'name is touched'}
+                      {touched.deep &&
+                        touched.deep.value &&
+                        'deep.value is touched'}
+                      {touched.arr &&
+                        touched.arr[0] &&
+                        touched.arr[0].title &&
+                        'arr 0 titlw is touched'};
+                    </div>
+
+                    <button
+                      onClick={() => {
+                        setErrors({ name: '2fff' });
+                        // Not sure this is needed to set error on whole subobject
+                        // setErrors({ deep: 'error' });
+                        setErrors({ deep: { value: 'error' } });
+
+                        // setErrors({ arr: 'error' });
+                        setErrors({
+                          arr: [{ title: 'error' }, { title: 'error2' }],
+                        });
+
+                        /* $ExpectError 'Cannot call `setErrors`
+                        with object literal bound to `errors`
+                        because property `unknown` is missing
+                        in object literal [1] but exists in `FormikErrors`"*/
+                        setErrors({ unknown: 'eeee' });
+
+                        /* $ExpectError Cannot call `setErrors`
+                        with object literal bound to `errors` because property
+                        `unknownValue` is missing in object literal [1]
+                        but exists in `FormikErrors` [2] in property `deep`.
+                        */
+                        setErrors({ deep: { unknownValue: 'error' } });
+
+                        /*
+                        $ExpectError Cannot call `setErrors` with object literal
+                        bound to `errors` because property `unknown` is missing
+                        in object literal [1] but exists in `FormikErrors` [2] in array element of property `arr`.
+                        */
+                        setErrors({
+                          arr: [{ unknown: 'error' }],
+                        });
+                      }}
+                    />
+
+                    <button
+                      onClick={() => {
+                        setTouched({ name: true });
+                        // Not sure this is needed to set error on whole subobject
+                        // setTouched({ deep: 'error' });
+                        setTouched({ deep: { value: true } });
+
+                        // setTouched({ arr: 'error' });
+                        setTouched({
+                          arr: [{ title: false }, { title: true }],
+                        });
+
+                        /* $ExpectError Cannot call `setTouched` with
+                        object literal bound to `touched` because
+                        property `unknown` is missing in object literal
+                        [1] but exists in `FormikTouched` [2]*/
+                        setTouched({ unknown: true });
+
+                        /* $ExpectError Cannot call `setTouched` with object literal
+                        bound to `touched` because property `unknownValue` is missing
+                        in object literal [1] but exists in `FormikTouched` [2] in property `deep`.
+                        */
+                        setTouched({ deep: { unknownValue: 'error' } });
+
+                        /*
+                        $ExpectError Cannot call `setTouched` with object
+                        literal bound to `touched` because property `unknown`
+                        is missing in object literal [1] but exists in
+                        `FormikTouched` [2] in array element of property `arr`
+                        */
+                        setTouched({
+                          arr: [{ unknown: 'error' }],
+                        });
+                      }}
+                    />
+
+                    <button
+                      onClick={handleReset}
+                      disabled={!dirty || isSubmitting}
+                    >
+                      {'Cancel'}
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={!dirty || isSubmitting || !isValid}
+                    >
+                      {'Save'}
+                    </button>
+                  </React.Fragment>
+                );
+              }}
+            </Formik>
+          )}
+        </Mutation>
+      </Form>
+    );
+  }
+}

--- a/flow-test-examples/bind.js
+++ b/flow-test-examples/bind.js
@@ -1,0 +1,24 @@
+/* @flow */
+import type { ChildrenProps } from '../dist/formik';
+
+export default function bind<
+  Values: {},
+  N: $Keys<Values>,
+  Props: ChildrenProps<Values>
+>(
+  props: Props,
+  name: N
+): { value: $ElementType<$ElementType<Props, 'values'>, N> } {
+  const values: Values = props.values;
+
+  return {
+    value: values[name] || null,
+    onChange: props.handleChange(name),
+    onBlur: props.handleBlur(name),
+    error: Boolean(props.touched[name] === true && props.errors[name]),
+    helperText:
+      props.touched[name] === true
+        ? props.errors[name] && props.errors[name].toString()
+        : '',
+  };
+}

--- a/flow-test-examples/controls/Input.js
+++ b/flow-test-examples/controls/Input.js
@@ -1,0 +1,22 @@
+/* @flow */
+import * as React from 'react';
+import { Input } from 'postcss';
+
+type Props = {
+  +value: string | null,
+  +onChange?: (evt: SyntheticInputEvent<HTMLInputElement>) => void,
+  +onBlur?: (evt: SyntheticEvent<HTMLInputElement>) => void,
+  +error?: boolean,
+  +helperText?: ?string,
+};
+// (e: SyntheticInputEvent<any>) => void
+export default ({ value, onChange, error, helperText, onBlur }: Props) => (
+  <div>
+    <div>
+      <input type="text" value={value} onChange={onChange} onBlur={onBlur} />
+    </div>
+    {error === true && (
+      <div> {helperText != null ? helperText : 'Unknown Error'} </div>
+    )}
+  </div>
+);

--- a/flow-test-examples/controls/Mutation.js
+++ b/flow-test-examples/controls/Mutation.js
@@ -1,0 +1,128 @@
+/* @flow */
+
+import * as React from 'react';
+import type { FormikActions } from '../../dist/formik';
+
+type State = {
+  error: ?string,
+};
+
+type ApiError = {|
+  +key: string,
+  +message: string,
+|};
+
+// Move all server errors we can show on formik into formik compatible errors object,
+// Move all others into error string
+function parseErrors<T: {}>(
+  errs: Array<ApiError>,
+  values: T
+): { errors: { [$Keys<T>]: ?string }, error: ?string } {
+  return {
+    errors: errs.reduce((r, err) => {
+      if (err.key in values) {
+        return { [err.key]: err.message, ...r };
+      }
+      return r;
+    }, {}),
+    error: errs
+      .filter(err => !(err.key in values))
+      .map(err => err.message)
+      .join('\n'),
+  };
+}
+
+export default class Mutation<InputData: {}> extends React.Component<
+  {|
+    +mutation: (data: InputData, (errs: ?Array<ApiError>) => void) => void,
+
+    +children: ({|
+      onSubmit: <T: {}>(
+        input: InputData,
+        values: T,
+        formikActions: FormikActions<T>
+      ) => void,
+      onResetError: () => void,
+      error: ?string,
+    |}) => React.Node,
+  |},
+  State
+> {
+  static contextTypes = {
+    relay: () => {},
+  };
+
+  context: {
+    relay: {
+      environment: mixed,
+    },
+  };
+
+  state = {
+    error: null,
+  };
+
+  isMounted_ = false;
+
+  updateState = (obj: $Shape<State>) => {
+    if (this.isMounted_) {
+      this.setState(obj);
+    }
+  };
+
+  handleResetError = () => {
+    this.setState({ error: null });
+  };
+
+  handleSubmit: <T: {}>(
+    input: InputData,
+    values: T,
+    formikActions: FormikActions<T>
+  ) => void = (input, values, { setErrors, resetForm, setSubmitting }) => {
+    const environment = this.context.relay.environment;
+    const { mutation } = this.props;
+
+    setSubmitting(true);
+
+    mutation(input, errs => {
+      if (errs) {
+        setSubmitting(false);
+
+        const { error, errors } = parseErrors(errs, values);
+
+        if (errors) {
+          setErrors(errors);
+        }
+        this.updateState({ error });
+      } else {
+        setSubmitting(false);
+
+        this.updateState({ error: null });
+        resetForm();
+      }
+    });
+  };
+
+  render() {
+    const {
+      handleSubmit: onSubmit,
+      handleResetError: onResetError,
+      state: { error },
+      props: { children },
+    } = this;
+
+    return children({
+      onSubmit,
+      onResetError,
+      error,
+    });
+  }
+
+  componentDidMount() {
+    this.isMounted_ = true;
+  }
+
+  componentWillUnmount() {
+    this.isMounted_ = false;
+  }
+}

--- a/flow-test-examples/controls/NumberInput.js
+++ b/flow-test-examples/controls/NumberInput.js
@@ -1,0 +1,22 @@
+/* @flow */
+import * as React from 'react';
+import { Input } from 'postcss';
+
+type Props = {
+  +value: number | null,
+  +onChange?: (evt: SyntheticInputEvent<HTMLInputElement>) => void,
+  +onBlur?: (evt: SyntheticEvent<HTMLInputElement>) => void,
+  +error?: boolean,
+  +helperText?: ?string,
+};
+// (e: SyntheticInputEvent<any>) => void
+export default ({ value, onChange, error, helperText, onBlur }: Props) => (
+  <div>
+    <div>
+      <input type="number" value={value} onChange={onChange} onBlur={onBlur} />
+    </div>
+    {error === true && (
+      <div> {helperText != null ? helperText : 'Unknown Error'} </div>
+    )}
+  </div>
+);

--- a/flow-test-examples/mutations/someApiMutation.js
+++ b/flow-test-examples/mutations/someApiMutation.js
@@ -1,0 +1,31 @@
+/* @flow */
+
+type ApiError = {|
+  +key: string,
+  +message: string,
+|};
+
+// Api can have different interface not same as formik submit
+export default (
+  {
+    id,
+    name,
+    age,
+    deep,
+    arr,
+    parentId,
+  }: $ReadOnly<{|
+    id: string,
+    name: string,
+    age: number,
+    deep: {|
+      +id: number,
+      +value: string,
+    |},
+    arr: Array<{| +title: string |}>,
+    parentId: string,
+  |}>,
+  callback: (errs: ?Array<ApiError>) => void
+) => {
+  // commitMutation, call callback on errors
+};

--- a/package.json
+++ b/package.json
@@ -18,23 +18,25 @@
   "main": "dist/formik.js",
   "module": "dist/formik.es6.js",
   "typings": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "test": "jest --env=jsdom && npm run size",
     "test:watch": "npm run test -- --watch",
-    "start": "cross-env NODE_ENV=development tsc-watch --project tsconfig.base.json  --onSuccess \"rollup -c\"",
+    "start":
+      "cross-env NODE_ENV=development tsc-watch --project tsconfig.base.json  --onSuccess \"rollup -c\"",
     "prebuild": "rimraf dist",
-    "build": "tsc -p tsconfig.base.json  && cross-env NODE_ENV=production rollup -c && cross-env NODE_ENV=development rollup -c && rimraf compiled",
+    "build":
+      "tsc -p tsconfig.base.json  && cross-env NODE_ENV=production rollup -c && cross-env NODE_ENV=development rollup -c && cp ./src/formik.js.flow ./dist/ && rimraf compiled",
     "prepublish": "npm run build",
-    "format": "prettier --trailing-comma es5 --single-quote --write 'src/**/*' 'test/**/*' 'README.md'",
+    "format":
+      "prettier --trailing-comma es5 --single-quote --write 'src/**/*' 'test/**/*' 'README.md'",
     "precommit": "lint-staged",
     "addc": "all-contributors add",
     "start-website": "cd website && yarn start",
     "build-website": "cd website && yarn install && yarn build",
     "gen-docs": "all-contributors generate && doctoc README.md",
-    "size": "size-limit"
+    "size": "size-limit",
+    "flowcheck": "yarn build && flow"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.5.0",
@@ -64,6 +66,7 @@
     "doctoc": "^1.3.0",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
+    "flow-bin": "^0.70.0",
     "husky": "0.14.3",
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
@@ -99,28 +102,14 @@
     "semi": true
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "<rootDir>/test/setupTest.ts"
-    ],
-    "collectCoverageFrom": [
-      "src/**/*.{ts,tsx}"
-    ],
+    "setupFiles": ["raf/polyfill", "<rootDir>/test/setupTest.ts"],
+    "collectCoverageFrom": ["src/**/*.{ts,tsx}"],
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testMatch": [
-      "<rootDir>/test/**/?(*.)(spec|test).ts?(x)"
-    ],
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json"
-    ]
+    "testMatch": ["<rootDir>/test/**/?(*.)(spec|test).ts?(x)"],
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+    "moduleFileExtensions": ["ts", "tsx", "js", "json"]
   },
   "size-limit": [
     {

--- a/src/formik.js.flow
+++ b/src/formik.js.flow
@@ -1,0 +1,128 @@
+/* @flow */
+import * as React from 'react';
+
+export type FormikErrors<Values> = $Shape<
+  $ObjMap<
+    { ...Values },
+    (<T>(a: Array<T>) => Array<FormikErrors<T>>) &
+      (<T: Object>(a: T) => FormikErrors<T>) &
+      (<T>(a: T) => ?string)
+  >
+>;
+
+export type FormikTouched<Values> = $Shape<
+  $ObjMap<
+    { ...Values },
+    (<T>(a: Array<T>) => Array<FormikTouched<T>>) &
+      (<T: Object>(a: T) => FormikTouched<T>) &
+      (<T>(a: T) => ?boolean)
+  >
+>;
+
+export type FormikActions<Values> = {
+  /** Manually set errors object */
+  setErrors(errors: FormikErrors<Values>): void,
+
+  /** Manually set isSubmitting */
+  setSubmitting(isSubmitting: boolean): void,
+
+  /** Manually set touched object */
+  setTouched(touched: FormikTouched<Values>): void,
+
+  /** Manually set values object  */
+  setValues(values: Values): void,
+
+  /** Set value of form field directly */
+  setFieldValue<P: $Keys<Values>>(
+    field: P,
+    value: $ElementType<Values, P>,
+    shouldValidate?: boolean
+  ): void,
+
+  /** Set error message of a form field directly */
+  setFieldError(field: $Keys<Values>, message: string): void,
+
+  /** Set whether field has been touched directly */
+  setFieldTouched(
+    field: $Keys<Values>,
+    isTouched?: boolean,
+    shouldValidate?: boolean
+  ): void,
+
+  /** Validate form values */
+  validateForm(values?: Values): void,
+
+  /** Reset form */
+  resetForm(nextValues?: Values): void,
+
+  /** Submit the form imperatively */
+  submitForm(): void,
+};
+
+export type FormikHandlers<Values> = {
+  /** Form submit handler */
+  handleSubmit: (e: SyntheticEvent<HTMLFormElement>) => void,
+  /** Reset form event handler  */
+  handleReset: () => void,
+  /** Classic React blur handler, keyed by input name */
+  /** or Preact-like linkState. Will return a handleBlur function. */
+  handleBlur: ((field: $Keys<Values>) => (e: SyntheticEvent<any>) => void) &
+    ((e: SyntheticEvent<any>) => void),
+
+  /** Classic React change handler, keyed by input name */
+  /** or Preact-like linkState. Will return a handleChange function.  */
+  handleChange: ((
+    field: $Keys<Values>
+  ) => (e: SyntheticInputEvent<any>) => void) &
+    ((e: SyntheticInputEvent<any>) => void),
+};
+
+export type ChildrenProps<Values> = {
+  values: Values,
+  isSubmitting: boolean,
+  dirty: boolean,
+  isValid: boolean,
+  errors: FormikErrors<Values>,
+  touched: FormikTouched<Values>,
+  ...$Exact<FormikActions<Values>>,
+  ...$Exact<FormikHandlers<Values>>,
+};
+
+export type FormikProps<Values> = {
+  initialValues: Values,
+  validateOnChange?: boolean,
+  /** Tells Formik to validate the form on each input's onBlur event */
+  validateOnBlur?: boolean,
+  /** Tell Formik if initial form values are valid or not on first render */
+  isInitialValid?: boolean,
+  /** Should Formik reset the form when new initialValues change */
+  enableReinitialize?: boolean,
+
+  onReset?: (values: Values, formikActions: FormikActions<Values>) => void,
+  onSubmit?: (values: Values, formikActions: FormikActions<Values>) => void,
+
+  render?: (props: FormikProps<Values>) => React.Node,
+
+  validate?: (
+    values: Values
+  ) => void | FormikErrors<Values> | Promise<FormikErrors<Values>>,
+
+  children: (props: ChildrenProps<Values>) => React.Node,
+};
+
+declare export class Formik<Values> extends React.Component<
+  FormikProps<Values>
+> {}
+
+declare export class Form extends React.Component<{|
+  children?: React.Node,
+  className?: string,
+  acceptCharset?: string,
+  action?: string,
+  encoding?: string,
+  enctype?: string,
+  length?: number,
+  method?: string,
+  name?: string,
+  target?: string,
+|}> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,6 +2191,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+flow-bin@^0.70.0:
+  version "0.70.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.70.0.tgz#080ae83a997f2b4ddb3dc2649bf13336825292b5"
+
 flush-write-stream@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.2.tgz#c81b90d8746766f1a609a46809946c45dd8ae417"


### PR DESCRIPTION
flow now can be easily distributed with package itself, without `flow-typed` (which has strange politics about types etc)

So here is  +-strict flow support for `Form` and `Formik`, see ./flow-test-examples/basic.js for details
It's some kind of flow test, each `$ExpectError` inside prevents from real error.

Now in progress, to going further I wanna ask one question.
To have a stricter Field type what if Field component can be passed as children render prop i.e
```javascript
<Formik>{({values, Field}) => ...</Formik>
```
In such case I could (I think ;-)) give to a Field a very good typings based on `Formik` types. So it would detect errors like `<Field name="unknownField"`, values types (as same as now `bind` works in basic.js)
