### PR TITLE
[docs] Update examples using Yup

### DIFF
--- a/examples/CustomInputs.js
+++ b/examples/CustomInputs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Formik, Field, Form } from 'formik';
-import Yup from 'yup';
+import * as Yup from 'yup';
 
 const SignUp = () => (
   <div>
@@ -116,7 +116,7 @@ const Fieldset = ({ component = 'input', render, name, label, ...rest }) => (
     render={({ field, form }) => {
       const error = form.touched[name] && form.errors[name];
       const classes = error ? 'fieldset fieldset--error' : 'fieldset';
-      
+
       return (
         <div className={classes}>
           <label htmlFor={name}>{label}</label>

--- a/examples/SchemaValidation.js
+++ b/examples/SchemaValidation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Formik, Field, Form } from 'formik';
-import Yup from 'yup';
+import * as Yup from 'yup';
 
 // While you can use any validation library (or write you own), Formik
 // comes with special support for Yup by @jquense. It has a builder API like

--- a/examples/withFormik.js
+++ b/examples/withFormik.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Yup from 'yup';
+import * as Yup from 'yup';
 import { withFormik } from '../src/formik';
 
 const formikEnhancer = withFormik({


### PR DESCRIPTION
The latest version of Yup (0.25) removes the default export. I updated the examples where Yup is used, so (hopefully!) nobody else beats their head against a wall for half a day trying to get validation to work 😭 

[Issue on Yup for context](https://github.com/jquense/yup/issues/218)