### PR TITLE
Update yup import

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ export const MyApp: React.SFC<{} /* whatever */> = () => {
 
 ```tsx
 import React from 'react';
-import Yup from 'yup';
+import * as Yup from 'yup';
 import { withFormik, FormikProps, FormikErrors, Form, Field } from 'formik';
 
 // Shape of form values


### PR DESCRIPTION
bring docs here inline with latest `yup` version which removed the default export in favor of named ones