### PR TITLE
setIn: keep the same object if nothing is changed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,11 @@ export function setIn(obj: any, path: string, value: any): any {
     }
   }
 
+  // Return original object if new value is the same as current
+  if ((i === 0 ? obj : resVal)[pathArray[i]] === value) {
+    return obj;
+  }
+
   if (value === undefined) {
     delete resVal[pathArray[i]];
   } else {

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -134,6 +134,12 @@ describe('utils', () => {
       expect(newObj).toEqual({ x: 'y', flat: 'value' });
     });
 
+    it('keep the same object if nothing is changed', () => {
+      const obj = { x: 'y' };
+      const newObj = setIn(obj, 'x', 'y');
+      expect(obj).toBe(newObj);
+    });
+
     it('removes flat value', () => {
       const obj = { x: 'y' };
       const newObj = setIn(obj, 'x', undefined);


### PR DESCRIPTION
As it was mentioned in https://github.com/jaredpalmer/formik/pull/646, `setIn` should return the same object if the new value is equal to current.