### PR TITLE
Tiny copy fix for the `render` prop definition

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -171,7 +171,7 @@ A field's name in Formik state. To access nested objects or arrays, name can als
 
 `render?: (props: FieldProps) => React.ReactNode`
 
-A function that returns a React.
+A function that returns one or more JSX elements.
 
 ```jsx
 // Renders an HTML <input> by default


### PR DESCRIPTION
It just said "returns a React". At first I thought that it should be "React component" but realized that's not right, so copied JSXeElements from definition of `children`