### PR TITLE
Validation optimization

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,21 @@ export function setNestedObjectValues<T>(
   return response;
 }
 
+/**
+ * Creates a function-updater which updates state only if something is really changed
+ * @param path
+ * @param value
+ */
+export function getStateUpdater<T>(
+  path: string,
+  value: any
+): (prevState: T) => T | null {
+  return (prevState: T) => {
+    const newState = setIn(prevState, path, value);
+    return prevState === newState ? null : newState;
+  };
+}
+
 // Assertions
 
 /** @private is the given object a Function? */

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -1,4 +1,9 @@
-import { setIn, setNestedObjectValues, isPromise } from '../src/utils';
+import {
+  setIn,
+  setNestedObjectValues,
+  isPromise,
+  getStateUpdater,
+} from '../src/utils';
 
 describe('utils', () => {
   describe('setNestedObjectValues', () => {
@@ -134,7 +139,7 @@ describe('utils', () => {
       expect(newObj).toEqual({ x: 'y', flat: 'value' });
     });
 
-    it('keep the same object if nothing is changed', () => {
+    it('keeps the same object if nothing is changed', () => {
       const obj = { x: 'y' };
       const newObj = setIn(obj, 'x', 'y');
       expect(obj).toBe(newObj);
@@ -250,6 +255,24 @@ describe('utils', () => {
 
       expect(isPromise(undefined)).toEqual(false);
       expect(isPromise(null)).toEqual(false);
+    });
+  });
+
+  describe('getStateUpdater', () => {
+    const updater = getStateUpdater('x.y', 'z');
+
+    it('returns null', () => {
+      const state = { x: { y: 'z' } };
+      const newState = updater(state);
+
+      expect(newState).toBe(null);
+    });
+
+    it('returns new state', () => {
+      const state = { x: { y: 'a' } };
+      const newState = updater(state);
+
+      expect(newState).toEqual({ x: { y: 'z' } });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4009,16 +4009,15 @@ entities@^1.1.1, entities@~1.1.1:
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
 enzyme-adapter-react-16@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.5.0.tgz#50af8d76a45fe0915de932bd95d34cdca75c0be3"
-  integrity sha512-R2LcVvMB2UwPH763d5jDtVedAIcEj+uZjOnq0nd1sOUs6z8TDbyHDvt8VwfrS4wMt7CawoyPmH0XzC8MtEqqDw==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz#3fca28d3c32f3ff427495380fe2dd51494689073"
   dependencies:
     enzyme-adapter-utils "^1.8.0"
     function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
     object.values "^1.0.4"
     prop-types "^15.6.2"
-    react-is "^16.4.2"
+    react-is "^16.5.2"
     react-test-renderer "^16.0.0-0"
 
 enzyme-adapter-utils@^1.8.0:
@@ -8892,7 +8891,7 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.4.2:
+react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
   integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
@@ -8939,13 +8938,13 @@ react-style-proptype@^3.0.0:
     prop-types "^15.5.4"
 
 react-test-renderer@^16.0.0-0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
-  integrity sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.2.tgz#92e9d2c6f763b9821b2e0b22f994ee675068b5ae"
   dependencies:
-    fbjs "^0.8.16"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    react-is "^16.5.2"
+    schedule "^0.5.0"
 
 react-transition-group@^2.0.0:
   version "2.4.0"
@@ -9691,6 +9690,12 @@ schedule@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
   integrity sha512-20+1KVo517sR7Nt+bYBN8a+bEJDKLPEx7Ohtts1kX05E4/HY53YUNuhfkVNItmWAnBYHcpG9vsd2/CJxG+aPCQ==
+  dependencies:
+    object-assign "^4.1.1"
+
+schedule@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
I've found that the inner state of Formik is updated too frequently even in cases where that can be avoided. For example, it is not needed to update the state if we just touch a field which was already touched before, or isValidating flag is set and unset even if there are no validations.

This PR fixes two things: how validations are run and how the state is updated.

New helper `getStateUpdater` create a state-updater which updates the state only if something is really changed (it helps to avoid rerender of form in case we call setFieldTouched for an already touched field). 

Renewed `runValidations` caches results of validations and returns the same `combinedErrors` if all validators return the same results. So, it becomes possible to use memoization or other optimizations in validators. It also doesn't set flag `isValidating` in case we don't have any validators or all validators is synchronous.