### PR TITLE
Fix #720. Upgrade to TypeScript@3.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "create-react-context": "^0.2.2",
     "deepmerge": "^2.1.1",
-    "hoist-non-react-statics": "^2.5.0",
+    "hoist-non-react-statics": "^2.5.5",
     "lodash.clonedeep": "^4.5.0",
     "lodash.topath": "4.5.2",
     "prop-types": "^15.6.1",
@@ -88,7 +88,7 @@
     "tsc-watch": "^1.0.21",
     "tslint": "5.5.0",
     "tslint-react": "3.2.0",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.0-dev.20180711",
     "yup": "0.21.3"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4243,9 +4243,9 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+hoist-non-react-statics@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -8888,9 +8888,9 @@ typescript@*:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-typescript@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.0-dev.20180711:
+  version "3.0.0-dev.20180711"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-dev.20180711.tgz#aa3d44fd3e3514779d0dd92f47be297ba1f327df"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
This bumps hoist-non-react-statics to 2.5.5. It also bumps TypeScript (in dev deps) to v3.0.0-dev. TS 3 is coming in a few days, so should be fine. The problem was that TS 2.9.1 was outputting the wrong paths to `create-react-context` types. Upgrading to v3.0.0 seems to have fixed this issue (#720).

**before**
```tsx 
// ./dist/connect.d.ts
import * as React from 'react';
import { FormikContext } from './types';
export declare const FormikProvider: React.ComponentClass<import("../../../../../../../Users/jared/workspace/github/jaredpalmer/formik/node_modules/create-react-context").ProviderProps<FormikContext<any>>>, FormikConsumer: React.ComponentClass<import("../../../../../../../Users/jared/workspace/github/jaredpalmer/formik/node_modules/create-react-context").ConsumerProps<FormikContext<any>>>;
export declare function connect<OuterProps, Values = {}>(Comp: React.ComponentType<OuterProps & {
    formik: FormikContext<Values>;
}>): React.ComponentClass<OuterProps> & {
    WrappedComponent: React.ComponentClass<OuterProps & {
        formik: FormikContext<Values>;
    }>;
};
```

**after**

```tsx
// ./dist/connect.d.ts
import * as React from 'react';
import { FormikContext } from './types';
export declare const FormikProvider: React.ComponentClass<import("create-react-context").ProviderProps<FormikContext<any>>>, FormikConsumer: React.ComponentClass<import("create-react-context").ConsumerProps<FormikContext<any>>>;
export declare function connect<OuterProps, Values = {}>(Comp: React.ComponentType<OuterProps & {
    formik: FormikContext<Values>;
}>): React.ComponentClass<OuterProps> & {
    WrappedComponent: React.ComponentClass<OuterProps & {
        formik: FormikContext<Values>;
    }>;
};

```