### PR TITLE
Update Snack example for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can play with Formik in your web browser with these live online playgrounds.
 * [Working with 3rd-party inputs #1: react-select](https://codesandbox.io/s/jRzE53pqR)
 * [Working with 3rd-party inputs #2: Draft.js](https://codesandbox.io/s/QW1rqjBLl)
 * [Accessing React lifecycle functions](https://codesandbox.io/s/pgD4DLypy)
-* [React Native](https://snack.expo.io/Bk9pPK87X)
+* [React Native](https://snack.expo.io/@ferrannp/react-native-x-formik)
 * [TypeScript](https://codesandbox.io/s/8y578o8152)
 
 ## Organizations and projects using Formik


### PR DESCRIPTION
https://snack.expo.io/@ferrannp/react-native-x-formik

`console.log` was not visible when you were using the example on your phone. So I used just an Alert.

![formik-react-native](https://user-images.githubusercontent.com/774577/45618193-3bae0380-ba75-11e8-9c61-5a69bf026dab.gif)

I also used `react-native-paper` and its own `TextInput`. I think is nice to see you can just use it with any other library :).