### PR TITLE
fix undefined var in react native

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -273,7 +273,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
 
     if (
       process.env.NODE_ENV !== 'production' &&
-      document &&
+      typeof document !== 'undefined' &&
       document.activeElement
     ) {
       const type =


### PR DESCRIPTION
This fixes an error in RN where `document` is not defined.