### PR TITLE
Fix #673. Fix fastfield using cDU

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -26,8 +26,6 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   FieldAttributes<Props> & { formik: FormikContext<Values> },
   FastFieldState
 > {
-  reset: (nextValues?: any) => void;
-
   constructor(
     props: FieldAttributes<Props> & { formik: FormikContext<Values> }
   ) {
@@ -36,15 +34,6 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
       value: getIn(props.formik.values, props.name),
       error: getIn(props.formik.errors, props.name),
     };
-
-    this.reset = (nextValues?: any) => {
-      this.setState({
-        value: getIn(nextValues, props.name),
-        error: getIn(props.formik.errors, props.name),
-      });
-    };
-
-    props.formik.registerField(props.name, this.reset);
 
     const { render, children, component } = props;
 
@@ -80,10 +69,6 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
     if (!isEqual(nextFieldError, prevFieldError)) {
       this.setState({ error: nextFieldError });
     }
-  }
-
-  componentWillUnmount() {
-    this.props.formik.unregisterField(this.props.name);
   }
 
   handleChange = (e: React.ChangeEvent<any>) => {

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -8,7 +8,7 @@ import { connect } from './connect';
 import { FormikContext } from './types';
 import { getIn, isEmptyChildren, isFunction, isPromise, setIn } from './utils';
 
-export interface FastFieldState {
+export interface FastFieldState<Props, Values> {
   value: any;
   error?: string;
 }
@@ -24,28 +24,9 @@ function isEqualExceptForKey(a: any, b: any, path: string) {
  */
 class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   FieldAttributes<Props> & { formik: FormikContext<Values> },
-  FastFieldState
+  FastFieldState<Props, Values>
 > {
   reset: (nextValues?: any) => void;
-
-  static getDerivedStateFromProps(
-    nextProps: any /* FieldAttributes<Props> & { formik: FormikContext<Values> }*/,
-    prevState: FastFieldState
-  ) {
-    const nextFieldValue = getIn(nextProps.formik.values, nextProps.name);
-    const nextFieldError = getIn(nextProps.formik.errors, nextProps.name);
-
-    let nextState = null;
-    if (!isEqual(nextFieldValue, prevState.value)) {
-      nextState = { ...prevState, value: nextFieldValue };
-    }
-
-    if (!isEqual(nextFieldError, prevState.error)) {
-      nextState = { ...prevState, error: nextFieldError };
-    }
-
-    return nextState;
-  }
 
   constructor(
     props: FieldAttributes<Props> & { formik: FormikContext<Values> }
@@ -81,6 +62,24 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
       !(render && children && !isEmptyChildren(children)),
       'You should not use <FastField render> and <FastField children> in the same <FastField> component; <FastField children> will be ignored'
     );
+  }
+
+  componentDidUpdate(
+    prevProps: any /* FieldAttributes<Props> & { formik: FormikContext<Values> }*/,
+    _state: FastFieldState<any, any>
+  ) {
+    const nextFieldValue = getIn(this.props.formik.values, this.props.name);
+    const nextFieldError = getIn(this.props.formik.errors, this.props.name);
+    const prevFieldValue = getIn(prevProps.formik.values, prevProps.name);
+    const prevFieldError = getIn(prevProps.formik.errors, prevProps.name);
+
+    if (!isEqual(nextFieldValue, prevFieldValue)) {
+      this.setState({ value: nextFieldValue });
+    }
+
+    if (!isEqual(nextFieldError, prevFieldError)) {
+      this.setState({ error: nextFieldError });
+    }
   }
 
   componentWillUnmount() {

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -8,7 +8,7 @@ import { connect } from './connect';
 import { FormikContext } from './types';
 import { getIn, isEmptyChildren, isFunction, isPromise, setIn } from './utils';
 
-export interface FastFieldState<Props, Values> {
+export interface FastFieldState {
   value: any;
   error?: string;
 }
@@ -24,7 +24,7 @@ function isEqualExceptForKey(a: any, b: any, path: string) {
  */
 class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   FieldAttributes<Props> & { formik: FormikContext<Values> },
-  FastFieldState<Props, Values>
+  FastFieldState
 > {
   reset: (nextValues?: any) => void;
 
@@ -66,7 +66,7 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
 
   componentDidUpdate(
     prevProps: any /* FieldAttributes<Props> & { formik: FormikContext<Values> }*/,
-    _state: FastFieldState<any, any>
+    _state: FastFieldState
   ) {
     const nextFieldValue = getIn(this.props.formik.values, this.props.name);
     const nextFieldError = getIn(this.props.formik.errors, this.props.name);

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -40,7 +40,6 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   hbCache: {
     [key: string]: (e: any) => void;
   } = {};
-  fields: { [field: string]: (nextValues?: any) => void };
 
   constructor(props: FormikConfig<Values> & ExtraProps) {
     super(props);
@@ -51,7 +50,6 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       isSubmitting: false,
       submitCount: 0,
     };
-    this.fields = {};
     this.initialValues = props.initialValues || ({} as any);
 
     warning(
@@ -69,14 +67,6 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       'You should not use <Formik render> and <Formik children> in the same <Formik> component; <Formik children> will be ignored'
     );
   }
-
-  registerField = (name: string, resetFn: (nextValues?: any) => void) => {
-    this.fields[name] = resetFn;
-  };
-
-  unregisterField = (name: string) => {
-    delete this.fields[name];
-  };
 
   componentDidUpdate(prevProps: Readonly<FormikConfig<Values> & ExtraProps>) {
     // If the initialValues change, reset the form
@@ -419,7 +409,6 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       values,
       submitCount: 0,
     });
-    Object.keys(this.fields).map(f => this.fields[f](values));
   };
 
   handleReset = () => {
@@ -481,8 +470,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       ...this.getFormikComputedProps(),
 
       // FastField needs to communicate with Formik during resets
-      registerField: this.registerField,
-      unregisterField: this.unregisterField,
+
       handleBlur: this.handleBlur,
       handleChange: this.handleChange,
       handleReset: this.handleReset,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -225,10 +225,7 @@ export type FormikProps<Values> = FormikSharedConfig &
   FormikState<Values> &
   FormikActions<Values> &
   FormikHandlers &
-  FormikComputedProps<Values> & {
-    registerField(name: string, resetFn: ((nextValues?: any) => void)): void;
-    unregisterField(name: string): void;
-  };
+  FormikComputedProps<Values>;
 
 /**
  * State, handlers, and helpers made available to Formik's primitive components through context.

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -69,13 +69,12 @@ describe('A <Field />', () => {
 
     it('calls validate during onBlur if present', () => {
       const validate = jest.fn(noop);
-      const registerField = jest.fn(noop);
+
       const setFormikState = jest.fn(noop);
       const tree = makeFieldTree({
         name: 'name',
         validate,
         formik: {
-          registerField,
           setFormikState,
           validateOnBlur: true,
         },
@@ -88,20 +87,18 @@ describe('A <Field />', () => {
         },
       });
       expect(setFormikState).toHaveBeenCalled();
-      expect(registerField).toHaveBeenCalled();
       expect(validate).toHaveBeenCalled();
     });
 
     it('does NOT call validate during onBlur if validateOnBlur is set to false', () => {
       const validate = jest.fn(noop);
-      const registerField = jest.fn(noop);
+
       const setFormikState = jest.fn(noop);
       const tree = makeFieldTree({
         name: 'name',
         validate,
         formik: {
           setFormikState,
-          registerField,
           validateOnBlur: false,
         },
       });
@@ -177,9 +174,7 @@ describe('A <Field />', () => {
 
     it('assigns innerRef as a ref to string components', () => {
       const innerRef = jest.fn();
-      const fmk = {
-        registerField: jest.fn(noop),
-      };
+      const fmk = {};
       const tree = mount(
         <Field.WrappedComponent
           name="name"


### PR DESCRIPTION
I (think) this fixes `<FastField>` on 16.4. I wasn't sure if we should do this in `componentDidUpdate` or if we should do this by storing old props on state and use `getDerivedStateFromProps`

https://reactjs.org/blog/2018/05/23/react-v-16-4.html#2-compare-incoming-props-to-previous-props-when-computing-controlled-values