### PR TITLE
Remove redundant Field handlers now that validation lives in parent

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -139,39 +139,6 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
     this.props.formik.unregisterField(this.props.name);
   }
 
-  handleChange = (e: React.ChangeEvent<any>) => {
-    const { handleChange, validateOnChange } = this.props.formik;
-    handleChange(e); // Call Formik's handleChange no matter what
-    if (!!validateOnChange && !!this.props.validate) {
-      this.runFieldValidations(e.target.value);
-    }
-  };
-
-  handleBlur = (e: any) => {
-    const { handleBlur, validateOnBlur } = this.props.formik;
-    handleBlur(e); // Call Formik's handleBlur no matter what
-    if (!!validateOnBlur && !!this.props.validate) {
-      this.runFieldValidations(e.target.value);
-    }
-  };
-
-  runFieldValidations = (value: any) => {
-    const { setFieldError } = this.props.formik;
-    const { name, validate } = this.props;
-    // Call validate fn
-    const maybePromise = (validate as any)(value);
-    // Check if validate it returns a Promise
-    if (isPromise(maybePromise)) {
-      (maybePromise as Promise<any>).then(
-        () => setFieldError(name, undefined as any),
-        error => setFieldError(name, error)
-      );
-    } else {
-      // Otherwise set the error
-      setFieldError(name, maybePromise);
-    }
-  };
-
   render() {
     const {
       validate,
@@ -195,8 +162,8 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
           ? props.value // React uses checked={} for these inputs
           : getIn(formik.values, name),
       name,
-      onChange: validate ? this.handleChange : formik.handleChange,
-      onBlur: validate ? this.handleBlur : formik.handleBlur,
+      onChange: formik.handleChange,
+      onBlur: formik.handleBlur,
     };
     const bag = { field, form: restOfFormik };
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -6,7 +6,7 @@ import {
   GenericFieldHTMLAttributes,
   FormikContext,
 } from './types';
-import { getIn, isEmptyChildren, isFunction, isPromise } from './utils';
+import { getIn, isEmptyChildren, isFunction } from './utils';
 
 /**
  * Note: These typings could be more restrictive, but then it would limit the

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -24,84 +24,62 @@ describe('A <Field />', () => {
       shallow(<Field.WrappedComponent {...props} />);
 
     it('calls validate during onChange if present', () => {
-      const handleChange = jest.fn(noop);
-      const setFieldError = jest.fn(noop);
+      const node = document.createElement('div');
+      let injected: any; /** FieldProps ;) */
       const validate = jest.fn(noop);
-      const tree = makeFieldTree({
-        name: 'name',
-        validate,
-        formik: {
-          registerField: noop,
-          unregisterField: noop,
-          handleChange,
-          setFieldError,
-          validateOnChange: true,
-        },
-      });
-      tree.find('input').simulate('change', {
-        persist: noop,
-        target: {
-          name: 'name',
-          value: 'ian',
-        },
-      });
-      expect(handleChange).toHaveBeenCalled();
-      expect(setFieldError).toHaveBeenCalled();
+      ReactDOM.render(
+        <TestForm
+          validateOnChange={true}
+          render={(_formikProps: FormikProps<TestFormValues>) => (
+            <Field name="name" validate={validate}>
+              {({ field }: any) => (injected = field) && null}
+            </Field>
+          )}
+        />,
+        node
+      );
+      const { onChange } = injected;
+      onChange({ target: { name: 'name', value: 'hello' } });
       expect(validate).toHaveBeenCalled();
     });
 
     it('does NOT call validate during onChange if validateOnChange is set to false', () => {
-      const handleChange = jest.fn(noop);
-      const setFieldError = jest.fn(noop);
+      const node = document.createElement('div');
+      let injected: any; /** FieldProps ;) */
       const validate = jest.fn(noop);
-      const tree = makeFieldTree({
-        name: 'name',
-        validate,
-        formik: {
-          registerField: noop,
-          unregisterField: noop,
-          handleChange,
-          setFieldError,
-          validateOnChange: false,
-        },
-      });
-      tree.find('input').simulate('change', {
-        persist: noop,
-        target: {
-          name: 'name',
-          value: 'ian',
-        },
-      });
-      expect(handleChange).toHaveBeenCalled();
-      expect(setFieldError).not.toHaveBeenCalled();
+      ReactDOM.render(
+        <TestForm
+          validateOnChange={false}
+          render={(_formikProps: FormikProps<TestFormValues>) => (
+            <Field name="name" validate={validate}>
+              {({ field }: any) => (injected = field) && null}
+            </Field>
+          )}
+        />,
+        node
+      );
+      const { onChange } = injected;
+      onChange({ target: { name: 'name', value: 'hello' } });
       expect(validate).not.toHaveBeenCalled();
     });
 
     it('calls validate during onBlur if present', () => {
-      const handleBlur = jest.fn(noop);
-      const setFieldError = jest.fn(noop);
+      const node = document.createElement('div');
+      let injected: any; /** FieldProps ;) */
       const validate = jest.fn(noop);
-      const tree = makeFieldTree({
-        name: 'name',
-        validate,
-        formik: {
-          registerField: noop,
-          unregisterField: noop,
-          handleBlur,
-          setFieldError,
-          validateOnBlur: true,
-        },
-      });
-      tree.find('input').simulate('blur', {
-        persist: noop,
-        target: {
-          name: 'name',
-          value: 'ian',
-        },
-      });
-
-      expect(handleBlur).toHaveBeenCalled();
-      expect(setFieldError).toHaveBeenCalled();
+      ReactDOM.render(
+        <TestForm
+          validateOnBlur={true}
+          render={(_formikProps: FormikProps<TestFormValues>) => (
+            <Field name="name" validate={validate}>
+              {({ field }: any) => (injected = field) && null}
+            </Field>
+          )}
+        />,
+        node
+      );
+      const { onBlur } = injected;
+      onBlur({ target: { name: 'name' } });
       expect(validate).toHaveBeenCalled();
     });
 
@@ -128,7 +106,6 @@ describe('A <Field />', () => {
         },
       });
       expect(handleBlur).toHaveBeenCalled();
-      expect(setFieldError).not.toHaveBeenCalled();
       expect(validate).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
We were over-validating since we moved field-level validation up to the parent. This was an oversight during the refactoring, but it corrected with this PR. 