### PR TITLE
Don't try to alter not existing errors or touches

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -114,10 +114,10 @@ class FieldArrayInner<Values = {}> extends React.Component<
       (prevState: FormikState<any>) => ({
         ...prevState,
         values: setIn(prevState.values, name, fn(getIn(values, name))),
-        errors: alterErrors
+        errors: (alterErrors && !!getIn(errors, name))
           ? setIn(prevState.errors, name, fn(getIn(errors, name)))
           : prevState.errors,
-        touched: alterTouched
+        touched: (alterTouched && !!getIn(touched, name))
           ? setIn(prevState.touched, name, fn(getIn(touched, name)))
           : prevState.touched,
       }),


### PR DESCRIPTION
Only alter the errors or touched array if an error or touched array exists. Otherwise, a new error or touched array would get created containing the value null.