### PR TITLE
Add custom_edit_url to versioned docs

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -1,7 +1,7 @@
 ---
 id: typescript
 title: TypeScript
-custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/react-native.md
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/typescript.md
 ---
 
 [![TypeScript Types](https://img.shields.io/npm/types/formik.svg)](https://npm.im/formik)

--- a/website/versioned_docs/version-1.2.0/api/connect.md
+++ b/website/versioned_docs/version-1.2.0/api/connect.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-connect
 title: connect()
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/connect.md
 original_id: connect
 ---
 

--- a/website/versioned_docs/version-1.2.0/api/fastfield.md
+++ b/website/versioned_docs/version-1.2.0/api/fastfield.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-fastfield
 title: <FastField />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/fastfield.md
 original_id: fastfield
 ---
 

--- a/website/versioned_docs/version-1.2.0/api/field.md
+++ b/website/versioned_docs/version-1.2.0/api/field.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-field
 title: <Field />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/field.md
 original_id: field
 ---
 

--- a/website/versioned_docs/version-1.2.0/api/fieldarray.md
+++ b/website/versioned_docs/version-1.2.0/api/fieldarray.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-fieldarray
 title: <FieldArray />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/fieldarray.md
 original_id: fieldarray
 ---
 

--- a/website/versioned_docs/version-1.2.0/api/form.md
+++ b/website/versioned_docs/version-1.2.0/api/form.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-form
 title: <Form />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/form.md
 original_id: form
 ---
 
@@ -13,4 +14,3 @@ Form is a small wrapper around an HTML `<form>` element that automatically hooks
 // is identical to this...
 <form onSubmit={formikProps.handleSubmit} {...props} />
 ```
-

--- a/website/versioned_docs/version-1.2.0/api/formik.md
+++ b/website/versioned_docs/version-1.2.0/api/formik.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-formik
 title: <Formik />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/formik.md
 original_id: formik
 ---
 

--- a/website/versioned_docs/version-1.2.0/api/withFormik.md
+++ b/website/versioned_docs/version-1.2.0/api/withFormik.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-withFormik
 title: withFormik()
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/withFormik.md
 original_id: withFormik
 ---
 

--- a/website/versioned_docs/version-1.2.0/guides/arrays.md
+++ b/website/versioned_docs/version-1.2.0/guides/arrays.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-arrays
 title: Arrays and Nested Objects
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/arrays.md
 original_id: arrays
 ---
 

--- a/website/versioned_docs/version-1.2.0/guides/form-submission.md
+++ b/website/versioned_docs/version-1.2.0/guides/form-submission.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-form-submission
 title: Form Submission
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/form-submission.md
 original_id: form-submission
 ---
 

--- a/website/versioned_docs/version-1.2.0/guides/react-native.md
+++ b/website/versioned_docs/version-1.2.0/guides/react-native.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-react-native
 title: React Native
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/react-native.md
 original_id: react-native
 ---
 

--- a/website/versioned_docs/version-1.2.0/guides/typescript.md
+++ b/website/versioned_docs/version-1.2.0/guides/typescript.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-typescript
 title: TypeScript
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/typescript.md
 original_id: typescript
 ---
 

--- a/website/versioned_docs/version-1.2.0/guides/validation.md
+++ b/website/versioned_docs/version-1.2.0/guides/validation.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.2.0-validation
 title: Validation
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/validation.md
 original_id: validation
 ---
 

--- a/website/versioned_docs/version-1.3.0/api/errormessage.md
+++ b/website/versioned_docs/version-1.3.0/api/errormessage.md
@@ -1,6 +1,7 @@
 ---
 id: version-1.3.0-errormessage
 title: <ErrorMessage />
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/errormessage.md
 original_id: errormessage
 ---
 


### PR DESCRIPTION
When I was adding the `withFormik()` example on my last PR (#965) I noticed that some "Edit" buttons were redirecting to GitHub's 404 page.