### PR TITLE
Fix FastField.handleBlur leading to undefined errors and invalid forms

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -6,7 +6,14 @@ import { FieldAttributes, FieldConfig, FieldProps } from './Field';
 import { validateYupSchema, yupToFormErrors } from './Formik';
 import { connect } from './connect';
 import { FormikContext } from './types';
-import { getIn, isEmptyChildren, isFunction, isPromise, setIn } from './utils';
+import {
+  getIn,
+  isEmptyChildren,
+  isFunction,
+  isPromise,
+  setIn,
+  unsetIn,
+} from './utils';
 
 export interface FastFieldState {
   value: any;
@@ -213,7 +220,7 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
             setFormikState((prevState: any) => ({
               ...prevState,
               values: setIn(prevState.values, name, this.state.value),
-              errors: setIn(prevState.errors, name, undefined),
+              errors: unsetIn(prevState.errors, name),
               touched: setIn(prevState.touched, name, true),
             })),
           error =>
@@ -235,7 +242,10 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
     } else {
       setFormikState((prevState: any) => ({
         ...prevState,
-        errors: setIn(prevState.errors, name, this.state.error),
+        errors:
+          this.state.error === undefined
+            ? unsetIn(prevState.errors, name)
+            : setIn(prevState.errors, name, this.state.error),
         values: setIn(prevState.values, name, this.state.value),
         touched: setIn(prevState.touched, name, true),
       }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,69 @@ export function setIn(obj: any, path: string, value: any): any {
   return { ...obj, ...res };
 }
 
+export function createCopyWithoutKey(obj: any, key: any) {
+  const copy: any = {};
+  for (let k of Object.keys(obj)) {
+    if (k !== key) {
+      copy[k] = obj[k];
+    }
+  }
+  return copy;
+}
+
+export function isEmptyObject(obj: any) {
+  if (Array.isArray(obj)) {
+    return obj.every(item => item === undefined);
+  }
+  return Object.keys(obj).length === 0;
+}
+
+export function _unsetIn(obj: any, path: string[]): any {
+  const firstPath = Array.isArray(obj) ? Number(path[0]) : path[0];
+
+  if (path.length === 1) {
+    return createCopyWithoutKey(obj, firstPath);
+  }
+
+  if (!obj.hasOwnProperty(firstPath)) {
+    return obj;
+  }
+
+  const objAtFirstPart = obj[firstPath];
+
+  const updatedObj = _unsetIn(objAtFirstPart, path.slice(1));
+
+  if (Array.isArray(obj)) {
+    obj = obj.slice();
+
+    if (isEmptyObject(updatedObj)) {
+      delete obj[firstPath];
+    } else {
+      obj[firstPath] = updatedObj;
+    }
+
+    return obj;
+  }
+
+  if (isEmptyObject(updatedObj)) {
+    return createCopyWithoutKey(obj, firstPath);
+  }
+
+  const copy = { ...obj };
+  copy[firstPath] = updatedObj;
+
+  return copy;
+}
+
+/**
+ * Deeply unsets a value and then removes data structures all the way back to
+ * the top if they're empty
+ */
+export function unsetIn(obj: any, path: string): any {
+  const splitPath = toPath(path);
+  return _unsetIn(obj, splitPath);
+}
+
 /**
  * Recursively a set the same value for all keys and arrays nested object, cloning
  * @param object

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -115,6 +115,21 @@ describe('A <Field />', () => {
       expect(setFormikState).toHaveBeenCalled();
       expect(validate).not.toHaveBeenCalled();
     });
+
+    it('does not cause undefined errors to be pushed into formik state', () => {
+      let injected: any; /** FieldProps<any> ;) */
+
+      const form = mount(
+        <TestForm
+          render={(formikProps: FormikProps<TestFormValues>) =>
+            (injected = formikProps) && <Field name="name" type={'text'} />
+          }
+        />
+      );
+
+      form.find('input').simulate('blur');
+      expect(injected.errors.hasOwnProperty('name')).toBe(false);
+    });
   });
 
   describe('<Field component />', () => {

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -1,4 +1,4 @@
-import { setIn, setNestedObjectValues, isPromise } from '../src/utils';
+import { unsetIn, setIn, setNestedObjectValues, isPromise } from '../src/utils';
 
 describe('utils', () => {
   describe('setNestedObjectValues', () => {
@@ -123,6 +123,83 @@ describe('utils', () => {
         },
       };
       expect(setNestedObjectValues(obj, true)).toEqual(newObj);
+    });
+  });
+
+  describe('unsetIn', () => {
+    it("does nothing when given a path that doesn't exist", () => {
+      const obj = { a: '1', b: '2' };
+      const newObj = unsetIn(obj, 'c');
+      expect(obj).toEqual({ a: '1', b: '2' });
+      expect(newObj).toEqual({ a: '1', b: '2' });
+    });
+
+    it("does nothing when given a nested path that doesn't exist", () => {
+      const obj = { a: '1', b: { c: '2' } };
+      const newObj = unsetIn(obj, 'b.d');
+      expect(obj).toEqual({ a: '1', b: { c: '2' } });
+      expect(newObj).toEqual({ a: '1', b: { c: '2' } });
+    });
+
+    it('unsets a flat value', () => {
+      const obj = { a: '1', b: '2' };
+      const newObj = unsetIn(obj, 'a');
+      expect(obj).toEqual({ a: '1', b: '2' });
+      expect(newObj).toEqual({ b: '2' });
+    });
+
+    it('unsets a flat value and leaves an empty object if one key at top', () => {
+      const obj = { a: '1' };
+      const newObj = unsetIn(obj, 'a');
+      expect(obj).toEqual({ a: '1' });
+      expect(newObj).toEqual({});
+    });
+
+    it('unsets a nested value and deletes empty objecct if nested', () => {
+      const obj = { a: '1', b: { c: '2' } };
+      const newObj = unsetIn(obj, 'b.c');
+      expect(obj).toEqual({ a: '1', b: { c: '2' } });
+      expect(newObj).toEqual({ a: '1' });
+    });
+
+    it('unsets and deletes multiple levels', () => {
+      const obj = { a: '1', b: { c: { d: '2' } } };
+      const newObj = unsetIn(obj, 'b.c.d');
+      expect(obj).toEqual({ a: '1', b: { c: { d: '2' } } });
+      expect(newObj).toEqual({ a: '1' });
+    });
+
+    it('can traverse arrays', () => {
+      const obj = { a: '1', b: [{ c: '2', d: '3' }, { e: '4' }] };
+      const newObj = unsetIn(obj, 'b.0.c');
+      expect(obj).toEqual({
+        a: '1',
+        b: [{ c: '2', d: '3' }, { e: '4' }],
+      });
+      expect(newObj).toEqual({
+        a: '1',
+        b: [{ d: '3' }, { e: '4' }],
+      });
+    });
+
+    it('replaces empty objects with deleted index in arrays', () => {
+      const obj = { a: '1', b: [{ c: '2', d: '3' }, { e: '4' }] };
+      const newObj = unsetIn(obj, 'b.1.e');
+      expect(obj).toEqual({
+        a: '1',
+        b: [{ c: '2', d: '3' }, { e: '4' }],
+      });
+      expect(newObj).toEqual({ a: '1', b: [{ c: '2', d: '3' }, undefined] });
+    });
+
+    it('deletes fully empty arrays too', () => {
+      const obj = { a: '1', b: [undefined, { e: '2' }] };
+      const newObj = unsetIn(obj, 'b.1.e');
+      expect(obj).toEqual({
+        a: '1',
+        b: [undefined, { e: '2' }],
+      });
+      expect(newObj).toEqual({ a: '1' });
     });
   });
 


### PR DESCRIPTION
# Bug
Using `FastField` in a `Formik` form with `validateOnBlur` leads to forms being invalid when Fields are blurred without inputting anything.

# Current Behaviour
If you render the following form and then click into and out of the name field, you'll see that eventually `formikProps.errors` is logged to the console as `{ name: undefined }`. This means that when you have a form with validation you end up with the form being invalid just because someone touched a field.

```js
<Formik
  initialValues={{ name: "formik" }}
  render={(formikProps) =>  {
      console.log(formikProps.errors);
      return (
        <FastField name="name" type="text" />
      );
  }}
/>
```

# Desired Behaviour
`FastField.handleBlur` causes errors to be removed from `FormikBag.errors`, nested to any level, when `FastField.state.error === undefined`. 

# Solution
I added an `unsetIn` function that is similar to `unset` from `lodash`, but it needs to do cleanup along the way. If you have nested form values and the key you're unsetting is the final one in that object, then that field.name, error object pair also needs to be removed so that there are no empty objects in `FormikBag.errors`.

I'm not particularly happy with how this code reads, so any suggestions for changes to how it works would be most welcome!

Formik Version: 1.0.0-beta-1
React Version: 16.2.0
OS: OS X 10.11.6
Node Version: 9.11.1
Package Manager and Version: npm@5.6.0
