### PR TITLE
Reset touched object for Multistep Wizard example

### DIFF
--- a/examples/MultistepWizard.js
+++ b/examples/MultistepWizard.js
@@ -43,6 +43,7 @@ class Wizard extends React.Component {
       return onSubmit(values, bag);
     } else {
       this.next(values);
+      bag.setTouched({});
       bag.setSubmitting(false);
     }
   };


### PR DESCRIPTION
This will reset the touched object when the user navigate to a new page on a multipage form, suppressing validation errors until Fields are touched again to ensure a consistent behaviour for all pages of the form instead of just the first page.