### PR TITLE
fix: Set touched state on change event

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -233,6 +233,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         this.setState(prevState => ({
           ...prevState,
           values: setIn(prevState.values, field!, val),
+          touched: setIn(prevState.touched, field!, true),
         }));
 
         if (this.props.validateOnChange) {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -181,6 +181,23 @@ describe('<Formik>', () => {
           });
         expect(validate).not.toHaveBeenCalled();
       });
+
+      it('sets touched state', () => {
+        const tree = shallow(BasicForm);
+
+        // Simulate a change event in the inner Form component's input
+        tree
+          .find(Form)
+          .dive()
+          .find('input')
+          .simulate('change', {
+            persist: noop,
+            target: {
+              id: 'name',
+            },
+          });
+        expect(tree.update().state().touched).toEqual({ name: true });
+      });
     });
 
     describe('handleBlur', () => {


### PR DESCRIPTION
Closes #599

sets `touched#<field>` to `true` in `handleChange`.

*before*: `touched` only true after losing focus

![formik-before](https://user-images.githubusercontent.com/30477263/42348264-a81848ca-805d-11e8-8e0d-6f00dee33efa.gif)

*after*: `touched` true when value is changed

![formik-after](https://user-images.githubusercontent.com/30477263/42348282-b4bc3ff0-805d-11e8-899d-da653f7831ee.gif)

