### PR TITLE
Improve field level validation

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -8,6 +8,7 @@ import CustomImputs from '../examples/CustomInputs';
 import MultistepWizard from '../examples/MultistepWizard';
 import SchemaValidation from '../examples/SchemaValidation';
 import SyncValidation from '../examples/SyncValidation';
+import FieldLevelValidation from '../examples/FieldLevelValidation';
 
 const AsyncValidationCode = require('!raw-loader!../examples/AsyncValidation');
 const ArraysCode = require('!raw-loader!../examples/Arrays');
@@ -16,6 +17,7 @@ const CustomInputsCode = require('!raw-loader!../examples/CustomInputs');
 const MultistepWizardCode = require('!raw-loader!../examples/MultistepWizard');
 const SchemaValidationCode = require('!raw-loader!../examples/SchemaValidation');
 const SyncValidationCode = require('!raw-loader!../examples/SyncValidation');
+const FieldLevelValidationCode = require('!raw-loader!../examples/FieldLevelValidation');
 
 const Code = props => (
   <pre
@@ -105,6 +107,16 @@ storiesOf('Example', module)
           <SyncValidation />
         </main>
         <Code>{SyncValidationCode}</Code>
+      </div>
+    );
+  })
+  .add('FieldLevelValidation', () => {
+    return (
+      <div className="story">
+        <main>
+          <FieldLevelValidation />
+        </main>
+        <Code>{FieldLevelValidationCode}</Code>
       </div>
     );
   });

--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -24,18 +24,19 @@ const CombinedValidationsCode = require('!raw-loader!../examples/CombinedValidat
 const Code = props => (
   <pre
     style={{
+      position: 'absolute',
+      top: 12,
+      right: 12,
+      bottom: 12,
+      width: 500,
       border: '1px solid #eee',
       borderRadius: 4,
-      fontSize: 11,
-      padding: 12,
-      margin: 12,
-      lineHeight: 1.4,
-      position: 'absolute',
-      top: 0,
-      right: 0,
-      width: 500,
-      height: '100%',
       overflowX: 'scroll',
+      fontSize: 11,
+      lineHeight: 1.4,
+      boxSizing: 'border-box',
+      padding: 12,
+      margin: 0,
     }}
     {...props}
   />

--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -9,6 +9,7 @@ import MultistepWizard from '../examples/MultistepWizard';
 import SchemaValidation from '../examples/SchemaValidation';
 import SyncValidation from '../examples/SyncValidation';
 import FieldLevelValidation from '../examples/FieldLevelValidation';
+import CombinedValidations from '../examples/CombinedValidations';
 
 const AsyncValidationCode = require('!raw-loader!../examples/AsyncValidation');
 const ArraysCode = require('!raw-loader!../examples/Arrays');
@@ -18,6 +19,7 @@ const MultistepWizardCode = require('!raw-loader!../examples/MultistepWizard');
 const SchemaValidationCode = require('!raw-loader!../examples/SchemaValidation');
 const SyncValidationCode = require('!raw-loader!../examples/SyncValidation');
 const FieldLevelValidationCode = require('!raw-loader!../examples/FieldLevelValidation');
+const CombinedValidationsCode = require('!raw-loader!../examples/CombinedValidations');
 
 const Code = props => (
   <pre
@@ -117,6 +119,16 @@ storiesOf('Example', module)
           <FieldLevelValidation />
         </main>
         <Code>{FieldLevelValidationCode}</Code>
+      </div>
+    );
+  })
+  .add('CombinedValidations', () => {
+    return (
+      <div className="story">
+        <main>
+          <CombinedValidations />
+        </main>
+        <Code>{CombinedValidationsCode}</Code>
       </div>
     );
   });

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ npm install yup --save
       - [`touched: { [field: string]: boolean }`](#touched--field-string-boolean-)
       - [`values: { [field: string]: any }`](#values--field-string-any-)
       - [`validateForm: (values?: any) => void`](#validateform-values-any--void)
+      - [`validateField: (field: string) => void`](#validatefield-field-string--void)
     - [`component`](#component)
     - [`render: (props: FormikProps<Values>) => ReactNode`](#render-props-formikpropsvalues--reactnode)
     - [`children: func`](#children-func)
@@ -991,7 +992,7 @@ Trigger a form submission.
 
 ##### `submitCount: number`
 
-Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling  
+Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling
 [`handleReset`](#handlereset---void). `submitCount` is readonly computed property and should not be mutated directly.
 
 ##### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
@@ -1039,6 +1040,10 @@ component.
 ##### `validateForm: (values?: any) => void`
 
 Imperatively call your [`validate`] or [`validateSchema`] depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
+
+#### `validateField: (field: string) => void`
+
+Imperatively call field's [`validate`] function if specified for given field. Formik will use the current field value.
 
 #### `component`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,7 @@ Trigger a form submission.
 
 #### `submitCount: number`
 
-Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling  
+Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-values-values-formikbag-formikbag--void) is called, resets after calling
 [`handleReset`](#handlereset---void). `submitCount` is readonly computed property and should not be mutated directly.
 
 #### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
@@ -182,6 +182,10 @@ component.
 #### `validateForm: (values?: any) => void`
 
 Imperatively call your [`validate`] or [`validateSchema`] depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
+
+#### `validateField: (field: string) => void`
+
+Imperatively call field's [`validate`] function if specified for given field. Formik will use the current field value.
 
 ### `component`
 

--- a/examples/CombinedValidations.js
+++ b/examples/CombinedValidations.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Formik, Field, Form } from 'formik';
+import * as Yup from 'yup';
+
+const Schema = Yup.object().shape({
+  email: Yup.string().required('This field is required'),
+});
+
+// Async Validation
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const validate = (values, props) =>
+  sleep(300).then(() => {
+    throw {
+      zip: 'This field is required',
+    };
+  });
+
+const isRequired = message => value => (!!value ? undefined : message);
+
+const FieldLevelValidation = () => (
+  <div>
+    <h1>Pick a username</h1>
+    <Formik
+      validationSchema={Schema}
+      validate={validate}
+      initialValues={{
+        username: '',
+        email: '',
+        zip: '',
+      }}
+      onSubmit={values => {
+        sleep(500).then(() => {
+          alert(JSON.stringify(values, null, 2));
+        });
+      }}
+      render={({
+        errors,
+        touched,
+        setFieldValue,
+        setFieldTouched,
+        validateField,
+        validateForm,
+      }) => (
+        <Form>
+          <label htmlFor="username">Username</label>
+          <div>
+            <Field
+              name="username"
+              validate={isRequired('This field is required')}
+              type="text"
+              placeholder="username"
+            />
+            {errors.username &&
+              touched.username && (
+                <div className="field-error">{errors.username}</div>
+              )}
+          </div>
+          <br />
+          <div>
+            <Field
+              name="email"
+              validate={isRequired('This field is required')}
+              type="text"
+              placeholder="email"
+            />
+            {errors.email &&
+              touched.email && (
+                <div className="field-error">{errors.email}</div>
+              )}
+          </div>
+          <br />
+          <div>
+            <Field
+              name="zip"
+              validate={isRequired('This field is required')}
+              type="text"
+              placeholder="zip"
+            />
+            {errors.zip &&
+              touched.zip && <div className="field-error">{errors.zip}</div>}
+          </div>
+          <br />
+
+          <button type="submit">Submit</button>
+        </Form>
+      )}
+    />
+  </div>
+);
+
+export default FieldLevelValidation;

--- a/examples/FieldLevelValidation.js
+++ b/examples/FieldLevelValidation.js
@@ -7,11 +7,9 @@ const FieldLevelValidation = () => (
   <div>
     <h1>Pick a username</h1>
     <Formik
-      initialValues={{username: '', password: ''}}
+      initialValues={{ username: '', email: '' }}
       onSubmit={values => {
-        sleep(500).then(() => {
-          alert(JSON.stringify(values, null, 2));
-        });
+        alert(JSON.stringify(values, null, 2));
       }}
       render={({
         errors,
@@ -40,7 +38,7 @@ const FieldLevelValidation = () => (
             <Field
               name="email"
               validate={isRequired('This field is required')}
-              type="email"
+              type="text"
               placeholder="Email"
             />
             {errors.email &&

--- a/examples/FieldLevelValidation.js
+++ b/examples/FieldLevelValidation.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Formik, Field, Form } from 'formik';
+
+const isRequired = message => value => (!!value ? undefined : message);
+
+const FieldLevelValidation = () => (
+  <div>
+    <h1>Pick a username</h1>
+    <Formik
+      initialValues={{username: '', password: ''}}
+      onSubmit={values => {
+        sleep(500).then(() => {
+          alert(JSON.stringify(values, null, 2));
+        });
+      }}
+      render={({
+        errors,
+        touched,
+        setFieldValue,
+        setFieldTouched,
+        validateField,
+        validateForm,
+      }) => (
+        <Form>
+          <label htmlFor="username">Username</label>
+          <div>
+            <Field
+              name="username"
+              validate={isRequired('This field is required')}
+              type="text"
+              placeholder="Username"
+            />
+            {errors.username &&
+              touched.username && (
+                <div className="field-error">{errors.username}</div>
+              )}
+          </div>
+          <br />
+          <div>
+            <Field
+              name="email"
+              validate={isRequired('This field is required')}
+              type="email"
+              placeholder="Email"
+            />
+            {errors.email &&
+              touched.email && (
+                <div className="field-error">{errors.email}</div>
+              )}
+          </div>
+          <div>
+            <pre>
+              Errors:<br />
+              {JSON.stringify(errors, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <pre>
+              Touched:<br />
+              {JSON.stringify(touched, null, 2)}
+            </pre>
+          </div>
+
+          <div>
+            <div>username actions</div>
+            <button
+              type="button"
+              onClick={() => {
+                setFieldTouched('username', true, true);
+              }}
+            >
+              setFieldTouched
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setFieldValue('username', '', true);
+              }}
+            >
+              setFieldValue
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                validateField('username');
+              }}
+            >
+              validateField
+            </button>
+            <br />
+          </div>
+          <br />
+          <div>
+            <div>Form actions</div>
+            <button type="button" onClick={validateForm}>
+              validate form
+            </button>
+            <button type="submit">Submit</button>
+          </div>
+        </Form>
+      )}
+    />
+  </div>
+);
+
+export default FieldLevelValidation;

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -202,7 +202,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   runValidateHandler(values: FormikValues): Promise<FormikErrors<Values>> {
     return new Promise(resolve => {
       const maybePromisedErrors = (this.props.validate as any)(values);
-      if (isPromise(maybePromisedErrors)) {
+      if (maybePromisedErrors === undefined) {
+        resolve({});
+      } else if (isPromise(maybePromisedErrors)) {
         (maybePromisedErrors as Promise<any>).then(
           () => {
             resolve({});
@@ -399,7 +401,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       submitCount: prevState.submitCount + 1,
     }));
 
-    this.runValidations().then(combinedErrors => {
+    return this.runValidations().then(combinedErrors => {
       this.setState({ isSubmitting: false });
       const isValid = Object.keys(combinedErrors).length === 0;
       if (isValid) {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -20,8 +20,8 @@ import {
   isString,
   setIn,
   setNestedObjectValues,
-  getIn,
   getActiveElement,
+  getIn,
 } from './utils';
 
 export class Formik<ExtraProps = {}, Values = object> extends React.Component<
@@ -140,46 +140,124 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   };
 
   /**
-   * Run validation against a Yup schema and optionally run a function if successful
+   * Run field level validation
    */
-  runValidationSchema = (values: FormikValues, onSuccess?: Function) => {
-    const { validationSchema } = this.props;
-    const schema = isFunction(validationSchema)
-      ? validationSchema()
-      : validationSchema;
-    validateYupSchema(values, schema).then(
-      () => {
-        this.setState({ errors: {} });
-        if (onSuccess) {
-          onSuccess();
-        }
-      },
-      (err: any) =>
-        this.setState({ errors: yupToFormErrors(err), isSubmitting: false })
-    );
+  validateField = (field: string) => {
+    this.runSingleFieldLevelValidation(
+      field,
+      getIn(this.state.values, field)
+    ).then(error => {
+      if (!!error) {
+        this.setState({ errors: setIn(this.state.errors, field, error) });
+      }
+    });
   };
 
-  /**
-   * Run validations and update state accordingly
-   */
-  runValidations = (values: FormikValues = this.state.values) => {
-    if (this.props.validationSchema) {
-      this.runValidationSchema(values);
-    }
+  runSingleFieldLevelValidation = (
+    field: string,
+    value: void | string
+  ): Promise<string | undefined | PromiseLike<any>> => {
+    return new Promise(resolve => resolve(this.fields[field].validate!(value)));
+  };
 
-    if (this.props.validate) {
+  runFieldLevelValidations(
+    values: FormikValues
+  ): Promise<FormikErrors<Values>> {
+    const fieldKeysWithValidation: string[] = Object.keys(this.fields).filter(
+      f =>
+        this.fields &&
+        this.fields[f] &&
+        this.fields[f].validate &&
+        isFunction(this.fields[f].validate)
+    );
+
+    // Construct an array with all of the field validation functions
+    const fieldValidations: Promise<string>[] =
+      fieldKeysWithValidation.length > 0
+        ? fieldKeysWithValidation.map(
+            f =>
+              this.runSingleFieldLevelValidation(f, values[f]).then(
+                x => x,
+                e => e
+              ) // always catch so Promise.all runs each one
+          )
+        : [Promise.resolve('DO_NOT_DELETE_YOU_WILL_BE_FIRED')]; // use special case ;)
+
+    return Promise.all(fieldValidations).then((fieldErrorsList: string[]) =>
+      fieldErrorsList.reduce(
+        (prev, curr, index) => {
+          if (curr === 'DO_NOT_DELETE_YOU_WILL_BE_FIRED') {
+            return prev;
+          }
+          if (!!curr) {
+            prev = setIn(prev, fieldKeysWithValidation[index], curr);
+          }
+          return prev;
+        },
+        {} as FormikErrors<Values>
+      )
+    );
+  }
+
+  runValidateHandler(values: FormikValues): Promise<FormikErrors<Values>> {
+    return new Promise(resolve => {
       const maybePromisedErrors = (this.props.validate as any)(values);
       if (isPromise(maybePromisedErrors)) {
         (maybePromisedErrors as Promise<any>).then(
           () => {
-            this.setState({ errors: {} });
+            resolve({});
           },
-          errors => this.setState({ errors, isSubmitting: false })
+          errors => {
+            resolve(errors);
+          }
         );
       } else {
-        this.setErrors(maybePromisedErrors as FormikErrors<Values>);
+        resolve(maybePromisedErrors);
       }
-    }
+    });
+  }
+
+  /**
+   * Run validation against a Yup schema and optionally run a function if successful
+   */
+  runValidationSchema = (values: FormikValues) => {
+    return new Promise(resolve => {
+      const { validationSchema } = this.props;
+      const schema = isFunction(validationSchema)
+        ? validationSchema()
+        : validationSchema;
+      validateYupSchema(values, schema).then(
+        () => {
+          resolve({});
+        },
+        (err: any) => {
+          resolve(yupToFormErrors(err));
+        }
+      );
+    });
+  };
+
+  /**
+   * Run all validations methods and update state accordingly
+   */
+  runValidations = (
+    values: FormikValues = this.state.values
+  ): Promise<FormikErrors<Values>> => {
+    return Promise.all([
+      this.runFieldLevelValidations(values),
+      this.props.validationSchema ? this.runValidationSchema(values) : {},
+      this.props.validate ? this.runValidateHandler(values) : {},
+    ]).then(([fieldErrors, schemaErrors, handlerErrors]) => {
+      const combinedErrors = deepmerge.all<FormikErrors<Values>>([
+        fieldErrors,
+        schemaErrors,
+        handlerErrors,
+      ]);
+
+      this.setState({ errors: combinedErrors });
+
+      return combinedErrors;
+    });
   };
 
   handleChange = (
@@ -321,106 +399,13 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       submitCount: prevState.submitCount + 1,
     }));
 
-    // We run field-level validation first!
-    const fieldKeysWithValidation: string[] = Object.keys(this.fields).filter(
-      f =>
-        this.fields &&
-        this.fields[f] &&
-        this.fields[f].validate &&
-        isFunction(this.fields[f].validate)
-    );
-
-    // Construct an array with all of the field validation functions
-    const fieldValidations: Promise<string>[] =
-      fieldKeysWithValidation.length > 0
-        ? fieldKeysWithValidation.map(
-            f =>
-              Promise.resolve<string | undefined | PromiseLike<any>>(
-                this.fields[f].validate!(getIn(this.state.values, f))
-              ).then(x => x, e => e) // always catch so Promise.all runs each one
-          )
-        : [Promise.resolve('DO_NOT_DELETE_YOU_WILL_BE_FIRED')]; // use special case ;)
-
-    // Always run field-level validations first
-    return Promise.all(fieldValidations)
-      .then((fieldErrorsList: string[]) =>
-        fieldErrorsList.reduce(
-          (prev, curr, index) => {
-            if (curr === 'DO_NOT_DELETE_YOU_WILL_BE_FIRED') {
-              return prev;
-            }
-            if (!!curr) {
-              prev = setIn(prev, fieldKeysWithValidation[index], curr);
-            }
-            return prev;
-          },
-          {} as FormikErrors<Values>
-        )
-      )
-      .then((fieldErrors: FormikErrors<Values>) => {
-        const hasFieldErrors = Object.keys(fieldErrors).length !== 0;
-        if (this.props.validate) {
-          const maybePromisedErrors =
-            (this.props.validate as any)(this.state.values) || {};
-          if (isPromise(maybePromisedErrors)) {
-            maybePromisedErrors.then(errors => {
-              const combinedErrors = deepmerge<FormikErrors<Values>>(
-                fieldErrors,
-                errors
-              );
-              this.setState({ errors: combinedErrors });
-              if (Object.keys(combinedErrors).length === 0) {
-                this.executeSubmit();
-              } else {
-                this.setState({ isSubmitting: false });
-                return;
-              }
-            });
-          } else {
-            const combinedErrors = deepmerge<FormikErrors<Values>>(
-              fieldErrors,
-              maybePromisedErrors
-            );
-            const isValid = Object.keys(combinedErrors).length === 0;
-            this.setState({
-              errors: combinedErrors,
-              isSubmitting: isValid,
-            });
-
-            // only submit if there are no errors
-            if (isValid) {
-              this.executeSubmit();
-            }
-          }
-        } else if (this.props.validationSchema) {
-          const { validationSchema } = this.props;
-          const schema = isFunction(validationSchema)
-            ? validationSchema()
-            : validationSchema;
-          validateYupSchema(this.state.values, schema).then(
-            () => {
-              if (hasFieldErrors) {
-                this.setState({ errors: fieldErrors, isSubmitting: false });
-              } else {
-                this.setState({ errors: {} });
-                this.executeSubmit();
-              }
-            },
-            (err: any) =>
-              this.setState({
-                errors: deepmerge<FormikErrors<Values>>(
-                  fieldErrors,
-                  yupToFormErrors(err)
-                ),
-                isSubmitting: false,
-              })
-          );
-        } else if (hasFieldErrors) {
-          this.setState({ errors: fieldErrors, isSubmitting: false });
-        } else {
-          this.executeSubmit();
-        }
-      });
+    this.runValidations().then(combinedErrors => {
+      this.setState({ isSubmitting: false });
+      const isValid = Object.keys(combinedErrors).length === 0;
+      if (isValid) {
+        this.executeSubmit();
+      }
+    });
   };
 
   executeSubmit = () => {
@@ -531,6 +516,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       resetForm: this.resetForm,
       submitForm: this.submitForm,
       validateForm: this.runValidations,
+      validateField: this.validateField,
       setError: this.setError,
       setErrors: this.setErrors,
       setFieldError: this.setFieldError,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -93,6 +93,8 @@ export interface FormikActions<Values> {
   ): void;
   /** Validate form values */
   validateForm(values?: any): void;
+  /** Validate field value */
+  validateField(field: string): void;
   /** Reset form */
   resetForm(nextValues?: any): void;
   /** Submit the form imperatively */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,17 +6,28 @@ declare module 'react-lifecycles-compat' {
     Comp: React.ComponentType<P>
   ): React.ComponentType<P>;
 }
+
 declare module 'deepmerge' {
-  // https://github.com/KyleAMathews/deepmerge
-  // 06/27/18 by Jared Palmer
-  // for Version 2.1.1
-  export default function deepmerge<T>(
-    x: any,
-    y: any,
-    options?: {
-      clone?: boolean;
-      arrayMerge?: (x: any[], y: any[], option: { clone?: boolean }) => any[];
-      isMergeableObject?: (obj: any) => boolean;
-    }
+  export = deepmerge;
+
+  function deepmerge<T>(
+    x: Partial<T>,
+    y: Partial<T>,
+    options?: deepmerge.Options
   ): T;
+  function deepmerge<T1, T2>(
+    x: T1,
+    y: T2,
+    options?: deepmerge.Options
+  ): T1 & T2;
+
+  namespace deepmerge {
+    interface Options {
+      clone?: boolean;
+      arrayMerge?(destination: any[], source: any[], options?: Options): any[];
+      isMergeableObject?(value: object): boolean;
+    }
+
+    function all<T>(objects: Array<Partial<T>>, options?: Options): T;
+  }
 }


### PR DESCRIPTION
Now, field level validation are not called in several handlers, e.g. `setFieldValue`, or `setFieldTouched`.
This PR improved this behaviour and adds calls to run field level validations to multiple places.

After this changes, validation handlers become almost identical. This is the reason for refactor. `runValidations` not calls all validation methods - field level, schema validation and custom validate handler

closes #734 