### PR TITLE
Begin to fix types, related to #733 and #735

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jest": "^23.1.0",
     "jest-cli": "^23.1.0",
     "lint-staged": "4.0.2",
-    "prettier": "1.11.1",
+    "prettier": "^1.13.7",
     "raw-loader": "^0.5.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -36,7 +36,7 @@ class FastFieldInner<ExtraProps, Values> extends React.Component<
       value: getIn(props.formik.values, props.name),
       error: getIn(props.formik.errors, props.name),
     };
-    warnRenderProps('FastField', props);
+    warnRenderProps('FastField', props, 'component');
 
     // Register the FastField with the parent Formik. Parent will cycle through
     // registered FastField's validate fns right prior to submit

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import isEqual from 'react-fast-compare';
-import warning from 'warning';
-import { FieldAttributes, FieldConfig, FieldProps } from './Field';
+import { Field, FieldConfig, FieldProps, FieldInner } from './Field';
 import { validateYupSchema, yupToFormErrors } from './Formik';
-import { connect } from './connect';
+import { FormikConsumer } from './connect';
 import { FormikContext } from './types';
-import { getIn, isEmptyChildren, isFunction, isPromise, setIn } from './utils';
+import { getIn, isFunction, isPromise, setIn, warnRenderProps } from './utils';
 
 export interface FastFieldState {
   value: any;
@@ -17,50 +16,36 @@ function isEqualExceptForKey(a: any, b: any, path: string) {
   return isEqual(setIn(a, path, undefined), setIn(b, path, undefined));
 }
 
+export namespace FastFieldInner {
+  export type Props<ExtraProps, Values> = FastField.Props<ExtraProps> & {
+    formik: FormikContext<Values>;
+  };
+}
+
 /**
  * Custom Field component for quickly hooking into Formik
  * context and wiring up forms.
  */
-class FastFieldInner<Props = {}, Values = {}> extends React.Component<
-  FieldAttributes<Props> & { formik: FormikContext<Values> },
+class FastFieldInner<ExtraProps, Values> extends React.Component<
+  FastFieldInner.Props<ExtraProps, Values>,
   FastFieldState
 > {
-  constructor(
-    props: FieldAttributes<Props> & { formik: FormikContext<Values> }
-  ) {
+  constructor(props: FieldInner.Props<ExtraProps, Values>) {
     super(props);
     this.state = {
       value: getIn(props.formik.values, props.name),
       error: getIn(props.formik.errors, props.name),
     };
+    warnRenderProps('FastField', props);
 
-    const { render, children, component, formik } = props;
-
-    warning(
-      !(component && render),
-      'You should not use <FastField component> and <FastField render> in the same <FastField> component; <FastField component> will be ignored'
-    );
-
-    warning(
-      !(props.component && children && isFunction(children)),
-      'You should not use <FastField component> and <FastField children> as a function in the same <FastField> component; <FastField component> will be ignored.'
-    );
-
-    warning(
-      !(render && children && !isEmptyChildren(children)),
-      'You should not use <FastField render> and <FastField children> in the same <FastField> component; <FastField children> will be ignored'
-    );
     // Register the FastField with the parent Formik. Parent will cycle through
     // registered FastField's validate fns right prior to submit
-    formik.registerField(props.name, {
+    props.formik.registerField(props.name, {
       validate: props.validate,
     });
   }
 
-  componentDidUpdate(
-    prevProps: any /* FieldAttributes<Props> & { formik: FormikContext<Values> }*/,
-    _state: FastFieldState
-  ) {
+  componentDidUpdate(prevProps: FieldInner.Props<ExtraProps, Values>) {
     const nextFieldValue = getIn(this.props.formik.values, this.props.name);
     const nextFieldError = getIn(this.props.formik.errors, this.props.name);
     const prevFieldValue = getIn(prevProps.formik.values, prevProps.name);
@@ -101,14 +86,16 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
     const { type, value, checked } = e.target;
     const val = /number|range/.test(type)
       ? parseFloat(value)
-      : /checkbox/.test(type) ? checked : value;
+      : /checkbox/.test(type)
+        ? checked
+        : value;
     if (validateOnChange) {
       // Field-level validation
       if (this.props.validate) {
-        const maybePromise = (this.props.validate as any)(value);
+        const maybePromise = this.props.validate(value);
         if (isPromise(maybePromise)) {
           this.setState({ value: val });
-          (maybePromise as any).then(
+          maybePromise.then(
             () => this.setState({ error: undefined }),
             (error: string) => this.setState({ error })
           );
@@ -117,13 +104,11 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
         }
       } else if (validate) {
         // Top-level validate
-        const maybePromise = (validate as any)(
-          setIn(values, this.props.name, val)
-        );
+        const maybePromise = validate(setIn(values, this.props.name, val));
 
         if (isPromise(maybePromise)) {
           this.setState({ value: val });
-          (maybePromise as any).then(
+          maybePromise.then(
             () => this.setState({ error: undefined }),
             (error: any) => {
               // Here we diff the errors object relative to Formik parents except for
@@ -207,9 +192,9 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
 
     // @todo refactor
     if (validateOnBlur && validate) {
-      const maybePromise = (validate as any)(this.state.value);
+      const maybePromise = validate(this.state.value);
       if (isPromise(maybePromise)) {
-        (maybePromise as Promise<any>).then(
+        maybePromise.then(
           () =>
             setFormikState((prevState: any) => ({
               ...prevState,
@@ -256,7 +241,9 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
       component = 'input',
       formik,
       ...props
-    } = this.props as FieldConfig & { formik: FormikContext<Values> };
+    } = this.props as FieldConfig<ExtraProps> & {
+      formik: FormikContext<Values>;
+    };
     const {
       validate: _validate,
       validationSchema: _validationSchema,
@@ -307,4 +294,27 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
   }
 }
 
-export const FastField = connect<FieldAttributes<any>, any>(FastFieldInner);
+export namespace FastField {
+  export type Props<ExtraProps> = Field.Props<ExtraProps>;
+  export type State = {};
+}
+
+export class FastField<ExtraProps, Values> extends React.Component<
+  FastField.Props<ExtraProps>,
+  FastField.State
+> {
+  static WrappedComponent = FastFieldInner;
+
+  render() {
+    return (
+      <FormikConsumer<Values>>
+        {formik => (
+          <FastFieldInner<ExtraProps, Values>
+            {...this.props as FastField.Props<ExtraProps>}
+            formik={formik}
+          />
+        )}
+      </FormikConsumer>
+    );
+  }
+}

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -95,7 +95,7 @@ class FieldInner<ExtraProps, Values> extends React.Component<
 > {
   constructor(props: FieldInner.Props<ExtraProps, Values>) {
     super(props);
-    warnRenderProps('Field', props);
+    warnRenderProps('Field', props, 'component');
 
     // Register the Field with the parent Formik. Parent will cycle through
     // registered Field's validate fns right prior to submit

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -6,7 +6,7 @@ export type FormikFormProps = Pick<
   Exclude<keyof React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>
 >;
 
-export const Form = connect<FormikFormProps>(
+export const Form = connect<FormikFormProps, any>(
   ({ formik: { handleSubmit }, ...props }) => (
     <form onSubmit={handleSubmit} {...props} />
   )

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -26,7 +26,6 @@ import {
 
 export namespace Formik {
   export type Props<ExtraProps, Values> = ExtraProps & FormikConfig<Values>;
-  export type RenderProps = {};
   export type State<Values> = {
     /** Form values */
     values: Values;

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -7,7 +7,6 @@ import {
   FormikActions,
   FormikConfig,
   FormikErrors,
-  FormikState,
   FormikTouched,
   FormikValues,
   FormikContext,
@@ -22,11 +21,39 @@ import {
   setNestedObjectValues,
   getActiveElement,
   getIn,
+  warnRenderProps,
 } from './utils';
 
-export class Formik<ExtraProps = {}, Values = object> extends React.Component<
-  FormikConfig<Values> & ExtraProps,
-  FormikState<any>
+export namespace Formik {
+  export type Props<ExtraProps, Values> = ExtraProps & FormikConfig<Values>;
+  export type RenderProps = {};
+  export type State<Values> = {
+    /** Form values */
+    values: Values;
+    /**
+     * Top level error, in case you need it
+     * @deprecated since 0.8.0
+     */
+    error?: any;
+    /** map of field names to specific error for that field */
+    errors: FormikErrors<Values>;
+    /** map of field names to whether the field has been touched */
+    touched: FormikTouched<Values>;
+    /** whether the form is currently submitting */
+    isSubmitting: boolean;
+    /** Top level status state, in case you need it */
+    status?: any;
+    /** Number of times user tried to submit the form */
+    submitCount: number;
+  };
+}
+
+export class Formik<
+  ExtraProps,
+  Values extends FormikValues
+> extends React.Component<
+  Formik.Props<ExtraProps, Values>,
+  Formik.State<Values>
 > {
   static defaultProps = {
     validateOnChange: true,
@@ -52,7 +79,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   constructor(props: FormikConfig<Values> & ExtraProps) {
     super(props);
     this.state = {
-      values: props.initialValues || ({} as any),
+      values: props.initialValues || ({} as Values),
       errors: {},
       touched: {},
       isSubmitting: false,
@@ -60,20 +87,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     };
     this.fields = {};
     this.initialValues = props.initialValues || ({} as any);
-    warning(
-      !(props.component && props.render),
-      'You should not use <Formik component> and <Formik render> in the same <Formik> component; <Formik render> will be ignored'
-    );
-
-    warning(
-      !(props.component && props.children && !isEmptyChildren(props.children)),
-      'You should not use <Formik component> and <Formik children> in the same <Formik> component; <Formik children> will be ignored'
-    );
-
-    warning(
-      !(props.render && props.children && !isEmptyChildren(props.children)),
-      'You should not use <Formik render> and <Formik children> in the same <Formik> component; <Formik children> will be ignored'
-    );
+    warnRenderProps('Formik', props);
   }
 
   registerField = (
@@ -114,7 +128,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     });
   };
 
-  setValues = (values: FormikValues) => {
+  setValues = (values: Values) => {
     this.setState({ values }, () => {
       if (this.props.validateOnChange) {
         this.runValidations(values);
@@ -160,9 +174,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     return new Promise(resolve => resolve(this.fields[field].validate!(value)));
   };
 
-  runFieldLevelValidations(
-    values: FormikValues
-  ): Promise<FormikErrors<Values>> {
+  runFieldLevelValidations(values: Values): Promise<FormikErrors<Values>> {
     const fieldKeysWithValidation: string[] = Object.keys(this.fields).filter(
       f =>
         this.fields &&
@@ -199,7 +211,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     );
   }
 
-  runValidateHandler(values: FormikValues): Promise<FormikErrors<Values>> {
+  runValidateHandler(values: Values): Promise<FormikErrors<Values>> {
     return new Promise(resolve => {
       const maybePromisedErrors = (this.props.validate as any)(values);
       if (maybePromisedErrors === undefined) {
@@ -222,7 +234,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   /**
    * Run validation against a Yup schema and optionally run a function if successful
    */
-  runValidationSchema = (values: FormikValues) => {
+  runValidationSchema = (values: Values) => {
     return new Promise(resolve => {
       const { validationSchema } = this.props;
       const schema = isFunction(validationSchema)
@@ -243,7 +255,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
    * Run all validations methods and update state accordingly
    */
   runValidations = (
-    values: FormikValues = this.state.values
+    values: Values = this.state.values
   ): Promise<FormikErrors<Values>> => {
     return Promise.all([
       this.runFieldLevelValidations(values),
@@ -305,7 +317,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         }
         val = /number|range/.test(type)
           ? ((parsed = parseFloat(value)), isNaN(parsed) ? '' : parsed)
-          : /checkbox/.test(type) ? checked : value;
+          : /checkbox/.test(type)
+            ? checked
+            : value;
       }
 
       if (field) {
@@ -574,9 +588,8 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   render() {
     const { component, render, children } = this.props;
     const props = this.getFormikBag();
-    const ctx = this.getFormikContext();
     return (
-      <FormikProvider value={ctx}>
+      <FormikProvider value={this.getFormikContext()}>
         {component
           ? React.createElement(component as any, props)
           : render

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -87,7 +87,7 @@ export class Formik<
     };
     this.fields = {};
     this.initialValues = props.initialValues || ({} as any);
-    warnRenderProps('Formik', props);
+    warnRenderProps('Formik', props, 'render');
   }
 
   registerField = (

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -1,22 +1,51 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import createContext from 'create-react-context';
+import createContext, {
+  ProviderProps,
+  ConsumerProps,
+} from 'create-react-context';
 import { FormikContext } from './types';
 
-export const {
-  Provider: FormikProvider,
-  Consumer: FormikConsumer,
-} = createContext<FormikContext<any>>({} as any);
+export const { Provider, Consumer } = createContext<FormikContext<any> | void>(
+  undefined
+);
+
+export function FormikProvider<Values>(
+  props: ProviderProps<FormikContext<Values>>
+) {
+  return <Provider value={props.value} children={props.children} />;
+}
+
+export function FormikConsumer<Values>(
+  props: ConsumerProps<FormikContext<Values>>
+) {
+  return (
+    <Consumer
+      children={formik => {
+        if (typeof formik === 'undefined') {
+          throw new Error(
+            'FormikConsumer called outside of a provider. This means you nested a' +
+              '<Field /> or connect() outside of a root <Formik /> element'
+          );
+        }
+        // Not sure why the create-react-context permits this Array signature.
+        return Array.isArray(props.children)
+          ? props.children[0](formik as FormikContext<Values>)
+          : props.children(formik as FormikContext<Values>);
+      }}
+    />
+  );
+}
 
 /**
  * Connect any component to Formik context, and inject as a prop called `formik`;
  * @param Comp React Component
  */
-export function connect<OuterProps, Values = {}>(
+export function connect<OuterProps, Values>(
   Comp: React.ComponentType<OuterProps & { formik: FormikContext<Values> }>
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (
-    <FormikConsumer>
+    <FormikConsumer<Values>>
       {formik => <Comp {...props} formik={formik} />}
     </FormikConsumer>
   );

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,4 +1,11 @@
 import * as React from 'react';
+import { Formik } from './Formik';
+/**
+ * Default values for extra props in the fields
+ */
+export interface FormikExtraProps {
+  [prop: string]: any;
+}
 /**
  * Values of fields in the form
  */
@@ -10,46 +17,25 @@ export interface FormikValues {
  * An object containing error messages whose keys correspond to FormikValues.
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
-export type FormikErrors<Values> = {
+export type FormikErrors<Values extends FormikValues> = {
   [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : {}
 };
 
 /**
  * An object containing touched state of the form whose keys correspond to FormikValues.
  */
-export type FormikTouched<Values> = {
+export type FormikTouched<Values extends FormikValues> = {
   [K in keyof Values]?: Values[K] extends object
     ? FormikTouched<Values[K]>
     : boolean
 };
 
-/**
- * Formik state tree
- */
-export interface FormikState<Values> {
-  /** Form values */
-  values: Values;
-  /**
-   * Top level error, in case you need it
-   * @deprecated since 0.8.0
-   */
-  error?: any;
-  /** map of field names to specific error for that field */
-  errors: FormikErrors<Values>;
-  /** map of field names to whether the field has been touched */
-  touched: FormikTouched<Values>;
-  /** whether the form is currently submitting */
-  isSubmitting: boolean;
-  /** Top level status state, in case you need it */
-  status?: any;
-  /** Number of times user tried to submit the form */
-  submitCount: number;
-}
+export type FormikState<Values extends FormikValues> = Formik.State<Values>;
 
 /**
  * Formik computed properties. These are read-only.
  */
-export interface FormikComputedProps<Values> {
+export interface FormikComputedProps<Values extends FormikValues> {
   /** True if any input has been touched. False otherwise. */
   readonly dirty: boolean;
   /** Result of isInitiallyValid on mount, then whether true values pass validation. */
@@ -61,7 +47,7 @@ export interface FormikComputedProps<Values> {
 /**
  * Formik state helpers
  */
-export interface FormikActions<Values> {
+export interface FormikActions<Values extends FormikValues> {
   /** Manually set top level status. */
   setStatus(status?: any): void;
   /**
@@ -84,7 +70,10 @@ export interface FormikActions<Values> {
     shouldValidate?: boolean
   ): void;
   /** Set error message of a form field directly */
-  setFieldError(field: keyof Values & string, message: string): void;
+  setFieldError(
+    field: keyof Values & string,
+    message: string | undefined
+  ): void;
   /** Set whether field has been touched directly */
   setFieldTouched(
     field: keyof Values & string,
@@ -110,11 +99,11 @@ export interface FormikActions<Values> {
 }
 
 /** Overloded methods / types */
-export interface FormikActions<Values> {
+export interface FormikActions<Values extends FormikValues> {
   /** Set value of form field directly */
   setFieldValue(field: string, value: any): void;
   /** Set error message of a form field directly */
-  setFieldError(field: string, message: string): void;
+  setFieldError(field: string, message: string | undefined): void;
   /** Set whether field has been touched directly */
   setFieldTouched(field: string, isTouched?: boolean): void;
   /** Set Formik state, careful! */
@@ -217,7 +206,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
  * of <Formik/>.
  */
 export type FormikProps<Values> = FormikSharedConfig &
-  FormikState<Values> &
+  Formik.State<Values> &
   FormikActions<Values> &
   FormikHandlers &
   FormikComputedProps<Values> & {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import toPath from 'lodash.topath';
 import * as React from 'react';
+import warning from 'warning';
 
 /**
  * Deeply get a value from an object via it's path.
@@ -129,4 +130,21 @@ export function getActiveElement(doc?: Document): Element | null {
   } catch (e) {
     return doc.body;
   }
+}
+
+export function warnRenderProps(c: string, props: any) {
+  warning(
+    !(props.component && props.render),
+    `You should not use <${c} component> and <${c} render> in the same <${c}> component; <${c} component> will be ignored`
+  );
+
+  warning(
+    !(props.component && props.children && isFunction(props.children)),
+    `You should not use <${c} component> and <${c} children> as a function in the same <${c}> component; <${c} component> will be ignored.`
+  );
+
+  warning(
+    !(props.render && props.children && !isEmptyChildren(props.children)),
+    `You should not use <${c} render> and <${c} children> in the same <${c}> component; <${c} children> will be ignored`
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,10 +132,10 @@ export function getActiveElement(doc?: Document): Element | null {
   }
 }
 
-export function warnRenderProps(c: string, props: any) {
+export function warnRenderProps(c: string, props: any, ignored: string) {
   warning(
     !(props.component && props.render),
-    `You should not use <${c} component> and <${c} render> in the same <${c}> component; <${c} component> will be ignored`
+    `You should not use <${c} component> and <${c} render> in the same <${c}> ${ignored}; <${c} ${ignored}> will be ignored`
   );
 
   warning(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7011,9 +7011,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+prettier@^1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
Ok so this is a new pass at #733 and #735, originally meant to get better types on `<Field />` but it grew a little in scope from there.

I found myself starting to get much more ambitious with cleaning up types in general but decided to stop and talk through some of these ideas/changes first and see if this is a direction I should continue.

Some goals:

**Use `any` and `... as ___` as little as possible.**

This can be useful occasionally, but IMO it's used a little much here, mostly to work around things that could otherwise be better expressed with the type system.

The fact that you can currently write a `<Field />` component with `render`, `children` and `component` and have it pass the type checker feels like a bug. The lack of strong typing here also leads to the need to manually cast in a bunch of places which can lead to subtle bugs. 

I split the constructor check which is similar in the various components to a util function (since that'll still be useful for JS consumers), but didn't begin to tackle proper typings to correct this in TS. 

Would you agree that proper type definitions for the various components would be useful here?

**Utilize TS 2.9 and generics as well as we can internally to track types.**

The generics are pretty neat in the fact that they are passed properly, TS inference does a good job of, for example, tracking what additional props should be defined on `<Field />` based on the `component={CustomComponent}` as long as the generic is passed through to the definition:

```ts
  /**
   * Field component to render. Can either be a string like 'select' or a component.
   */
  component?:
    | string
    | React.ComponentType<ExtraProps & FieldProps<any>>
    | React.ComponentType<void>;
```

**Unify type naming**

A pattern I've begun to use in my own React components and started to implement here is to define a namespace with the same name as the component. I've found it simpler to organize/reference via `ClassName.Props`, without needing to import a bunch of different typings when referencing them cross module. Don't feel strongly about it either way, just a suggestion.

**`<Values, ExtraProps>` vs `<ExtraProps, Values>`**

Didn't do anything with this, but kept thinking that this would probably be a lot nicer to work on if #726 were to be rolled into it. Especially since `ExtraProps` usually doesn't need to be defined explicitly by the end-user, as mentioned above, even with a default `{}` it appears to properly infer the props as defined by a custom component prop. Thoughts on whether I should roll that into some of the work here?

I'm going to add a few comments on the PR with other thoughts/notes as I was working through it. So this is still WIP (though the update type definitions seems to work pretty well as-is). I'm mostly interested to hear any feedback on these ideas / whether moving in the direction of getting a bit more strict/correct with the types internally is something welcomed/worthwhile to work on.