### PR TITLE
Fix missing variable reference for field API

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -105,8 +105,8 @@ Either JSX elements or callback function. Same as `render`.
 {({ field, form }) => (
   <div>
     <input type="text" {...field} placeholder="First Name"/>
-    {touched[field.name] &&
-      errors[field.name] && <div className="error">{errors[field.name]}</div>}
+    {form.touched[field.name] &&
+      form.errors[field.name] && <div className="error">{form.errors[field.name]}</div>}
   </div>
 )}
 </Field>

--- a/website/versioned_docs/version-1.2.0/api/field.md
+++ b/website/versioned_docs/version-1.2.0/api/field.md
@@ -105,8 +105,8 @@ Either JSX elements or callback function. Same as `render`.
 {({ field, form }) => (
   <div>
     <input type="text" {...field} placeholder="First Name"/>
-    {touched[field.name] &&
-      errors[field.name] && <div className="error">{errors[field.name]}</div>}
+    {form.touched[field.name] &&
+      form.errors[field.name] && <div className="error">{form.errors[field.name]}</div>}
   </div>
 )}
 </Field>


### PR DESCRIPTION
I fixed it by adding `form.` prefix for variables. I could switch to use destructuring (`{ field, form: { touched, errors } }`) if that's preferred.