### PR TITLE
utils setIn() is cloning too much and kills PureComponent

### DIFF
--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -197,6 +197,13 @@ describe('utils', () => {
       expect(obj).toEqual({ x: 'y' });
       expect(newObj).toEqual({ x: 'y', a: { x: { c: 'value' } } });
     });
+
+    it('does not clone unaffected keys of the object', () => {
+      const obj = { x: { name: 'n1', arr: [1] } };
+      const newObj = setIn(obj, 'x.name', 'n2');
+
+      expect(newObj.x.arr).toBe(obj.x.arr);
+    });
   });
 
   describe('isPromise', () => {


### PR DESCRIPTION
I am using formik in a rather complex and nested form application and we lately ran into some performance issues.

Some of our ```render()``` props of Field/FieldArray are containing lots of other components. Every change rerenders all of them down the tree. We tried to wrap those component inside ```render()``` with PureComponent to minimize performance impact.

But it does not help, because the current implementation of ```setIn``` is cloning object keys even if it is not necessary. This kills PureComponent.

I added a failing test case in this pull request.

This pull request is not to be merged (not yet) - but rather to discuss if this is expected behavior or a bug which should be addressed?
