### PR TITLE
fix withFormik display name

### DIFF
--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -109,11 +109,18 @@ export function withFormik<
   return function createFormik(
     Component: CompositeComponent<InjectedFormikProps<Props, Values>>
   ): React.ComponentClass<Props> {
+    const componentDisplayName =
+      Component.displayName ||
+      Component.name ||
+      (Component.constructor && Component.constructor.name) ||
+      'Component';
     /**
      * We need to use closures here for to provide the wrapped component's props to
      * the respective withFormik config methods.
      */
     class C extends React.Component<Props, {}> {
+      static displayName = `WithFormik(${componentDisplayName})`;
+
       validate = (values: Values): void | object | Promise<any> => {
         return config.validate!(values, this.props);
       };

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -76,6 +76,11 @@ describe('withFormik()', () => {
     expect(tree.find(Form).props().isValid).toBe(false);
   });
 
+  it('should correctly set displayName', () => {
+    const tree = mount(<BasicForm user={{ name: 'jared' }} />);
+    expect((tree.get(0).type as any).displayName).toBe('WithFormik(Form)');
+  });
+
   describe('FormikHandlers', () => {
     describe('handleChange', () => {
       it('sets values state', async () => {


### PR DESCRIPTION
Previously any debugger that uses displayName would report the component wrapped with `withFormik` as `C`. This change makes it such that debuggers will now resolve it as `withFormik(ComponentName)`.

Should fix the issue raised in #310 (~4 months is long enough to assume he's not going to raise the PR I think).