### PR TITLE
Prevent double build of esm and cjs bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:watch": "npm run test -- --watch",
     "start": "cross-env NODE_ENV=development tsc-watch --project tsconfig.base.json  --onSuccess \"rollup -c\"",
     "prebuild": "rimraf dist",
-    "build": "tsc -p tsconfig.base.json  && cross-env NODE_ENV=production rollup -c && cross-env NODE_ENV=development rollup -c && rimraf compiled",
+    "build": "tsc -p tsconfig.base.json && rollup -c && rimraf compiled",
     "prepublish": "npm run build",
     "format": "prettier --trailing-comma es5 --single-quote --write 'src/**/*' 'test/**/*' 'README.md'",
     "precommit": "lint-staged",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,76 +6,78 @@ import sourceMaps from 'rollup-plugin-sourcemaps';
 import uglify from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
-const shared = {
-  input: `compiled/index.js`,
+const input = './compiled/index.js';
+
+const getUMDConfig = ({ env }) => ({
+  input,
   external: ['react', 'react-native'],
-};
+  output: {
+    name: 'Formik',
+    format: 'umd',
+    sourcemap: true,
+    file:
+      env === 'production'
+        ? './dist/formik.umd.min.js'
+        : './dist/formik.umd.js',
+    exports: 'named',
+    globals: {
+      react: 'React',
+      'react-native': 'ReactNative',
+    },
+  },
+
+  plugins: [
+    resolve(),
+    replace({
+      exclude: 'node_modules/**',
+      'process.env.NODE_ENV': JSON.stringify(env),
+    }),
+    commonjs({
+      include: /node_modules/,
+      namedExports: {
+        'node_modules/prop-types/index.js': [
+          'object',
+          'oneOfType',
+          'string',
+          'node',
+          'func',
+          'bool',
+          'element',
+        ],
+      },
+    }),
+    sourceMaps(),
+    env === 'production' && filesize(),
+    env === 'production' &&
+      uglify({
+        output: { comments: false },
+        compress: {
+          keep_infinity: true,
+          pure_getters: true,
+        },
+        warnings: true,
+        ecma: 5,
+        toplevel: false,
+      }),
+  ],
+});
 
 export default [
-  Object.assign({}, shared, {
-    output: {
-      name: 'Formik',
-      format: 'umd',
-      sourcemap: true,
-      file:
-        process.env.NODE_ENV === 'production'
-          ? './dist/formik.umd.min.js'
-          : './dist/formik.umd.js',
-      exports: 'named',
-      globals: {
-        react: 'React',
-        'react-native': 'ReactNative',
-      },
-    },
+  getUMDConfig({ env: 'production' }),
 
-    plugins: [
-      resolve(),
-      replace({
-        exclude: 'node_modules/**',
-        'process.env.NODE_ENV': JSON.stringify(
-          process.env.NODE_ENV || 'development'
-        ),
-      }),
-      commonjs({
-        include: /node_modules/,
-        namedExports: {
-          'node_modules/prop-types/index.js': [
-            'object',
-            'oneOfType',
-            'string',
-            'node',
-            'func',
-            'bool',
-            'element',
-          ],
-        },
-      }),
-      sourceMaps(),
-      process.env.NODE_ENV === 'production' && filesize(),
-      process.env.NODE_ENV === 'production' &&
-        uglify({
-          output: { comments: false },
-          compress: {
-            keep_infinity: true,
-            pure_getters: true,
-          },
-          warnings: true,
-          ecma: 5,
-          toplevel: false,
-        }),
-    ],
-  }),
+  getUMDConfig({ env: 'development' }),
 
-  Object.assign({}, shared, {
-    external: shared.external.concat(Object.keys(pkg.dependencies)),
+  {
+    input,
+    external: id => !id.startsWith('.') && !id.startsWith('/'),
     output: [
       {
-        file: 'dist/formik.es6.js',
+        file: pkg.module,
         format: 'es',
         sourcemap: true,
       },
       {
-        file: 'dist/formik.js',
+        file: pkg.main,
         format: 'cjs',
         sourcemap: true,
       },
@@ -83,7 +85,7 @@ export default [
     plugins: [
       resolve(),
       sourceMaps(),
-      process.env.NODE_ENV === 'production' && filesize(),
+      filesize(),
     ],
-  }),
+  },
 ];


### PR DESCRIPTION
In this diff I moved umd config into function and provided environment
as an argument.

Added universal external function to not bundle any dependency.

Also reused `main` and `module` fields from package.json in rollup config.