### PR TITLE
Fix error props when the Value does not extend object

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -11,7 +11,7 @@ export interface FormikValues {
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
 export type FormikErrors<Values> = {
-  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : {}
+  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : Values[K]
 };
 
 /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -11,7 +11,7 @@ export interface FormikValues {
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
 export type FormikErrors<Values> = {
-  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : Values[K]
+  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : string
 };
 
 /**


### PR DESCRIPTION
This resolves errors like this for me:

```
Type '{} | undefined' is not assignable to type 'string | undefined'.
  Type '{}' is not assignable to type 'string'.
TextField.tsx(40, 3): The expected type comes from property 'error' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<TextField> & Readonly<{ children?: ReactNode; }> & Readonly<Partial<TextFieldProps>>'
```