### PR TITLE
Update initialValues to be optional

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -25,6 +25,8 @@ import {
   getIn,
 } from './utils';
 
+const DEFAULT_INITIAL_VALUE = '';
+
 export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   FormikConfig<Values> & ExtraProps,
   FormikState<Values>
@@ -79,6 +81,18 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
 
   registerField = (name: string, Comp: React.Component<any>) => {
     this.fields[name] = Comp;
+
+    if (!getIn(this.initialValues, name)) {
+      this.initialValues = setIn(
+        this.initialValues,
+        name,
+        DEFAULT_INITIAL_VALUE
+      );
+      this.setState(prevState => ({
+        ...prevState,
+        values: setIn(prevState.values, name, DEFAULT_INITIAL_VALUE),
+      }));
+    }
   };
 
   unregisterField = (name: string) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -189,7 +189,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Initial values of the form
    */
-  initialValues: Values;
+  initialValues?: Values;
 
   /**
    * Reset handler

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import toPath from 'lodash.topath';
 import * as React from 'react';
 
 /**
- * Deeply get a value from an object via it's path.
+ * Deeply get a value from an object via its path.
  */
 export function getIn(
   obj: any,
@@ -19,7 +19,7 @@ export function getIn(
 }
 
 /**
- * Deeply set a value from in object via it's path.
+ * Deeply set a value from in object via its path.
  * @see https://github.com/developit/linkstate
  */
 export function setIn(obj: any, path: string, value: any): any {

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -198,9 +198,44 @@ describe('A <Field />', () => {
         />,
         node
       );
-      const { handleBlur, handleChange } = injected;
       expect(actual.field.name).toBe('name');
       expect(actual.field.value).toBe('jared');
+
+      const { handleBlur, handleChange } = injected;
+      expect(actual.field.onChange).toBe(handleChange);
+      expect(actual.field.onBlur).toBe(handleBlur);
+      expect(actual.form).toEqual(injected);
+    });
+
+    it('receives { field, form } props - no initialValues', () => {
+      const TestFormNoInitialValues: React.SFC<any> = p => (
+        <Formik
+          onSubmit={noop}
+          // omitted: initialValues={{ }}
+          {...p}
+        />
+      );
+
+      let actual: any; /** FieldProps ;) */
+      let injected: any; /** FieldProps ;) */
+      const Component: React.SFC<FieldProps> = props =>
+        (actual = props) && null;
+
+      ReactDOM.render(
+        <TestFormNoInitialValues
+          render={(formikProps: FormikProps<TestFormValues>) =>
+            (injected = formikProps) && (
+              <Field name="name" component={Component} />
+            )
+          }
+        />,
+        node
+      );
+      expect(actual.field.name).toBe('name');
+      expect(actual.field.value).toBe('');
+      expect(actual.form.initialValues.name).toBe('');
+
+      const { handleBlur, handleChange } = injected;
       expect(actual.field.onChange).toBe(handleChange);
       expect(actual.field.onBlur).toBe(handleBlur);
       expect(actual.form).toEqual(injected);
@@ -345,7 +380,7 @@ describe('A <Field />', () => {
       );
     });
 
-    it('warns if both non-string component and children children as a function', () => {
+    it('warns if both non-string component and children as a function', () => {
       let output = '';
       let actual;
       const Component: React.SFC<FieldProps> = props =>


### PR DESCRIPTION
Been using Formik for a while now and it would definitely be convenient (less 😭) to have `initialValues` be optional, defaulting to an empty string as per #691.

This is my first time contributing to Formik so I could use some guidance. The logical place to do this seems to be `registerField`, but this approach still leads to the React warning about an uncontrolled input becoming controlled because in the initial `Field.render`, the value is undefined.

Suggestions? The only thing I can think of is calling `registerField` earlier in the lifecycle, eg `getDerivedStateFromProps` instead of `componentDidMount`.