### PR TITLE
Prevent setState calls in submit if unmounted after validation

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -425,13 +425,11 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
 
     return this.runValidations().then(combinedErrors => {
       const isValid = Object.keys(combinedErrors).length === 0;
-      // Make sure Formik is still mounted.
-      if (this.didMount) {
-        if (isValid) {
-          this.executeSubmit();
-        } else {
-          this.setState({ isSubmitting: false });
-        }
+      if (isValid) {
+        this.executeSubmit();
+      } else if (this.didMount) {
+        // ^^^ Make sure Formik is still mounted before calling setState
+        this.setState({ isSubmitting: false });
       }
     });
   };

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -425,10 +425,13 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
 
     return this.runValidations().then(combinedErrors => {
       const isValid = Object.keys(combinedErrors).length === 0;
-      if (isValid) {
-        this.executeSubmit();
-      } else {
-        this.setState({ isSubmitting: false });
+      // Make sure Formik is still mounted.
+      if (this.didMount) {
+        if (isValid) {
+          this.executeSubmit();
+        } else {
+          this.setState({ isSubmitting: false });
+        }
       }
     });
   };


### PR DESCRIPTION
Fixes #854 by checking for `this.didMount` after async validation is done