### PR TITLE
Add apiErrors and setApiErrors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "create-react-context": "^0.2.2",
     "hoist-non-react-statics": "^2.5.0",
+    "lodash": "^4.17.10",
     "lodash.clonedeep": "^4.5.0",
     "lodash.topath": "4.5.2",
     "prop-types": "^15.6.1",
@@ -54,6 +55,7 @@
     "@pisano/enzyme": "^3.3.0-pisano.public.1",
     "@pisano/enzyme-adapter-react-16": "^1.1.1-pisano.public.1",
     "@types/jest": "^22.2.3",
+    "@types/lodash": "^4.14.108",
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.topath": "4.5.3",
     "@types/react": "16.0.28",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ const buildUmd = ({ env }) => ({
           'bool',
           'element',
         ],
+        'node_modules/lodash/lodash.js': ['omit'],
       },
     }),
     sourceMaps(),

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -36,6 +36,8 @@ export interface FormikState<Values> {
   error?: any;
   /** map of field names to specific error for that field */
   errors: FormikErrors<Values>;
+  /** map of field names to specific api error for that field */
+  apiErrors: FormikErrors<Values>;
   /** map of field names to whether the field has been touched */
   touched: FormikTouched<Values>;
   /** whether the form is currently submitting */
@@ -69,6 +71,8 @@ export interface FormikActions<Values> {
    * @deprecated since 0.8.0
    */
   setError(e: any): void;
+  /** Manually set apiErrors object */
+  setApiErrors(errors: FormikErrors<Values>): void;
   /** Manually set errors object */
   setErrors(errors: FormikErrors<Values>): void;
   /** Manually set isSubmitting */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,6 +79,22 @@ export function setNestedObjectValues<T>(
   return response;
 }
 
+/**
+ * Recursively creates an array of keys of a nested object
+ * @param obj
+ * @param path
+ */
+export function deepKeys(obj: { [field: string]: any }, path: string = '') {
+  return Object.keys(obj).reduce((acc: any[], key: string) => {
+    if (isObject(obj[key])) {
+      acc = acc.concat(deepKeys(obj[key], path + key + '.'));
+    } else {
+      acc.push(path + key);
+    }
+    return acc;
+  }, []);
+}
+
 // Assertions
 
 /** @private is the given object a Function? */

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,9 +84,9 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
-  version "4.14.88"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.88.tgz#97eaf2dc668f33ed8e511a5b627035f4ea20b0f5"
+"@types/lodash@*", "@types/lodash@^4.14.108":
+  version "4.14.108"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.108.tgz#02656af3add2e5b3174f830862c47421c00ef817"
 
 "@types/node@*":
   version "8.0.57"
@@ -6198,6 +6198,12 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
 string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
 


### PR DESCRIPTION
Fixes #150.

Exposes new `apiErrors` and `setApiErrors` props. `apiErrors` are automatically removed on a field-by-field basis with `handleChange` events and `setValues` / `setFieldValue` calls.

Users who want all errors in one prop could do:
```jsx
import { merge } from 'lodash';

<Formik {...props}>
  {(errors: validationErrors, apiErrors) => {
    const errors = merge(validationErrors, apiErrors);
    return (...);
  }
</Formik>
```