### PR TITLE
Attempt to fix force-update bug

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -36,7 +36,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   };
 
   initialValues: Values;
-
+  didMount: boolean;
   hcCache: {
     [key: string]: (e: string | React.ChangeEvent<any>) => void;
   } = {};
@@ -58,6 +58,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       isSubmitting: false,
       submitCount: 0,
     };
+    this.didMount = false;
     this.fields = {};
     this.initialValues = props.initialValues || ({} as any);
     warning(
@@ -89,6 +90,10 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
   unregisterField = (name: string) => {
     delete this.fields[name];
   };
+
+  componentDidMount() {
+    this.didMount = true;
+  }
 
   componentDidUpdate(prevProps: Readonly<FormikConfig<Values> & ExtraProps>) {
     // If the initialValues change, reset the form
@@ -255,8 +260,9 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
         schemaErrors,
         handlerErrors,
       ]);
-
-      this.setState({ errors: combinedErrors });
+      if (this.didMount) {
+        this.setState({ errors: combinedErrors });
+      }
 
       return combinedErrors;
     });

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -95,6 +95,16 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
     this.didMount = true;
   }
 
+  componentWillUnmount() {
+    // This allows us to prevent setting state on an
+    // unmounted component. This can occur if Formik is in a modal, and submission
+    // toggles show/hide, and validation of a blur field takes longer than validation
+    // before a submit.
+    // @see https://github.com/jaredpalmer/formik/issues/597
+    // @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+    this.didMount = false;
+  }
+
   componentDidUpdate(prevProps: Readonly<FormikConfig<Values> & ExtraProps>) {
     // If the initialValues change, reset the form
     if (
@@ -152,7 +162,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
       field,
       getIn(this.state.values, field)
     ).then(error => {
-      if (!!error) {
+      if (!!error && this.didMount) {
         this.setState({ errors: setIn(this.state.errors, field, error) });
       }
     });


### PR DESCRIPTION
This tracks whether Formik is currently mounted and prevents setState calls after async validation if Formik is not mounted. This prevents the "setState on unmounted component" warning.  

React deprecated `isMounted()` in 2015. This PR uses the technique described in this blog post: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html

Fixes #597 

Demo Problem: codesandbox.io/s/21jowlv4p
Demo Solution: https://codesandbox.io/s/p9nrkjw7lj

