### PR TITLE
fix: correct typing of handleSubmit in FormikHandlers

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -131,7 +131,7 @@ export interface FormikActions<Values> {
  */
 export interface FormikHandlers {
   /** Form submit handler */
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (e?: React.FormEvent<HTMLFormElement>) => void;
   /** Reset form event handler  */
   handleReset: () => void;
   /** Classic React blur handler, keyed by input name */


### PR DESCRIPTION
according to the code
https://github.com/jaredpalmer/formik/blob/f2d0d3bbe4e9801c556ba8f5a59eb46576cedb96/src/Formik.tsx#L384
I believe `e` in `handleSubmit` is an optional param.