### PR TITLE
Prevent users to set state when the form is unmounted

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -152,7 +152,9 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
   };
 
   setSubmitting = (isSubmitting: boolean) => {
-    this.setState({ isSubmitting });
+    if (this.didMount) {
+      this.setState({ isSubmitting });
+    }
   };
 
   /**

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -364,6 +364,9 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
     value: any,
     shouldValidate: boolean = true
   ) => {
+    if (!this.didMount) {
+      return;
+    }
     // Set form field by name
     this.setState(
       prevState => ({


### PR DESCRIPTION
There are a couple of callbacks given to code using formic forms, that allow users to indirectly set state on the form itself. However, there's nothing preventing these calls to set the state when the form was unmounted. As it happens today in other places, this PR adds a check for this condition to prevent these callbacks to go through calling `setState`, thus avoiding the annoying warning from React in the console.