### PR TITLE
Handle reset by default in Form

### DIFF
--- a/docs/api/form.md
+++ b/docs/api/form.md
@@ -4,12 +4,12 @@ title: <Form />
 custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/form.md
 ---
 
-Form is a small wrapper around an HTML `<form>` element that automatically hooks into Formik's `handleSubmit`. All other props are passed directly through to the DOM node.
+Form is a small wrapper around an HTML `<form>` element that automatically hooks into Formik's `handleSubmit` and `handleReset`. All other props are passed directly through to the DOM node.
 
 ```jsx
 // so...
 <Form />
 
 // is identical to this...
-<form onSubmit={formikProps.handleSubmit} {...props} />
+<form onReset={formikProps.handleReset} onSubmit={formikProps.handleSubmit} {...props} />
 ```

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -3,12 +3,15 @@ import { connect } from './connect';
 
 export type FormikFormProps = Pick<
   React.FormHTMLAttributes<HTMLFormElement>,
-  Exclude<keyof React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>
+  Exclude<
+    keyof React.FormHTMLAttributes<HTMLFormElement>,
+    'onReset' | 'onSubmit'
+  >
 >;
 
 export const Form = connect<FormikFormProps>(
-  ({ formik: { handleSubmit }, ...props }) => (
-    <form onSubmit={handleSubmit} {...props} />
+  ({ formik: { handleReset, handleSubmit }, ...props }) => (
+    <form onReset={handleReset} onSubmit={handleSubmit} {...props} />
   )
 );
 


### PR DESCRIPTION
This will make `<button type="reset">` inside the form trigger the form's reset handler. This seems like expected behavior for the `Form` component, because it's almost the exact same functionality as the `submit` case.

I'm not sure which documentation changes you'll want to make if you accept this. I've made the one that seems most clearcut.