### PR TITLE
Begin Deprecate InjectedFormikProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,16 +221,16 @@ const Basic = () => (
     <h1>My Form</h1>
     <p>This can be anywhere in your application</p>
     {/*
-          The benefit of the render prop approach is that you have full access to React's
-          state, props, and composition model. Thus there is no need to map outer props
-          to values...you can just set the initial values, and if they depend on props / state
-          then--boom--you can directly access to props / state.
-          The render prop accepts your inner form component, which you can define separately or inline
-          totally up to you:
-          - `<Formik render={props => <form>...</form>}>`
-          - `<Formik component={InnerForm}>`
-          - `<Formik>{props => <form>...</form>}</Formik>` (identical to as render, just written differently)
-        */}
+                  The benefit of the render prop approach is that you have full access to React's
+                  state, props, and composition model. Thus there is no need to map outer props
+                  to values...you can just set the initial values, and if they depend on props / state
+                  then--boom--you can directly access to props / state.
+                  The render prop accepts your inner form component, which you can define separately or inline
+                  totally up to you:
+                  - `<Formik render={props => <form>...</form>}>`
+                  - `<Formik component={InnerForm}>`
+                  - `<Formik>{props => <form>...</form>}</Formik>` (identical to as render, just written differently)
+                */}
     <Formik
       initialValues={{
         email: '',
@@ -600,8 +600,7 @@ DOM and React Native are:
 1.  Formik's `props.handleSubmit` is passed to a `<Button onPress={...} />`
     instead of HTML `<form onSubmit={...} />` component (since there is no
     `<form />` element in React Native).
-2.  `<TextInput />` uses Formik's `props.handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly     assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with ReactNative we can't get it automatically like for web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setTouched(fieldName, bool)` as an alternative.
-
+2.  `<TextInput />` uses Formik's `props.handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with ReactNative we can't get it automatically like for web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setTouched(fieldName, bool)` as an alternative.
 
 #### Avoiding new functions in render
 
@@ -737,7 +736,7 @@ interface OtherProps {
   message: string;
 }
 
-// You may see / use InjectedFormikProps<OtherProps, FormValues> instead of what comes below, they are almost the same. InjectedFormikProps was artifact of when Formik only exported a HoC. It is also less flexible as it MUST wrap all props (it passes them through).
+// Aside: You may see InjectedFormikProps<OtherProps, FormValues> instead of what comes below in older code.. InjectedFormikProps was artifact of when Formik only exported a HoC. It is also less flexible as it MUST wrap all props (it passes them through).
 const InnerForm = (props: OtherProps & FormikProps<FormValues>) => {
   const { touched, errors, isSubmitting, message } = props;
   return (

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -11,7 +11,9 @@ export interface FormikValues {
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
 export type FormikErrors<Values> = {
-  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : string
+  [K in keyof Values]?: Values[K] extends object
+    ? FormikErrors<Values[K]>
+    : string
 };
 
 /**
@@ -222,17 +224,21 @@ export type FormikProps<Values> = FormikSharedConfig &
   FormikState<Values> &
   FormikActions<Values> &
   FormikHandlers &
-  FormikComputedProps<Values> & {
-    registerField(
-      name: string,
-      fns: {
-        validate?: ((
-          value: any
-        ) => string | Function | Promise<void> | undefined);
-      }
-    ): void;
-    unregisterField(name: string): void;
-  };
+  FormikComputedProps<Values> &
+  FormikRegistration;
+
+/** Internal Formik registration methods that get passed down as props */
+export interface FormikRegistration {
+  registerField(
+    name: string,
+    fns: {
+      validate?: ((
+        value: any
+      ) => string | Function | Promise<void> | undefined);
+    }
+  ): void;
+  unregisterField(name: string): void;
+}
 
 /**
  * State, handlers, and helpers made available to Formik's primitive components through context.

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -12,10 +12,10 @@ import { isFunction } from './utils';
 /**
  * State, handlers, and helpers injected as props into the wrapped form component.
  * Used with withFormik()
- * @deprecated
+ *
+ * @deprecated  Use `OuterProps & FormikProps<Values>` instead.
  */
 export type InjectedFormikProps<Props, Values> = Props & FormikProps<Values>;
-
 /**
  * Formik actions + { props }
  */
@@ -77,11 +77,11 @@ export interface InferableComponentDecorator<TOwnProps> {
  * A public higher-order component to access the imperative API
  */
 export function withFormik<
-  Props,
+  OuterProps,
   Values extends FormikValues,
   Payload = Values
 >({
-  mapPropsToValues = (vanillaProps: Props): Values => {
+  mapPropsToValues = (vanillaProps: OuterProps): Values => {
     let val: Values = {} as Values;
     for (let k in vanillaProps) {
       if (
@@ -94,13 +94,13 @@ export function withFormik<
     return val as Values;
   },
   ...config
-}: WithFormikConfig<Props, Values, Payload>): ComponentDecorator<
-  Props,
-  InjectedFormikProps<Props, Values>
+}: WithFormikConfig<OuterProps, Values, Payload>): ComponentDecorator<
+  OuterProps,
+  OuterProps & FormikProps<Values>
 > {
   return function createFormik(
-    Component: CompositeComponent<InjectedFormikProps<Props, Values>>
-  ): React.ComponentClass<Props> {
+    Component: CompositeComponent<OuterProps & FormikProps<Values>>
+  ): React.ComponentClass<OuterProps> {
     const componentDisplayName =
       Component.displayName ||
       Component.name ||
@@ -110,7 +110,7 @@ export function withFormik<
      * We need to use closures here for to provide the wrapped component's props to
      * the respective withFormik config methods.
      */
-    class C extends React.Component<Props, {}> {
+    class C extends React.Component<OuterProps, {}> {
       static displayName = `WithFormik(${componentDisplayName})`;
 
       validate = (values: Values): void | object | Promise<any> => {
@@ -152,9 +152,9 @@ export function withFormik<
       }
     }
 
-    return hoistNonReactStatics<Props, InjectedFormikProps<Props, Values>>(
+    return hoistNonReactStatics<OuterProps, OuterProps & FormikProps<Values>>(
       C,
-      Component as React.ComponentClass<InjectedFormikProps<Props, Values>> // cast type to ComponentClass (even if SFC)
-    ) as React.ComponentClass<Props>;
+      Component as React.ComponentClass<OuterProps & FormikProps<Values>> // cast type to ComponentClass (even if SFC)
+    ) as React.ComponentClass<OuterProps>;
   };
 }

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -9,6 +9,7 @@ import {
   FormikSharedConfig,
   FormikState,
   FormikValues,
+  FormikRegistration,
 } from './types';
 import { isFunction } from './utils';
 
@@ -20,7 +21,8 @@ export type InjectedFormikProps<Props, Values> = Props &
   FormikState<Values> &
   FormikActions<Values> &
   FormikHandlers &
-  FormikComputedProps<Values>;
+  FormikComputedProps<Values> &
+  FormikRegistration;
 
 /**
  * Formik actions + { props }

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -16,13 +16,9 @@ import { isFunction } from './utils';
 /**
  * State, handlers, and helpers injected as props into the wrapped form component.
  * Used with withFormik()
+ * @deprecated
  */
-export type InjectedFormikProps<Props, Values> = Props &
-  FormikState<Values> &
-  FormikActions<Values> &
-  FormikHandlers &
-  FormikComputedProps<Values> &
-  FormikRegistration;
+export type InjectedFormikProps<Props, Values> = Props & FormikProps<Values>;
 
 /**
  * Formik actions + { props }

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -16,6 +16,7 @@ import { isFunction } from './utils';
  * @deprecated  Use `OuterProps & FormikProps<Values>` instead.
  */
 export type InjectedFormikProps<Props, Values> = Props & FormikProps<Values>;
+
 /**
  * Formik actions + { props }
  */

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -3,13 +3,9 @@ import * as React from 'react';
 import { Formik } from './Formik';
 import {
   FormikActions,
-  FormikComputedProps,
-  FormikHandlers,
   FormikProps,
   FormikSharedConfig,
-  FormikState,
   FormikValues,
-  FormikRegistration,
 } from './types';
 import { isFunction } from './utils';
 

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { withFormik, InjectedFormikProps } from '../src';
+import { withFormik, FormikProps } from '../src';
 import { mount, shallow } from '@pisano/enzyme';
 
 // tslint:disable-next-line:no-empty
@@ -19,7 +19,7 @@ interface Values {
   name: string;
 }
 
-const Form: React.SFC<InjectedFormikProps<Props, Values>> = ({
+const Form: React.SFC<Props & FormikProps<Values>> = ({
   values,
   handleSubmit,
   handleChange,


### PR DESCRIPTION
- Refactor dangling TS types in `FormikProps` to a new `interface FormikRegistration` 
- Remove usage of `InjectedFormikProps` and begin type deprecation as it is redundant and less flexible than `FormikProps<Values>`.

Fixes #862.