### PR TITLE
Fix validateForm typescript typings and documentation

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -185,7 +185,7 @@ Your form's values. Will have the shape of the result of `mapPropsToValues`
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-#### `validateForm: (values?: any) => void`
+#### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -229,7 +229,7 @@ export const FieldLevelValidationExample = () => (
         console.log(values);
       }}
     >
-      {({ errors, touched }) => (
+      {({ errors, touched, validateField, validateForm }) => (
         <Form>
           <Field name="email" validate={validateEmail} />
           {errors.email && touched.email && <div>{errors.email}</div>}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -96,7 +96,7 @@ export interface FormikActions<Values> {
     shouldValidate?: boolean
   ): void;
   /** Validate form values */
-  validateForm(values?: any): void;
+  validateForm(values?: any): Promise<FormikErrors<Values>>;
   /** Validate field value */
   validateField(field: string): void;
   /** Reset form */


### PR DESCRIPTION
update typescript typings and corresponding documentation to indicate that `validateForm` returns a `Promise`