### PR TITLE
Adds a namespace option on withFormik, to consolidate props

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,35 +1,35 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 175856,
-    "minified": 47562,
-    "gzipped": 13810
+    "bundled": 176571,
+    "minified": 47789,
+    "gzipped": 13890
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 40587,
-    "minified": 20665,
-    "gzipped": 5192
+    "bundled": 41270,
+    "minified": 20924,
+    "gzipped": 5270
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 41475,
-    "minified": 21548,
-    "gzipped": 5533
+    "bundled": 42158,
+    "minified": 21807,
+    "gzipped": 5616
   },
   "dist/index.js": {
-    "bundled": 38223,
-    "minified": 21696,
-    "gzipped": 5577
+    "bundled": 38812,
+    "minified": 21955,
+    "gzipped": 5655
   },
   "dist/formik.esm.js": {
-    "bundled": 37015,
-    "minified": 20594,
-    "gzipped": 5405,
+    "bundled": 37585,
+    "minified": 20831,
+    "gzipped": 5486,
     "treeshaked": {
       "rollup": {
-        "code": 628,
+        "code": 658,
         "import_statements": 345
       },
       "webpack": {
-        "code": 3269
+        "code": 3333
       }
     }
   }

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -60,6 +60,12 @@ export interface WithFormikConfig<
    * throws an error object where that object keys map to corresponding value.
    */
   validate?: (values: Values, props: Props) => void | object | Promise<any>;
+
+  /**
+   * If specified, provides all Formik props as a single prop, rather than spreading
+   * them on the wrapped component. Specifying a string will provide them as that prop.
+   */
+  namespace?: boolean | string;
 }
 
 export type CompositeComponent<P> =
@@ -135,6 +141,14 @@ export function withFormik<
        * Just avoiding a render callback for perf here
        */
       renderFormComponent = (formikProps: FormikProps<Values>) => {
+        if (config.namespace) {
+          const namespace =
+            config.namespace === true ? 'formik' : config.namespace;
+          const toSpread: any = {
+            [namespace]: formikProps,
+          };
+          return <Component {...this.props} {...toSpread} />;
+        }
         return <Component {...this.props} {...formikProps} />;
       };
 

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -56,10 +56,14 @@ const Form: React.SFC<Props & FormikProps<Values>> = ({
   );
 };
 
+const defaultOptions = {
+  mapPropsToValues: ({ user }: any) => ({ ...user }),
+  handleSubmit: noop,
+};
+
 const FormFactory = (options = {}) =>
   withFormik<Props, Values, Values>({
-    mapPropsToValues: ({ user }) => ({ ...user }),
-    handleSubmit: noop,
+    ...defaultOptions,
     ...options,
   })(Form);
 
@@ -473,6 +477,46 @@ describe('withFormik()', () => {
           expect(validate).toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe('namespace', () => {
+    it('should provide formikProps under a "formik" prop', () => {
+      const NSForm = ({ formik }: any) => {
+        return <form onSubmit={formik.onSubmit} />;
+      };
+      const NamespaceForm = withFormik({ namespace: true, ...defaultOptions })(
+        NSForm
+      );
+      const tree = mount(<NamespaceForm user={{ name: 'jared' }} />);
+      expect(tree.find(NSForm).props().formik.isSubmitting).toBe(false);
+      expect(tree.find(NSForm).props().formik.touched).toEqual({});
+      expect(tree.find(NSForm).props().formik.values).toEqual({
+        name: 'jared',
+      });
+      expect(tree.find(NSForm).props().formik.errors).toEqual({});
+      expect(tree.find(NSForm).props().formik.dirty).toBe(false);
+      expect(tree.find(NSForm).props().formik.isValid).toBe(false);
+      expect(tree.find(NSForm).props().isSubmitting).toBeUndefined();
+    });
+    it('should be possible to define a customNamespace', () => {
+      const NSForm = ({ formikProps }: any) => {
+        return <form onSubmit={formikProps.onSubmit} />;
+      };
+      const NamespaceForm = withFormik({
+        namespace: 'formikProps',
+        ...defaultOptions,
+      })(NSForm);
+      const tree = mount(<NamespaceForm user={{ name: 'jared' }} />);
+      expect(tree.find(NSForm).props().formikProps.isSubmitting).toBe(false);
+      expect(tree.find(NSForm).props().formikProps.touched).toEqual({});
+      expect(tree.find(NSForm).props().formikProps.values).toEqual({
+        name: 'jared',
+      });
+      expect(tree.find(NSForm).props().formikProps.errors).toEqual({});
+      expect(tree.find(NSForm).props().formikProps.dirty).toBe(false);
+      expect(tree.find(NSForm).props().formikProps.isValid).toBe(false);
+      expect(tree.find(NSForm).props().isSubmitting).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Pretty self-explanatory, instead of spreading the formikProps into the component, this gives the option of providing them as a single prop, either `formik` or another if a string is passed for the option. 

Addresses #718