### PR TITLE
fix array helpers push side effect issue

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cloneDeep from 'lodash.clonedeep';
 import { connect } from './connect';
 import {
   FormikContext,
@@ -125,7 +126,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
 
   push = (value: any) =>
     this.updateArrayField(
-      (array: any[]) => [...(array || []), value],
+      (array: any[]) => [...(array || []), cloneDeep(value)],
       false,
       false
     );

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -95,6 +95,37 @@ describe('<FieldArray />', () => {
       const expected = ['jared', 'andrea', 'brent', 'jared'];
       expect(formikBag.values.friends).toEqual(expected);
     });
+    it('should push clone not actual referance', () => {
+      let personTemplate = { firstName: '', lastName: '' };
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestForm
+          initialValues={{ people: [] }}
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="people"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      arrayHelpers.push(personTemplate);
+      expect(
+        formikBag.values.people[formikBag.values.people.length - 1]
+      ).not.toBe(personTemplate);
+      expect(
+        formikBag.values.people[formikBag.values.people.length - 1]
+      ).toMatchObject(personTemplate);
+    });
   });
 
   describe('props.pop()', () => {


### PR DESCRIPTION
Fixes side effect that happen when using object in `arrayProps.push`
Use `cloneDeep` when pushing new value in FieldArray 

| Before | After |
|:-:|:-:|
| ![formik push reference](https://user-images.githubusercontent.com/7680511/44469479-e292b180-a627-11e8-88c2-5f970de4df34.gif) |  ![fix 841](https://user-images.githubusercontent.com/7680511/44469490-eb838300-a627-11e8-8336-1e865e21964d.gif) |



fixes #841 