### PR TITLE
Reduce bundle sizes by adding tslib as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lodash.topath": "4.5.2",
     "prop-types": "^15.6.1",
     "react-fast-compare": "^1.0.0",
+    "tslib": "^1.9.3",
     "warning": "^3.0.0"
   },
   "optionalDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -8822,6 +8822,10 @@ tslib@^1.7.1, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
+tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
 tslint-react@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.2.0.tgz#851fb505201c63d0343c51726e6364f7e9ad2e99"


### PR DESCRIPTION
Couldn't see if this had been discussed before, so started with the smallest possible thing. I might be missing context so feel free to 🗑 if that's the case.

Since we're using `importHelpers` in `tsconfig.json`, adding `tslib` as a direct dep will externalise it in the relevant rollup configs rather than baking it into the bundle, reducing bundle size. Also noticed that the UMD builds are only externalising peer deps, so have not done anything there.

Some initial numbers after the change:

```
./dist/formik.cjs.production.js: 8.35Kb -> 7.56Kb
./dist/formik.cjs.development.js: 8.63Kb -> 7.85Kb
./dist/formik.esm.js: 8.46Kb -> 7.69Kb
./dist/index.js: 8.64Kb -> 7.87Kb
```