### PR TITLE
add tree-shaking to exports (#946)

### DIFF
--- a/src/ErrorMessage.tsx
+++ b/src/ErrorMessage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FormikContext } from './types';
 import { getIn, isFunction } from './utils';
-import { connect } from './connect';
+import connect from './connect';
 
 export interface ErrorMessageProps {
   name: string;
@@ -47,7 +47,7 @@ class ErrorMessageImpl extends React.Component<
   }
 }
 
-export const ErrorMessage = connect<
+export default connect<
   ErrorMessageProps,
   ErrorMessageProps & { formik: FormikContext<any> }
 >(ErrorMessageImpl);

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import warning from 'warning';
-import { connect } from './connect';
+import connect from './connect';
 import {
   FormikProps,
   GenericFieldHTMLAttributes,
@@ -200,4 +200,4 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
   }
 }
 
-export const FastField = connect<FastFieldAttributes<any>, any>(FastFieldInner);
+export default connect<FastFieldAttributes<any>, any>(FastFieldInner);

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import warning from 'warning';
-import { connect } from './connect';
+import connect from './connect';
 import {
   FormikProps,
   GenericFieldHTMLAttributes,
@@ -188,4 +188,4 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
   }
 }
 
-export const Field = connect<FieldAttributes<any>, any>(FieldInner);
+export default connect<FieldAttributes<any>, any>(FieldInner);

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import cloneDeep from 'lodash.clonedeep';
-import { connect } from './connect';
+import connect from './connect';
 import {
   FormikContext,
   FormikState,
@@ -149,11 +149,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
     this.swap(indexA, indexB);
 
   move = (from: number, to: number) =>
-    this.updateArrayField(
-      (array: any[]) => move(array, from, to),
-      true,
-      true
-    );
+    this.updateArrayField((array: any[]) => move(array, from, to), true, true);
 
   handleMove = (from: number, to: number) => () => this.move(from, to);
 
@@ -287,4 +283,4 @@ class FieldArrayInner<Values = {}> extends React.Component<
   }
 }
 
-export const FieldArray = connect<FieldArrayConfig, any>(FieldArrayInner);
+export default connect<FieldArrayConfig, any>(FieldArrayInner);

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
-import { connect } from './connect';
+import connect from './connect';
 
 export type FormikFormProps = Pick<
   React.FormHTMLAttributes<HTMLFormElement>,
   Exclude<keyof React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>
 >;
 
-export const Form = connect<FormikFormProps>(
+const Form = connect<FormikFormProps>(
   ({ formik: { handleSubmit }, ...props }) => (
     <form onSubmit={handleSubmit} {...props} />
   )
 );
 
 Form.displayName = 'Form';
+
+export default Form;

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -25,7 +25,10 @@ import {
   getIn,
 } from './utils';
 
-export class Formik<Values = object, ExtraProps = {}> extends React.Component<
+export default class Formik<
+  Values = object,
+  ExtraProps = {}
+> extends React.Component<
   FormikConfig<Values> & ExtraProps,
   FormikState<Values>
 > {

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -12,7 +12,7 @@ export const {
  * Connect any component to Formik context, and inject as a prop called `formik`;
  * @param Comp React Component
  */
-export function connect<OuterProps, Values = {}>(
+export default function connect<OuterProps, Values = {}>(
   Comp: React.ComponentType<OuterProps & { formik: FormikContext<Values> }>
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,50 @@
-export * from './Formik';
-export * from './Field';
-export * from './Form';
-export * from './withFormik';
-export * from './FieldArray';
-export * from './utils';
-export * from './FastField';
+import Formik, { yupToFormErrors, validateYupSchema } from './Formik';
+import Field from './Field';
+import Form from './Form';
+import withFormik from './withFormik';
+import FieldArray, { move, insert, swap, replace } from './FieldArray';
+import {
+  getIn,
+  setIn,
+  setNestedObjectValues,
+  isFunction,
+  isObject,
+  isInteger,
+  isString,
+  isNaN,
+  isEmptyChildren,
+  isPromise,
+  getActiveElement,
+} from './utils';
+import FastField from './FastField';
+import connect from './connect';
+import ErrorMessage from './ErrorMessage';
 export * from './types';
-export * from './connect';
-export * from './ErrorMessage';
+
+export {
+  Formik,
+  yupToFormErrors,
+  validateYupSchema,
+  Field,
+  Form,
+  withFormik,
+  FieldArray,
+  move,
+  insert,
+  swap,
+  replace,
+  FastField,
+  ErrorMessage,
+  connect,
+  getIn,
+  setIn,
+  setNestedObjectValues,
+  isFunction,
+  isObject,
+  isInteger,
+  isString,
+  isNaN,
+  isEmptyChildren,
+  isPromise,
+  getActiveElement,
+};

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -1,6 +1,6 @@
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
-import { Formik } from './Formik';
+import Formik from './Formik';
 import {
   FormikActions,
   FormikProps,
@@ -77,11 +77,7 @@ export interface InferableComponentDecorator<TOwnProps> {
 /**
  * A public higher-order component to access the imperative API
  */
-export function withFormik<
-  OuterProps,
-  Values extends FormikValues,
-  Payload = Values
->({
+function withFormik<OuterProps, Values extends FormikValues, Payload = Values>({
   mapPropsToValues = (vanillaProps: OuterProps): Values => {
     let val: Values = {} as Values;
     for (let k in vanillaProps) {
@@ -159,3 +155,5 @@ export function withFormik<
     ) as React.ComponentClass<OuterProps>;
   };
 }
+
+export default withFormik;


### PR DESCRIPTION
Adding tree-shaking to Formik according to (#946 ). This will allow better bundling for users out there, whenever they only import parts oft he application.

@jaredpalmer input is welcome