### PR TITLE
Use FormikConsumer rather than connect for Field/FastField

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -307,9 +307,7 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   }
 }
 
-export class FastField<Props = {}> extends React.Component<
-  FieldAttributes<Props>
-> {
+export class FastField<Props> extends React.Component<FieldAttributes<Props>> {
   static WrappedComponent = FastFieldInner;
 
   render() {

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -3,7 +3,7 @@ import isEqual from 'react-fast-compare';
 import warning from 'warning';
 import { FieldAttributes, FieldConfig, FieldProps } from './Field';
 import { validateYupSchema, yupToFormErrors } from './Formik';
-import { connect } from './connect';
+import { FormikConsumer } from './connect';
 import { FormikContext } from './types';
 import { getIn, isEmptyChildren, isFunction, isPromise, setIn } from './utils';
 
@@ -307,4 +307,16 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   }
 }
 
-export const FastField = connect<FieldAttributes<any>, any>(FastFieldInner);
+export class FastField<Props = {}> extends React.Component<
+  FieldAttributes<Props>
+> {
+  static WrappedComponent = FastFieldInner;
+
+  render() {
+    return (
+      <FormikConsumer>
+        {formik => <FastFieldInner {...this.props} formik={formik} />}
+      </FormikConsumer>
+    );
+  }
+}

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -226,7 +226,7 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
   }
 }
 
-export class Field<Props = {}> extends React.Component<FieldAttributes<Props>> {
+export class Field<Props> extends React.Component<FieldAttributes<Props>> {
   static WrappedComponent = FieldInner;
 
   render() {

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import warning from 'warning';
-import { connect } from './connect';
+import { FormikConsumer } from './connect';
 import {
   FormikProps,
   GenericFieldHTMLAttributes,
@@ -226,4 +226,14 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
   }
 }
 
-export const Field = connect<FieldAttributes<any>, any>(FieldInner);
+export class Field<Props = {}> extends React.Component<FieldAttributes<Props>> {
+  static WrappedComponent = FieldInner;
+
+  render() {
+    return (
+      <FormikConsumer>
+        {formik => <FieldInner {...this.props} formik={formik} />}
+      </FormikConsumer>
+    );
+  }
+}


### PR DESCRIPTION
The `connect` path shouldn't be needed for these components since there are no statics we need to hoist, so it's simpler to just use `<FormikConsumer>` directly and provide the `WrappedComponent` as a static prop on the class. 

This way we get the generics that we need to properly track the types in any custom component.