### PR TITLE
Add current props to FastField.shouldUpdate

### DIFF
--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -50,7 +50,8 @@ export interface FastFieldConfig<T> {
 
   /** Override FastField's default shouldComponentUpdate */
   shouldUpdate?: (
-    props: T & GenericFieldHTMLAttributes & { formik: FormikContext<any> }
+    nextProps: T & GenericFieldHTMLAttributes & { formik: FormikContext<any> },
+    props: {}
   ) => boolean;
 
   /**
@@ -105,7 +106,7 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
     props: FastFieldAttributes<Props> & { formik: FormikContext<Values> }
   ) {
     if (this.props.shouldUpdate) {
-      return this.props.shouldUpdate(props);
+      return this.props.shouldUpdate(props, this.props);
     } else if (
       getIn(this.props.formik.values, this.props.name) !==
         getIn(props.formik.values, this.props.name) ||


### PR DESCRIPTION
`FastField.shouldComponentUpdate` currently passes its first arg to `shouldUpdate`, but this generally won't be enough info for a custom `shouldUpdate` method: you'll want both the nextProps (first arg of sCU) _and_ the current Props (`this.props`).

(Use case: my validation schema messages are generally strings, but occasionally an object which I need to provide a custom deep comparison for via `shouldUpdate` since Yup's use of cloning means the objects won't equal on a shallow comparison.)
