### PR TITLE
Use fbjs's getActiveElement for better IE support

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -19,6 +19,7 @@ import {
   isString,
   setIn,
   setNestedObjectValues,
+  getActiveElement,
 } from './utils';
 
 export class Formik<ExtraProps = {}, Values = object> extends React.Component<
@@ -271,24 +272,26 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       e.preventDefault();
     }
 
+    // Warn if form submission is triggered by a <button> without a
+    // specified `type` attribute during development. This mitigates
+    // a common gotcha in forms with both reset and submit buttons,
+    // where the dev forgets to add type="button" to the reset button.
     if (
       process.env.NODE_ENV !== 'production' &&
-      typeof document !== 'undefined' &&
-      document.activeElement
+      typeof document !== 'undefined'
     ) {
-      const type =
-        document.activeElement.attributes &&
-        document.activeElement.attributes.getNamedItem('type');
-
-      const submitTriggeredFromButton =
-        document.activeElement instanceof HTMLButtonElement;
-
-      const buttonHasType = submitTriggeredFromButton && !!type;
-
-      if (submitTriggeredFromButton) {
+      // Safely get the active element (works with IE)
+      const activeElement = getActiveElement();
+      if (
+        activeElement !== null &&
+        activeElement instanceof HTMLButtonElement
+      ) {
         warning(
-          buttonHasType,
-          'You submitted a Formik form using a button with an unspecified type.  Most browsers default button elements to type="submit". If this is not a submit button please add type="button".'
+          !!(
+            activeElement.attributes &&
+            activeElement.attributes.getNamedItem('type')
+          ),
+          'You submitted a Formik form using a button with an unspecified `type` attribute.  Most browsers default button elements to `type="submit"`. If this is not a submit button, please add `type="button"`.'
         );
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,3 +107,26 @@ export const isEmptyChildren = (children: any): boolean =>
 /** @private is the given object/value a promise? */
 export const isPromise = (value: any): boolean =>
   isObject(value) && isFunction(value.then);
+
+/**
+ * Same as document.activeElement but wraps in a try-catch block. In IE it is
+ * not safe to call document.activeElement if there is nothing focused.
+ *
+ * The activeElement will be null only if the document or document body is not
+ * yet defined.
+ *
+ * @param {?Document} doc Defaults to current document.
+ * @return {Element | null}
+ * @see https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/dom/getActiveElement.js
+ */
+export function getActiveElement(doc?: Document): Element | null {
+  doc = doc || (typeof document !== 'undefined' ? document : undefined);
+  if (typeof doc === 'undefined') {
+    return null;
+  }
+  try {
+    return doc.activeElement || doc.body;
+  } catch (e) {
+    return doc.body;
+  }
+}

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -1123,7 +1123,7 @@ describe('<Formik>', () => {
     });
     expect(global.console.error).toHaveBeenCalledWith(
       expect.stringMatching(
-        /Warning: You submitted a Formik form using a button with an unspecified type./
+        /Warning: You submitted a Formik form using a button with an unspecified `type./
       )
     );
 


### PR DESCRIPTION
Some IE throws if nothing is focused and activeElement is referenced. This adds Facebook's `getActiveElement` workaround and streamlines logic a bit.

