### PR TITLE
Fix type of handleChange on FormikHandlers

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -147,7 +147,7 @@ export interface FormikHandlers {
     field: T
   ): T extends React.ChangeEvent<any>
     ? void
-    : ((e: React.ChangeEvent<any>) => void);
+    : ((e: string | React.ChangeEvent<any>) => void);
 }
 
 /**


### PR DESCRIPTION
According to the code: 
https://github.com/jaredpalmer/formik/blob/7f44262ee4a16371144fa60a196762d9b268a46f/src/Formik.tsx#L290 

https://github.com/jaredpalmer/formik/blob/7f44262ee4a16371144fa60a196762d9b268a46f/src/types.tsx#L150

I believe the type `handleChange`  that is on the `FormikHandlers` interface is incomplete

