### PR TITLE
Issue templates improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,33 +1,43 @@
 ---
 name: "\U0001F41B Bug report"
 about: Create a report to help make Formik better
-
 ---
 
-## Current Behavior
+## 🐛 Bug report
+
+### Current Behavior
+
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-## Steps to Reproduce
-<!-- Steps to reproduce the behavior: -->
+### Expected behavior
 
-## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-## Suggested solution(s)
+### Reproducible example
+
+<!-- Use one of the Codesandbox templates: -->
+
+<!-- Formik template: https://codesandbox.io/s/91q6rxmmrp -->
+
+<!-- withFormik template: https://codesandbox.io/s/437wy20rx4 -->
+
+### Suggested solution(s)
+
 <!-- How could we solve this bug? What changes would need to made to Formik? -->
 
-## Additional context
+### Additional context
+
 <!-- Add any other context about the problem here.  -->
 
+### Your environment
 
-**CodeSandbox Link**:
-
----
 <!-- PLEASE FILL THIS OUT -->
-- Formik Version:
-- React Version:
-- TypeScript Version:
-- Browser and Version:
-- OS: 
-- Node Version:
-- Package Manager and Version:
+
+| Software         | Version(s) |
+| ---------------- | ---------- |
+| Formik           |
+| React            |
+| TypeScript       |
+| Browser          |
+| npm/Yarn         |
+| Operating System |

--- a/.github/ISSUE_TEMPLATE/Documentation.md
+++ b/.github/ISSUE_TEMPLATE/Documentation.md
@@ -1,0 +1,6 @@
+---
+name: "\U0001F41B Documentation"
+about: Imrovements or suggestions of Formik documentation
+---
+
+## 📖 Documentation

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,26 +1,32 @@
 ---
 name: "\U0001F680Feature request"
 about: Suggest an idea for Formik
-
 ---
 
-## Current Behavior
+## 🚀 Feature request
+
+### Current Behavior
+
 <!-- A clear and concise description of what is the current behavior / use.  -->
 
-## Desired Behavior
+### Desired Behavior
+
 <!-- A clear and concise description of what you want to happen.  -->
 
-## Suggested Solution
+### Suggested Solution
+
 <!-- Suggest a solution that the community/maintainers/you may take to enable the desired behavior  -->
+
 <!-- NOTE: Feature Requests without suggested solutions may not be addressed or treated with the same level of urgency as those that have suggested solutions. -->
 
-## Who does this impact? Who is this for?
+### Who does this impact? Who is this for?
+
 <!-- Who is this for? All users? TypeScript users? Beginners? Advanced? Yourself? People using X, Y, X, etc.? -->
 
-## Describe alternatives you've considered
+### Describe alternatives you've considered
+
 <!-- A clear and concise description of any alternative solutions or features you've considered.  -->
 
-## Additional context
+### Additional context
+
 <!-- Add any other context or links about the feature request here. -->
-
-

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -2,7 +2,8 @@
 name: "❓Question"
 about: 'Have a question? Checkout the #formik channel on Reactiflux Discord channel
   or on Spectrum.'
-
 ---
+
+## ❓Question
 
 Seriously, for immediate help, just ask your question on the #formik channel on [Reactiflux](https://discordapp.com/invite/MbKwYuq).


### PR DESCRIPTION
What's included:

- added heading to each issue template for better visual differentiation
- new `bug_report` structure, where reproducible examples are more emphasised
- created two base templates users can start their reproducible examples from (Formik - https://codesandbox.io/s/91q6rxmmrp, withFormik - https://codesandbox.io/s/437wy20rx4)
- added new `documentation` issue template
- level 2 headings for each section seems to be really large, lowered them to level 3