### PR TITLE
Alter errors and touched object on index change

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -177,16 +177,17 @@ class FieldArrayInner<Values = {}> extends React.Component<
     this.replace(index, value);
 
   unshift = (value: any) => {
-    let arr = [];
+    let length = -1;
     this.updateArrayField(
       (array: any[]) => {
-        arr = array ? [value, ...array] : [value];
+        const arr = array ? [value, ...array] : [value];
+        if (length < 0) length = arr.length;
         return arr;
       },
       true,
       true
     );
-    return arr.length;
+    return length;
   };
 
   handleUnshift = (value: any) => () => this.unshift(value);

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -141,8 +141,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   swap = (indexA: number, indexB: number) =>
     this.updateArrayField(
       (array: any[]) => swap(array, indexA, indexB),
-      false,
-      false
+      true,
+      true
     );
 
   handleSwap = (indexA: number, indexB: number) => () =>
@@ -151,8 +151,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   move = (from: number, to: number) =>
     this.updateArrayField(
       (array: any[]) => move(array, from, to),
-      false,
-      false
+      true,
+      true
     );
 
   handleMove = (from: number, to: number) => () => this.move(from, to);
@@ -160,8 +160,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   insert = (index: number, value: any) =>
     this.updateArrayField(
       (array: any[]) => insert(array, index, value),
-      false,
-      false
+      true,
+      true
     );
 
   handleInsert = (index: number, value: any) => () => this.insert(index, value);
@@ -183,8 +183,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
         arr = array ? [value, ...array] : [value];
         return arr;
       },
-      false,
-      false
+      true,
+      true
     );
     return arr.length;
   };


### PR DESCRIPTION
Alter errors and touched object after index changing operations on the values array. (E.g. move, unshift, swap) 
Otherwise, after modifying the array, errors get assigned to the wrong input.