### PR TITLE
Add initialErrors to Formik and mapPropsToErrors to withFormik

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,8 @@ in `initialValues`. If you are using [`validationSchema`] (which you should be),
 keys and shape will match your schema exactly. Internally, Formik transforms raw
 [Yup validation errors](https://github.com/jquense/yup#validationerrorerrors-string--arraystring-value-any-path-string)
 on your behalf. If you are using [`validate`], then that function will determine
-the `errors` objects shape.
+the `errors` objects shape. If you are using [`initialErrors`] and no further
+validation was performed yet, it will match the ones provided.
 
 #### `handleBlur: (e: any) => void`
 
@@ -134,7 +135,7 @@ Trigger a form submission.
 
 #### `submitCount: number`
 
-Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling  
+Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling
 [`handleReset`](#handlereset---void). `submitCount` is readonly computed property and should not be mutated directly.
 
 #### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
@@ -267,7 +268,7 @@ don’t use both in the same `<Formik>`.
 ### `enableReinitialize?: boolean`
 
 Default is `false`. Control whether Formik should reset the form if
-[`initialValues`] changes (using deep equality).
+[`initialValues`] or [`initialErrors`] changes (using deep equality).
 
 ### `isInitialValid?: boolean`
 
@@ -275,7 +276,7 @@ Default is `false`. Control the initial value of [`isValid`] prop prior to
 mount. You can also pass a function. Useful for situations when you want to
 enable/disable a submit and reset buttons on initial mount.
 
-### `initialValues?: Values`
+### `initialValues: Values`
 
 Initial field values of the form, Formik will make these values available to
 render methods component as [`props.values`][`values`].
@@ -284,8 +285,16 @@ Even if your form is empty by default, you must initialize all fields with
 initial values otherwise React will throw an error saying that you have changed
 an input from uncontrolled to controlled.
 
-Note: `initialValues` not available to the higher-order component, use
+Note: `initialValues` are not available to the higher-order component, use
 [`mapPropsToValues`] instead.
+
+### `initialErrors?: FormikErrors<Values>`
+
+Initial errors for field values of the form, Formik will make these values
+available to render methods component as [`props.errors`][`errors`].
+
+Note: `initialErrors` are not available to the higher-order component, use
+[`mapPropsToErrors`] instead.
 
 ### `onReset?: (values: Values, formikBag: FormikBag) => void`
 
@@ -791,6 +800,13 @@ will map all props that are not functions to the inner component's
 
 Even if your form is not receiving any props from its parent, use
 `mapPropsToValues` to initialize your forms empty state.
+
+#### `mapPropsToErrors?: (props: Props) => FormikErrors<Values>`
+
+If this option is specified, then Formik will transfer its results into
+updatable form state and make these values available to the new component as
+[`props.errors`][`errors`]. If `mapPropsToErrors` is not specified, then no
+[`initialErrors`] will be passed down.
 
 #### `validate?: (values: Values, props: Props) => FormikErrors<Values> | Promise<any>`
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -49,7 +49,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     this.state = {
       values: props.initialValues || {},
       errors: props.initialErrors || {},
-      touched: {},
+      touched: props.initialErrors
+        ? setNestedObjectValues(props.initialErrors, true)
+        : {},
       isSubmitting: false,
       submitCount: 0,
     };
@@ -428,7 +430,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       isSubmitting: false,
       values,
       errors,
-      touched: {},
+      touched: setNestedObjectValues(errors, true),
       error: undefined,
       status: undefined,
       submitCount: 0,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -52,10 +52,12 @@ export interface FormikState<Values> {
 export interface FormikComputedProps<Values> {
   /** True if any input has been touched. False otherwise. */
   readonly dirty: boolean;
-  /** Result of isInitiallyValid on mount, then whether true values pass validation. */
+  /** Result of isInitialValid on mount, then whether values pass validation. */
   readonly isValid: boolean;
-  /** initialValues */
+  /** Values passed to the form as initialValues */
   readonly initialValues: Values;
+  /** Errors passed to the form as initialErrors */
+  readonly initialErrors: FormikErrors<Values>;
 }
 
 /**
@@ -168,6 +170,11 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * Initial values of the form
    */
   initialValues: Values;
+
+  /**
+   * Initial errors of the form
+   */
+  initialErrors?: FormikErrors<Values>;
 
   /**
    * Reset handler

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -9,6 +9,7 @@ import {
   FormikSharedConfig,
   FormikState,
   FormikValues,
+  FormikErrors,
 } from './types';
 import { isFunction } from './utils';
 
@@ -49,6 +50,11 @@ export interface WithFormikConfig<
    * Map props to the form values
    */
   mapPropsToValues?: (props: Props) => Values;
+
+  /**
+   * Map props to the form errors
+   */
+  mapPropsToErrors?: (props: Props) => FormikErrors<Values>;
 
   /**
    * @deprecated in 0.9.0 (but needed to break TS types)
@@ -99,6 +105,7 @@ export function withFormik<
     }
     return val as Values;
   },
+  mapPropsToErrors,
   ...config
 }: WithFormikConfig<Props, Values, Payload>): ComponentDecorator<
   Props,
@@ -151,6 +158,7 @@ export function withFormik<
             validate={config.validate && this.validate}
             validationSchema={config.validationSchema && this.validationSchema}
             initialValues={mapPropsToValues(this.props)}
+            initialErrors={mapPropsToErrors && mapPropsToErrors(this.props)}
             onSubmit={this.handleSubmit as any}
             render={this.renderFormComponent}
           />

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -878,66 +878,127 @@ describe('<Formik>', () => {
   });
 
   describe('componentDidUpdate', () => {
-    let form: any, initialValues: any;
+    let form: any, initialValues: any, initialErrors: any;
     beforeEach(() => {
       initialValues = {
         name: 'formik',
         github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
         watchers: ['ian', 'sam'],
       };
+      initialErrors = {
+        watchers: 'should contain jam',
+      };
       form = new Formik({
         initialValues,
+        initialErrors,
         onSubmit: jest.fn(),
         enableReinitialize: true,
       });
       form.resetForm = jest.fn();
     });
 
-    it('should not resetForm if new initialValues are the same as previous', () => {
-      const newInitialValues = Object.assign({}, initialValues);
+    it('should not resetForm if new initialValues/initialErrors are the same as previous', () => {
+      const prevInitialValues = { ...initialValues };
+      const prevInitialErrors = { ...initialErrors };
       form.componentDidUpdate({
-        initialValues: newInitialValues,
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
         onSubmit: jest.fn(),
       });
       expect(form.resetForm).not.toHaveBeenCalled();
     });
 
     it('should resetForm if new initialValues are different than previous', () => {
-      const newInitialValues = {
+      const prevInitialValues = {
         ...initialValues,
         watchers: ['jared', 'ian', 'sam'],
       };
+      const prevInitialErrors = { ...initialErrors };
       form.componentDidUpdate({
-        initialValues: newInitialValues,
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
+        onSubmit: jest.fn(),
+      });
+      expect(form.resetForm).toHaveBeenCalled();
+    });
+
+    it('should resetForm if new initialErrors are different than previous', () => {
+      const prevInitialValues = { ...initialValues };
+      const prevInitialErrors = {
+        ...initialErrors,
+        watchers: 'Should contain jam & sam',
+      };
+      form.componentDidUpdate({
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
         onSubmit: jest.fn(),
       });
       expect(form.resetForm).toHaveBeenCalled();
     });
 
     it('should resetForm if new initialValues are deeply different than previous', () => {
-      const newInitialValues = {
+      const prevInitialValues = {
         ...initialValues,
         github: { repoUrl: 'different' },
       };
+      const prevInitialErrors = { ...initialErrors };
       form.componentDidUpdate({
-        initialValues: newInitialValues,
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
         onSubmit: jest.fn(),
       });
       expect(form.resetForm).toHaveBeenCalled();
     });
 
-    it('should NOT resetForm without enableReinitialize flag', () => {
+    it('should resetForm if new initialErrors are deeply different than previous', () => {
+      const prevInitialValues = { ...initialValues };
+      const prevInitialErrors = {
+        ...initialErrors,
+        watchers: ['old certificate', undefined],
+      };
+      form.componentDidUpdate({
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
+        onSubmit: jest.fn(),
+      });
+      expect(form.resetForm).toHaveBeenCalled();
+    });
+
+    it('should NOT resetForm without enableReinitialize flag (initialValues)', () => {
       form = new Formik({
         initialValues,
+        initialErrors,
         onSubmit: jest.fn(),
       });
       form.resetForm = jest.fn();
-      const newInitialValues = {
+      const prevInitialValues = {
         ...initialValues,
         watchers: ['jared', 'ian', 'sam'],
       };
+      const prevInitialErrors = { ...initialErrors };
       form.componentDidUpdate({
-        initialValues: newInitialValues,
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
+        onSubmit: jest.fn(),
+      });
+      expect(form.resetForm).not.toHaveBeenCalled();
+    });
+
+    it('should NOT resetForm without enableReinitialize flag (initialErrors)', () => {
+      form = new Formik({
+        initialValues,
+        initialErrors,
+        onSubmit: jest.fn(),
+      });
+      form.resetForm = jest.fn();
+      const prevInitialValues = { ...initialValues };
+      const prevInitialErrors = {
+        ...initialErrors,
+        watchers: [undefined, 'did you mean jam?'],
+      };
+      form.componentDidUpdate({
+        initialValues: prevInitialValues,
+        initialErrors: prevInitialErrors,
         onSubmit: jest.fn(),
       });
       expect(form.resetForm).not.toHaveBeenCalled();

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -877,131 +877,150 @@ describe('<Formik>', () => {
     });
   });
 
-  describe('componentDidUpdate', () => {
-    let form: any, initialValues: any, initialErrors: any;
-    beforeEach(() => {
-      initialValues = {
-        name: 'formik',
-        github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
-        watchers: ['ian', 'sam'],
-      };
-      initialErrors = {
-        watchers: 'should contain jam',
-      };
-      form = new Formik({
-        initialValues,
-        initialErrors,
-        onSubmit: jest.fn(),
+  describe('getDerivedStateFromProps', () => {
+    it('Merges values and initialValues if enableReinitialize', () => {
+      const newProps = {
+        initialValues: {
+          name: 'formik',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
         enableReinitialize: true,
-      });
-      form.resetForm = jest.fn();
-    });
-
-    it('should not resetForm if new initialValues/initialErrors are the same as previous', () => {
-      const prevInitialValues = { ...initialValues };
-      const prevInitialErrors = { ...initialErrors };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
         onSubmit: jest.fn(),
-      });
-      expect(form.resetForm).not.toHaveBeenCalled();
-    });
-
-    it('should resetForm if new initialValues are different than previous', () => {
-      const prevInitialValues = {
-        ...initialValues,
-        watchers: ['jared', 'ian', 'sam'],
       };
-      const prevInitialErrors = { ...initialErrors };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
-        onSubmit: jest.fn(),
+      const oldState = {
+        values: {
+          name: 'yan',
+        },
+        touched: {
+          name: true,
+        },
+        errors: {},
+        isSubmitting: false,
+        submitCount: 0,
+      };
+      const newState = Formik.getDerivedStateFromProps(newProps, oldState);
+      expect(newState).toEqual({
+        ...oldState,
+        values: {
+          name: 'yan',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
+        touched: {},
+        error: undefined,
+        status: undefined,
       });
-      expect(form.resetForm).toHaveBeenCalled();
     });
 
-    it('should resetForm if new initialErrors are different than previous', () => {
-      const prevInitialValues = { ...initialValues };
-      const prevInitialErrors = {
-        ...initialErrors,
-        watchers: 'Should contain jam & sam',
-      };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
+    it('Does not merge values and initialValues if not enableReinitialize', () => {
+      const newProps = {
+        initialValues: {
+          name: 'formik',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
+        enableReinitialize: false,
         onSubmit: jest.fn(),
-      });
-      expect(form.resetForm).toHaveBeenCalled();
+      };
+      const oldState = {
+        values: {
+          name: 'yan',
+        },
+        touched: {
+          name: true,
+        },
+        errors: {},
+        isSubmitting: false,
+        submitCount: 0,
+      };
+      const newState = Formik.getDerivedStateFromProps(newProps, oldState);
+      expect(newState).toEqual(oldState);
     });
 
-    it('should resetForm if new initialValues are deeply different than previous', () => {
-      const prevInitialValues = {
-        ...initialValues,
-        github: { repoUrl: 'different' },
-      };
-      const prevInitialErrors = { ...initialErrors };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
+    it('Merges errors and initialErrors if enableReinitialize', () => {
+      const newProps = {
+        initialValues: {
+          name: 'formik',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
+        initialErrors: {
+          name: 'too formy',
+          github: {
+            repoUrl: 'too official',
+          },
+        },
+        enableReinitialize: true,
         onSubmit: jest.fn(),
+      };
+      const oldState = {
+        values: {
+          name: 'yan',
+        },
+        touched: {
+          name: true,
+        },
+        errors: {
+          name: 'too yanny',
+        },
+        isSubmitting: false,
+        submitCount: 0,
+      };
+      const newState = Formik.getDerivedStateFromProps(newProps, oldState);
+      expect(newState).toEqual({
+        ...oldState,
+        values: {
+          name: 'yan',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
+        touched: {
+          name: true,
+          github: {
+            repoUrl: true,
+          },
+        },
+        errors: {
+          name: 'too yanny',
+          github: { repoUrl: 'too official' },
+        },
+        error: undefined,
+        status: undefined,
       });
-      expect(form.resetForm).toHaveBeenCalled();
     });
 
-    it('should resetForm if new initialErrors are deeply different than previous', () => {
-      const prevInitialValues = { ...initialValues };
-      const prevInitialErrors = {
-        ...initialErrors,
-        watchers: ['old certificate', undefined],
+    it('Does not merge errors and initialErrors if not enableReinitialize', () => {
+      const newProps = {
+        initialValues: {
+          name: 'formik',
+          github: { repoUrl: 'https://github.com/jaredpalmer/formik' },
+          watchers: ['ian', 'sam'],
+        },
+        initialErrors: {
+          name: 'too formy',
+          github: {
+            repoUrl: 'too official',
+          },
+        },
+        enableReinitialize: false,
+        onSubmit: jest.fn(),
       };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
-        onSubmit: jest.fn(),
-      });
-      expect(form.resetForm).toHaveBeenCalled();
-    });
-
-    it('should NOT resetForm without enableReinitialize flag (initialValues)', () => {
-      form = new Formik({
-        initialValues,
-        initialErrors,
-        onSubmit: jest.fn(),
-      });
-      form.resetForm = jest.fn();
-      const prevInitialValues = {
-        ...initialValues,
-        watchers: ['jared', 'ian', 'sam'],
+      const oldState = {
+        values: {
+          name: 'yan',
+        },
+        touched: {
+          name: true,
+        },
+        errors: {
+          name: 'too yanny',
+        },
+        isSubmitting: false,
+        submitCount: 0,
       };
-      const prevInitialErrors = { ...initialErrors };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
-        onSubmit: jest.fn(),
-      });
-      expect(form.resetForm).not.toHaveBeenCalled();
-    });
-
-    it('should NOT resetForm without enableReinitialize flag (initialErrors)', () => {
-      form = new Formik({
-        initialValues,
-        initialErrors,
-        onSubmit: jest.fn(),
-      });
-      form.resetForm = jest.fn();
-      const prevInitialValues = { ...initialValues };
-      const prevInitialErrors = {
-        ...initialErrors,
-        watchers: [undefined, 'did you mean jam?'],
-      };
-      form.componentDidUpdate({
-        initialValues: prevInitialValues,
-        initialErrors: prevInitialErrors,
-        onSubmit: jest.fn(),
-      });
-      expect(form.resetForm).not.toHaveBeenCalled();
+      const newState = Formik.getDerivedStateFromProps(newProps, oldState);
+      expect(newState).toEqual(oldState);
     });
   });
 

--- a/website/src/examples/AsyncValidationOuter.js
+++ b/website/src/examples/AsyncValidationOuter.js
@@ -78,6 +78,9 @@ class SignIn extends React.Component {
         errors: {},
         values: { ...prevState.values, email: values.email },
       }));
+      setTimeout(() => {
+        alert(JSON.stringify(values, null, 2));
+      }, 500);
     }
   }
 }

--- a/website/src/examples/AsyncValidationOuter.js
+++ b/website/src/examples/AsyncValidationOuter.js
@@ -14,6 +14,9 @@ const validate = values => {
   } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {
     errors.email = 'Invalid email address';
   }
+  if (!values.password || values.password.length < 3) {
+    errors.password = 'Password must be at least 3 characters long'
+  }
   return errors;
 };
 
@@ -21,7 +24,10 @@ class SignIn extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { errors: {} };
+    this.state = {
+      errors: {},
+      values: { email: '', password: '' },
+    };
   }
 
   render() {
@@ -29,10 +35,7 @@ class SignIn extends React.Component {
       <div>
         <h1>Sign In</h1>
         <Formik
-          initialValues={{
-            email: '',
-            password: '',
-          }}
+          initialValues={this.state.values}
           initialErrors={this.state.errors}
           enableReinitialize={true}
           validate={validate}
@@ -52,6 +55,10 @@ class SignIn extends React.Component {
               <label htmlFor="password">Password</label>
               <Field name="password" type="password" />
 
+              {errors.password && touched.password &&
+                <div className="field-error">{errors.password}</div>
+              }
+
               <button type="submit">Sign In</button>
             </Form>
           )}
@@ -62,9 +69,15 @@ class SignIn extends React.Component {
 
   handleSubmit = (values) => {
     if (EXISTING_EMAILS.indexOf(values.email) === -1) {
-      this.setState({ errors: { email: 'That account does not exist' } });
+      this.setState((prevState) => ({
+        errors: { email: 'That account does not exist' },
+        values: { ...prevState.values, email: values.email },
+      }));
     } else {
-      this.setState({ errors: {} });
+      this.setState((prevState) => ({
+        errors: {},
+        values: { ...prevState.values, email: values.email },
+      }));
     }
   }
 }

--- a/website/src/examples/AsyncValidationOuter.js
+++ b/website/src/examples/AsyncValidationOuter.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Formik, Field, Form } from 'formik';
+
+const EXISTING_EMAILS = [
+  "foo@bar.com",
+  "baz@buzz.io",
+  "asdf@qwerty.com",
+];
+
+const validate = values => {
+  let errors = {};
+  if (!values.email) {
+    errors.email = 'Required';
+  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {
+    errors.email = 'Invalid email address';
+  }
+  return errors;
+};
+
+class SignIn extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { errors: {} };
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>Sign In</h1>
+        <Formik
+          initialValues={{
+            email: '',
+            password: '',
+          }}
+          initialErrors={this.state.errors}
+          enableReinitialize={true}
+          validate={validate}
+          onSubmit={(values, { setSubmitting }) => {
+            setSubmitting(true);
+            this.handleSubmit(values);
+          }}
+          render={({ errors, touched }) => (
+            <Form>
+              <label htmlFor="email">Email</label>
+              <Field name="email" placeholder="john@acme.com" type="email" />
+
+              {errors.email && touched.email &&
+                <div className="field-error">{errors.email}</div>
+              }
+
+              <label htmlFor="password">Password</label>
+              <Field name="password" type="password" />
+
+              <button type="submit">Sign In</button>
+            </Form>
+          )}
+        />
+      </div>
+    );
+  }
+
+  handleSubmit = (values) => {
+    if (EXISTING_EMAILS.indexOf(values.email) === -1) {
+      this.setState({ errors: { email: 'That account does not exist' } });
+    } else {
+      this.setState({ errors: {} });
+    }
+  }
+}
+
+export default () => <SignIn />;

--- a/website/src/navigation.ts
+++ b/website/src/navigation.ts
@@ -19,6 +19,7 @@ export const APILINKS: {
       Basic: '/examples/basic',
       'Sync Validation': '/examples/sync-validation',
       'Async Validation': '/examples/async-validation',
+      'Async Validation with initialErrors': '/examples/async-validation-outer',
       'Schema Validation': '/examples/schema-validation',
       'Custom Inputs': '/examples/custom-inputs',
       Arrays: '/examples/arrays',

--- a/website/src/pages/examples/async-validation-outer.tsx
+++ b/website/src/pages/examples/async-validation-outer.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { Example } from 'components/Example';
+import { Form } from 'formik';
+
+const ExampleComponent = require('../../examples/AsyncValidationOuter.js');
+const ExampleCode = require('!raw-loader!../../examples/AsyncValidationOuter.js');
+
+const BasicExample: React.SFC<any> = props => {
+  return (
+    <Example
+      js={ExampleCode}
+      component={ExampleComponent}
+      color="indigo"
+      title="Async Validation with initialErrors"
+      description="An example of a another approach to async validation"
+    />
+  );
+};
+
+export default BasicExample;


### PR DESCRIPTION
UPDATED

This PR adds:

- `initialErrors` to `<Formik />`
- `mapPropsToErrors` to `withFormik`

It also extends tests around `initialValues` and `enableReinitialize` to handle `initialErrors`.

Interactions with other features:

- `isInitialValid` could be inferred from `initialErrors` if not provided explicitly, but the default `false` probably makes more sense with or without `initialErrors` so I left it as is.
- `touched` is affected by `initialErrors`, since the docs usually recommend this pattern for rendering error messages: `{errors.fieldName && touched.fieldName && <FieldError error={errors.fieldName}>}` and the validation message would not be displayed otherwise.

One other major change is the removal of `componentDidUpdate`. It is replaced by `getDerivedStateFromProps`, because `componentDidUpdate` should `setState` only if the props *changed*. If `initialErrors` doesn't change, the errors are still present and should not be ignored. Old tests for `componentDidUpdate` were removed and replaced with tests for `getDerivedStateFromProps`. 

The logic for resolving `values` and `errors` from `props.initial{Values,Errors}` and `state.{values,errors}` is also changed from `resetForm` to object merge, where local state always overwrites props provided values. This allow us to display the most recent local validation error if there is one, or the original error, if there are no local validation errors produced.

Tasks:

- [x] Add docs
- [x] Add example

Partially Fixes: https://github.com/jaredpalmer/formik/issues/288