### PR TITLE
fix email regex in documentation

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -110,7 +110,7 @@ const Basic = () => (
         if (!values.email) {
           errors.email = 'Required';
         } else if (
-          !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)
+          !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)
         ) {
           errors.email = 'Invalid email address';
         }
@@ -181,7 +181,7 @@ const Basic = () => (
         if (!values.email) {
           errors.email = 'Required';
         } else if (
-          !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)
+          !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)
         ) {
           errors.email = 'Invalid email address';
         }


### PR DESCRIPTION
the email regex in the documentation did not match gTLDs with more than 4 characters. I change it to use the first regex recommended on https://www.regular-expressions.info/email.html