### PR TITLE
URL to Docs from Help page fixed

### DIFF
--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -15,7 +15,9 @@ const GridBlock = CompLibrary.GridBlock;
 const siteConfig = require(`${process.cwd()}/siteConfig.js`);
 
 function docUrl(doc, language) {
-  return `${siteConfig.baseUrl}docs/${language ? `${language}/` : ''}${doc}`;
+  return `${siteConfig.baseUrl}docs/${
+    language && language !== 'en' ? `${language}/` : ''
+  }${doc}`;
 }
 
 class Help extends React.Component {


### PR DESCRIPTION
Issue was that the current help-page leads to `https://jaredpalmer.com/formik/docs/en/overview.html` But the correct url is `https://jaredpalmer.com/formik/docs/overview.html`.

The language part is currently non-existent for the docs, therefore a language based url to the docs, does not make sense.