### PR TITLE
Pass props down in FieldArray

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -260,9 +260,10 @@ class FieldArrayInner<Values = {}> extends React.Component<
         validationSchema: _validationSchema,
         ...restOfFormik
       },
+      ...rest
     } = this.props;
 
-    const props = { ...arrayHelpers, form: restOfFormik, name };
+    const props = { ...arrayHelpers, form: restOfFormik, name, ...rest };
 
     return component
       ? React.createElement(component as any, props)

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -36,6 +36,27 @@ describe('<FieldArray />', () => {
     );
   });
 
+  it('renders component with custom props', () => {
+    const customPropValue = 'beep';
+    const TestComponent = ({ customProp }) => {
+      expect(customProp).toBe(customPropValue);
+      return null;
+    };
+
+    ReactDOM.render(
+      <TestForm
+        component={() => (
+          <FieldArray
+            name="friends"
+            component={TestComponent}
+            customProp={customPropValue}
+          />
+        )}
+      />,
+      node
+    );
+  });
+
   it('renders with render callback with array helpers as props', () => {
     ReactDOM.render(
       <TestForm


### PR DESCRIPTION
Right now custom props aren't being passed down to the component when using:

`<FieldArray component={CustomComponent} customProp={beep}/>`

It works as expected already with Field, so extending the same functionality to FieldArray.