### PR TITLE
Set filed to null when field type is number and value is empty

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -327,7 +327,7 @@ export class Formik<ExtraProps = {}, Values = object> extends React.Component<
           });
         }
         val = /number|range/.test(type)
-          ? ((parsed = parseFloat(value)), isNaN(parsed) ? '' : parsed)
+          ? ((parsed = parseFloat(value)), isNaN(parsed) ? null : parsed)
           : /checkbox/.test(type) ? checked : value;
       }
 


### PR DESCRIPTION
I have a number input and when I remove the last digit the field takes an empty string value (`""`). This is breaking some form submissions on the server side (graphql) as the input is defined as `types.Float`