### PR TITLE
no children prop passed in withFormik

### DIFF
--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -139,9 +139,10 @@ export function withFormik<
       };
 
       render() {
+        const { children, ...props } = this.props as any;
         return (
           <Formik
-            {...this.props as any}
+            {...props}
             {...config}
             validate={config.validate && this.validate}
             validationSchema={config.validationSchema && this.validationSchema}


### PR DESCRIPTION
#311

This PR fixes the warning `You should not use <Formik render> and <Formik children> in the same <Formik> component; <Formik children> will be ignored` when we use `withFormik`.

The children prop is passed in the `renderFormComponent` method anyway, so it's fine.