### PR TITLE
Fix FastField for number input with empty value

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -99,8 +99,9 @@ class FastFieldInner<Props = {}, Values = {}> extends React.Component<
       setFormikState,
     } = this.props.formik;
     const { type, value, checked } = e.target;
+    let parsed;
     const val = /number|range/.test(type)
-      ? parseFloat(value)
+      ? ((parsed = parseFloat(value)), isNaN(parsed) ? '' : parsed)
       : /checkbox/.test(type) ? checked : value;
     if (validateOnChange) {
       // Field-level validation


### PR DESCRIPTION
Issue:
FastField have an issue in handling input with type number or range when the value is empty.
It triggers infinite loop warnings "The specified value "NaN" is not a valid number...".

Here is the demo of issue: [https://codesandbox.io/s/n4rlmq208p](https://codesandbox.io/s/n4rlmq208p)

Solution:
if input value is '' for number or range input, don't parseFloat it. 