### PR TITLE
feat(setFieldValue): support for callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ legacy.d.ts
 .idea
 *.orig
 .DS_Store
+.vscode/
 
 node_modules
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -362,7 +362,10 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
     value: any,
     shouldValidate: boolean = true
   ) => {
-    if (this.didMount) {
+    return new Promise(resolve => {
+      if (!this.didMount) {
+        resolve();
+      }
       // Set form field by name
       this.setState(
         prevState => ({
@@ -371,11 +374,13 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
         }),
         () => {
           if (this.props.validateOnChange && shouldValidate) {
-            this.runValidations(this.state.values);
+            this.runValidations(this.state.values).then(() => resolve());
+          } else {
+            resolve();
           }
         }
       );
-    }
+    });
   };
 
   handleSubmit = (e: React.FormEvent<HTMLFormElement> | undefined) => {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -569,6 +569,48 @@ describe('<Formik>', () => {
       ).toEqual('ian');
     });
 
+    it('setFieldValue promise is called succesfully with no validation', async () => {
+      const tree = shallow(BasicForm);
+      await tree
+        .find(Form)
+        .props()
+        .setFieldValue('name', 'ian', false);
+
+      expect(
+        tree
+          .update()
+          .find(Form)
+          .props().values.name
+      ).toEqual('ian');
+    });
+
+    it('setFieldValue promise is called succesfully with validation after validation', async () => {
+      const validate = jest.fn().mockReturnValue({});
+
+      const tree = shallow(
+        <Formik
+          initialValues={{ name: 'jared' }}
+          onSubmit={noop}
+          component={Form}
+          validate={validate}
+        />
+      );
+
+      await tree
+        .find(Form)
+        .props()
+        .setFieldValue('name', 'ian');
+
+      expect(
+        tree
+          .update()
+          .find(Form)
+          .props().values.name
+      ).toEqual('ian');
+
+      expect(validate).toHaveBeenCalled();
+    });
+
     it('setFieldValue should run validations when validateOnChange is true', () => {
       const validate = jest.fn().mockReturnValue({});
 


### PR DESCRIPTION
relates #529 

Hey @jaredpalmer this is my first attempt at #529, I want to know if I'm in the right direction. I'm not proficient in typescript btw. 
I'm thinking about adding the same bahavior for the methods inside `getFormikActions`, mostly the `set*` ones:

```
setError
setErrors
setFieldError
setFieldTouched
setFieldValue
setStatus
setSubmitting
setTouched
setValues
setFormikState
```

Please review, and tell me what do you think
Thanks!