### PR TITLE
Add missing preposition to Validation docs

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -64,7 +64,7 @@ For more information about `<Formik validate>`, see the API reference.
 As you can see above, validation is left up to you. Feel free to write your own
 validators or use a 3rd party library. At The Palmer Group, we use
 [Yup](https://github.com/jquense/yup) for object schema validation. It has an
-API that's pretty similar [Joi](https://github.com/hapijs/joi) and
+API that's pretty similar to [Joi](https://github.com/hapijs/joi) and
 [React PropTypes](https://github.com/facebook/prop-types) but is small enough
 for the browser and fast enough for runtime usage. Because we :heart: Yup sooo
 much, Formik has a special config option / prop for Yup object schemas called `validationSchema` which will automatically transform Yup's validation errors into a pretty object whose keys match `values` and `touched`. This symmetry makes it easy to manage business logic around error messages.

--- a/website/versioned_docs/version-1.2.0/guides/validation.md
+++ b/website/versioned_docs/version-1.2.0/guides/validation.md
@@ -64,7 +64,7 @@ For more information about `<Formik validate>`, see the API reference.
 As you can see above, validation is left up to you. Feel free to write your own
 validators or use a 3rd party library. At The Palmer Group, we use
 [Yup](https://github.com/jquense/yup) for object schema validation. It has an
-API that's pretty similar [Joi](https://github.com/hapijs/joi) and
+API that's pretty similar to [Joi](https://github.com/hapijs/joi) and
 [React PropTypes](https://github.com/facebook/prop-types) but is small enough
 for the browser and fast enough for runtime usage. Because we :heart: Yup sooo
 much, Formik has a special config option / prop for Yup object schemas called `validationSchema` which will automatically transform Yup's validation errors into a pretty object whose keys match `values` and `touched`. This symmetry makes it easy to manage business logic around error messages.

--- a/website/versioned_docs/version-1.3.1/guides/validation.md
+++ b/website/versioned_docs/version-1.3.1/guides/validation.md
@@ -65,7 +65,7 @@ For more information about `<Formik validate>`, see the API reference.
 As you can see above, validation is left up to you. Feel free to write your own
 validators or use a 3rd party library. At The Palmer Group, we use
 [Yup](https://github.com/jquense/yup) for object schema validation. It has an
-API that's pretty similar [Joi](https://github.com/hapijs/joi) and
+API that's pretty similar to [Joi](https://github.com/hapijs/joi) and
 [React PropTypes](https://github.com/facebook/prop-types) but is small enough
 for the browser and fast enough for runtime usage. Because we :heart: Yup sooo
 much, Formik has a special config option / prop for Yup object schemas called `validationSchema` which will automatically transform Yup's validation errors into a pretty object whose keys match `values` and `touched`. This symmetry makes it easy to manage business logic around error messages.


### PR DESCRIPTION
I believe there's a preposition missing at `It has an
API that's pretty similar Joi and React PropTypes but ...`.