### PR TITLE
Using handleBlur with field name types were wrong

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -136,12 +136,8 @@ export interface FormikHandlers {
   handleSubmit: (e?: React.FormEvent<HTMLFormElement>) => void;
   /** Reset form event handler  */
   handleReset: () => void;
-  /** Classic React blur handler, keyed by input name */
-  handleBlur(e: any): void;
   /** Preact-like linkState. Will return a handleBlur function. */
-  handleBlur<T = string | any>(
-    fieldOrEvent: T
-  ): T extends string ? ((e: any) => void) : void;
+  handleBlur<T>(fieldOrEvent: T): T extends string ? ((e: any) => void) : void;
   /** Classic React change handler, keyed by input name */
   handleChange(e: React.ChangeEvent<any>): void;
   /** Preact-like linkState. Will return a handleChange function.  */


### PR DESCRIPTION
`handleBlur(e: any): void;` was capturing the types even though `handleBlur<T>(fieldOrEvent: T): T extends string ? ((e: any) => void) : void;` already takes care of the case if the parameter is something else than a string :)

That is why there is no need for both and tsc is happy