### PR TITLE
Fix #483. Run Field validate() prior to submit

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -63,7 +63,7 @@ export interface FieldConfig {
   /**
    * Validate a single field value independently
    */
-  validate?: ((value: any) => string | Function | Promise<void> | undefined);
+  validate?: ((value: any) => string | Promise<void> | undefined);
 
   /**
    * Field name
@@ -94,7 +94,7 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
     props: FieldAttributes<Props> & { formik: FormikContext<Values> }
   ) {
     super(props);
-    const { render, children, component } = this.props;
+    const { render, children, component, formik } = this.props;
     warning(
       !(component && render),
       'You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored'
@@ -109,6 +109,33 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
       !(render && children && !isEmptyChildren(children)),
       'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
     );
+
+    // Register the Field with the parent Formik. Parent will cycle through
+    // registered Field's validate fns right prior to submit
+    this.props.formik.registerField(this.props.name, {
+      validate: this.props.validate,
+    });
+  }
+
+  componentDidUpdate(
+    prevProps: FieldAttributes<Props> & { formik: FormikContext<Values> }
+  ) {
+    if (this.props.name !== prevProps.name) {
+      this.props.formik.unregisterField(prevProps.name);
+      this.props.formik.registerField(this.props.name, {
+        validate: this.props.validate,
+      });
+    }
+
+    if (this.props.validate !== prevProps.validate) {
+      this.props.formik.registerField(this.props.name, {
+        validate: this.props.validate,
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.formik.unregisterField(this.props.name);
   }
 
   handleChange = (e: React.ChangeEvent<any>) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -226,7 +226,15 @@ export type FormikProps<Values> = FormikSharedConfig &
   FormikActions<Values> &
   FormikHandlers &
   FormikComputedProps<Values> & {
-    registerField(name: string, resetFn: ((nextValues?: any) => void)): void;
+    registerField(
+      name: string,
+      fns: {
+        reset?: ((nextValues?: any) => void);
+        validate?: ((
+          value: any
+        ) => string | Function | Promise<void> | undefined);
+      }
+    ): void;
     unregisterField(name: string): void;
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,5 +105,5 @@ export const isEmptyChildren = (children: any): boolean =>
   React.Children.count(children) === 0;
 
 /** @private is the given object/value a promise? */
-export const isPromise = (value: any): boolean =>
+export const isPromise = (value: any): value is PromiseLike<any> =>
   isObject(value) && isFunction(value.then);


### PR DESCRIPTION
This is half of the PR to fix #483. Still need to reimplement the pre-submit behavior if `validationSchema` is present.

This code is gross. Comments welcome.