### PR TITLE
Remove deprecated setError method

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -135,15 +135,6 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
     this.setState({ status });
   };
 
-  setError = (error: any) => {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        `Warning: Formik\'s setError(error) is deprecated and may be removed in future releases. Please use Formik\'s setStatus(status) instead. It works identically. For more info see https://github.com/jaredpalmer/formik#setstatus-status-any--void`
-      );
-    }
-    this.setState({ error });
-  };
-
   setSubmitting = (isSubmitting: boolean) => {
     if (this.didMount) {
       this.setState({ isSubmitting });
@@ -542,7 +533,6 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
       submitForm: this.submitForm,
       validateForm: this.runValidations,
       validateField: this.validateField,
-      setError: this.setError,
       setErrors: this.setErrors,
       setFieldError: this.setFieldError,
       setFieldTouched: this.setFieldTouched,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -68,11 +68,6 @@ export interface FormikComputedProps<Values> {
 export interface FormikActions<Values> {
   /** Manually set top level status. */
   setStatus(status?: any): void;
-  /**
-   * Manually set top level error
-   * @deprecated since 0.8.0
-   */
-  setError(e: any): void;
   /** Manually set errors object */
   setErrors(errors: FormikErrors<Values>): void;
   /** Manually set isSubmitting */

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -954,7 +954,6 @@ describe('<Formik>', () => {
         { name: 'jared' },
         expect.objectContaining({
           resetForm: expect.any(Function),
-          setError: expect.any(Function),
           setErrors: expect.any(Function),
           setFieldError: expect.any(Function),
           setFieldTouched: expect.any(Function),
@@ -1009,7 +1008,6 @@ describe('<Formik>', () => {
         { name: 'jared' },
         expect.objectContaining({
           resetForm: expect.any(Function),
-          setError: expect.any(Function),
           setErrors: expect.any(Function),
           setFieldError: expect.any(Function),
           setFieldTouched: expect.any(Function),


### PR DESCRIPTION
It's been almost [a year](https://github.com/jaredpalmer/formik/blame/master/src/Formik.tsx#L140) when this method was deprecated, so I think it's time to say good bye to it in `2.0`.