### PR TITLE
Added isSubmitting boolean to onSubmit handler

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -437,7 +437,11 @@ export class Formik<Values = {}, ExtraProps = {}> extends React.Component<
   };
 
   executeSubmit = () => {
-    this.props.onSubmit(this.state.values, this.getFormikActions());
+    this.props.onSubmit(
+      this.state.values,
+      this.getFormikActions(),
+      this.state.isSubmitting
+    );
   };
 
   handleBlur = (eventOrString: any): void | ((e: any) => void) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -183,7 +183,11 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Submission handler
    */
-  onSubmit: (values: Values, formikActions: FormikActions<Values>) => void;
+  onSubmit: (
+    values: Values,
+    formikActions: FormikActions<Values>,
+    isSubmitting: boolean
+  ) => void;
 
   /**
    * Form component to render


### PR DESCRIPTION
In the following case:
```
        <Formik>
            onSubmit={values => {
                doSubmit(values).then(onClose);
            }}
            render={({ handleSubmit, ...rest }) => (
                <form onSubmit={handleSubmit}>
                    ...
                </form>
            )}
        />
```

Repeatedly pressing enter in the form would cause multiple calls to handleSubmit. (html5 spec: https://stackoverflow.com/a/3403470/1798137). You could prevent this with the following code:

```
<form onSubmit={!isSubmitting ? handleSubmit : undefined}>
   ...
</form>
```

However, in the case of `onSubmit=undefined` the browser does a default GET request on the page which causes the application to refresh. You need a `event.preventDefault` call but Formik's `handleSubmit` already takes care of this. Therefore I propose to send the `isSubmitting` state to the `onSubmit` handler so the user can prevent double submits.

Alternatives would be to prevent double submits in `handleSubmit` by checking for `isSubmitting` state, however maybe the user intentionally wants to re-submit if the case of a server hang?
