### PR TITLE
Late registration

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -122,9 +122,9 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
   }
 
   componentDidMount() {
-    this.props.formik.registerField(this.props.name, {
-      validate: this.props.validate,
-    });
+    // Register the Field with the parent Formik. Parent will cycle through
+    // registered Field's validate fns right prior to submit
+    this.props.formik.registerField(this.props.name, this);
   }
 
   componentDidUpdate(
@@ -132,15 +132,11 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
   ) {
     if (this.props.name !== prevProps.name) {
       this.props.formik.unregisterField(prevProps.name);
-      this.props.formik.registerField(this.props.name, {
-        validate: this.props.validate,
-      });
+      this.props.formik.registerField(this.props.name, this);
     }
 
     if (this.props.validate !== prevProps.validate) {
-      this.props.formik.registerField(this.props.name, {
-        validate: this.props.validate,
-      });
+      this.props.formik.registerField(this.props.name, this);
     }
   }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -86,7 +86,7 @@ export type FieldAttributes<T> = GenericFieldHTMLAttributes & FieldConfig & T;
  * Custom Field component for quickly hooking into Formik
  * context and wiring up forms.
  */
-class FieldInner<Props = {}, Values = {}> extends React.Component<
+class FieldInner<Values = {}, Props = {}> extends React.Component<
   FieldAttributes<Props> & { formik: FormikContext<Values> },
   {}
 > {
@@ -94,8 +94,7 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
     props: FieldAttributes<Props> & { formik: FormikContext<Values> }
   ) {
     super(props);
-
-    const { render, children, component, formik } = props;
+    const { render, children, component } = props;
     warning(
       !(component && render),
       'You should not use <Field component> and <Field render> in the same <Field> component; <Field component> will be ignored'
@@ -110,12 +109,12 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
       !(render && children && !isEmptyChildren(children)),
       'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
     );
+  }
 
+  componentDidMount() {
     // Register the Field with the parent Formik. Parent will cycle through
     // registered Field's validate fns right prior to submit
-    formik.registerField(props.name, {
-      validate: props.validate,
-    });
+    this.props.formik.registerField(this.props.name, this);
   }
 
   componentDidUpdate(
@@ -123,15 +122,11 @@ class FieldInner<Props = {}, Values = {}> extends React.Component<
   ) {
     if (this.props.name !== prevProps.name) {
       this.props.formik.unregisterField(prevProps.name);
-      this.props.formik.registerField(this.props.name, {
-        validate: this.props.validate,
-      });
+      this.props.formik.registerField(this.props.name, this);
     }
 
     if (this.props.validate !== prevProps.validate) {
-      this.props.formik.registerField(this.props.name, {
-        validate: this.props.validate,
-      });
+      this.props.formik.registerField(this.props.name, this);
     }
   }
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -44,9 +44,7 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
     [key: string]: (e: any) => void;
   } = {};
   fields: {
-    [field: string]: {
-      validate?: ((value: any) => string | Promise<void> | undefined);
-    };
+    [field: string]: React.Component<any>;
   };
 
   constructor(props: FormikConfig<Values> & ExtraProps) {
@@ -78,14 +76,8 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
     );
   }
 
-  registerField = (
-    name: string,
-    fns: {
-      reset?: ((nextValues?: any) => void);
-      validate?: ((value: any) => string | Promise<void> | undefined);
-    }
-  ) => {
-    this.fields[name] = fns;
+  registerField = (name: string, Comp: React.Component<any>) => {
+    this.fields[name] = Comp;
   };
 
   unregisterField = (name: string) => {
@@ -180,7 +172,7 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
     value: void | string
   ): Promise<string> => {
     return new Promise(resolve =>
-      resolve(this.fields[field].validate!(value))
+      resolve(this.fields[field].props.validate(value))
     ).then(x => x, e => e);
   };
 
@@ -191,8 +183,8 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
       f =>
         this.fields &&
         this.fields[f] &&
-        this.fields[f].validate &&
-        isFunction(this.fields[f].validate)
+        this.fields[f].props.validate &&
+        isFunction(this.fields[f].props.validate)
     );
 
     // Construct an array with all of the field validation functions

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -229,14 +229,7 @@ export type FormikProps<Values> = FormikSharedConfig &
 
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {
-  registerField(
-    name: string,
-    fns: {
-      validate?: ((
-        value: any
-      ) => string | Function | Promise<void> | undefined);
-    }
-  ): void;
+  registerField(name: string, Comp: React.Component<any>): void;
   unregisterField(name: string): void;
 }
 


### PR DESCRIPTION
- Move register `<Field>` and `<FastField>` to `componentDidMount` and out of `constructor` for better compat with React 16.5+ and future suspense / timeslicing stuff (believe me)
- Instead of just registering the validate function, this now just registers the whole instance of the component.

Closes #865 