### PR TITLE
Automagically set <Field> type radio & checkbox `checked` and `value` props against form values

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -34,7 +34,12 @@ const Example = () => (
   <div>
     <h1>My Form</h1>
     <Formik
-      initialValues={{ email: '', color: 'red', firstName: '' }}
+      initialValues={{
+        email: '',
+        color: 'red',
+        firstName: '',
+        lastName: '',
+        likesCats: false }}
       onSubmit={(values, actions) => {
         setTimeout(() => {
           alert(JSON.stringify(values, null, 2));
@@ -56,6 +61,8 @@ const Example = () => (
               <input {...field} placeholder="lastName" />
             )}
           />
+          <label htmlFor="likesCats">I like cats</label>
+          <Field type="checkbox" name="likesCats" />
           <button type="submit">Submit</button>
         </form>
       )}

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -64,8 +64,6 @@ const Example = () => (
           <label htmlFor="likesCats">I like cats</label>
           <Field type="checkbox" name="likesCats" />
           
-          <label htmlFor="likesCats">I like cats</label>
-          
           <div>Contact me via:</div>
           <label>Email
             <Field type="radio" name="contact" value="email" />

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -63,6 +63,16 @@ const Example = () => (
           />
           <label htmlFor="likesCats">I like cats</label>
           <Field type="checkbox" name="likesCats" />
+          
+          <label htmlFor="likesCats">I like cats</label>
+          
+          <div>Contact me via:</div>
+          <label>Email
+            <Field type="radio" name="contact" value="email" />
+          </label>
+          <label>SMS
+            <Field type="radio" name="contact" value="sms" />
+          </label>
           <button type="submit">Submit</button>
         </form>
       )}

--- a/examples/Basic.js
+++ b/examples/Basic.js
@@ -10,6 +10,7 @@ const Basic = () => (
         firstName: '',
         lastName: '',
         email: '',
+        terms: false
       }}
       onSubmit={values => {
         setTimeout(() => {
@@ -26,6 +27,10 @@ const Basic = () => (
 
           <label htmlFor="email">Email</label>
           <Field name="email" placeholder="jane@acme.com" type="email" />
+          
+          <label htmlFor="terms">I accept the terms and conditions</label>
+          <Field name="terms" type="checkbox" />
+          
           <button type="submit">Submit</button>
           <Debug />
         </Form>

--- a/examples/Basic.js
+++ b/examples/Basic.js
@@ -10,7 +10,8 @@ const Basic = () => (
         firstName: '',
         lastName: '',
         email: '',
-        terms: false
+        terms: false,
+        favoriteColor: "green"
       }}
       onSubmit={values => {
         setTimeout(() => {
@@ -30,6 +31,10 @@ const Basic = () => (
           
           <label htmlFor="terms">I accept the terms and conditions</label>
           <Field name="terms" type="checkbox" />
+          
+          <div>Favorite color:</div>
+          <label><Field name="favoriteColor" type="radio" value="red" />Red</label>
+          <label><Field name="favoriteColor" type="radio" value="green" />Green</label>
           
           <button type="submit">Submit</button>
           <Debug />

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -171,6 +171,10 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
       name,
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
+      checked:
+        props.type === 'radio' || props.type === 'checkbox'
+          ? getIn(formik.values, name)
+          : undefined,
     };
     const bag = { field, form: restOfFormik };
 

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -172,9 +172,11 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
       checked:
-        props.type === 'radio' || props.type === 'checkbox'
+        props.type === 'checkbox'
           ? getIn(formik.values, name)
-          : undefined,
+          : props.type === 'radio'
+            ? getIn(formik.values, name) === props.value
+            : undefined,
     };
     const bag = { field, form: restOfFormik };
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -160,9 +160,11 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
       checked:
-        props.type === 'radio' || props.type === 'checkbox'
+        props.type === 'checkbox'
           ? getIn(formik.values, name)
-          : undefined,
+          : props.type === 'radio'
+            ? getIn(formik.values, name) === props.value
+            : undefined,
     };
     const bag = { field, form: restOfFormik };
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -159,6 +159,10 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
       name,
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
+      checked:
+        props.type === 'radio' || props.type === 'checkbox'
+          ? getIn(formik.values, name)
+          : undefined,
     };
     const bag = { field, form: restOfFormik };
 

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -149,11 +149,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
     this.swap(indexA, indexB);
 
   move = (from: number, to: number) =>
-    this.updateArrayField(
-      (array: any[]) => move(array, from, to),
-      true,
-      true
-    );
+    this.updateArrayField((array: any[]) => move(array, from, to), true, true);
 
   handleMove = (from: number, to: number) => () => this.move(from, to);
 

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -364,6 +364,7 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+
       (global as any).console = {
         error: jest.fn(input => (output += input)),
       };
@@ -487,6 +488,7 @@ describe('A <Field />', () => {
         />,
         node
       );
+
       const { handleBlur, handleChange } = injected;
       expect(actual.field.name).toBe('name');
       expect(actual.field.onChange).toBe(handleChange);
@@ -500,6 +502,7 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -364,7 +364,6 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
       (global as any).console = {
         error: jest.fn(input => (output += input)),
       };
@@ -415,8 +414,6 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-
-      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -503,8 +500,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}
@@ -524,8 +519,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
 
       ReactDOM.render(
         <TestForm
@@ -546,8 +539,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
 
       ReactDOM.render(
         <TestForm

--- a/test/FastField.test.tsx
+++ b/test/FastField.test.tsx
@@ -13,7 +13,11 @@ interface TestFormValues {
 const TestForm: React.SFC<any> = p => (
   <Formik
     onSubmit={noop}
-    initialValues={{ name: 'jared', email: 'hello@reason.nyc' }}
+    initialValues={{
+      name: 'jared',
+      email: 'hello@reason.nyc',
+      isAwesome: true,
+    }}
     {...p}
   />
 );
@@ -180,6 +184,16 @@ describe('A <Field />', () => {
       );
 
       expect((node.firstChild as HTMLTextAreaElement).name).toBe('name');
+    });
+
+    it('renders checkbox type with initialValues', () => {
+      ReactDOM.render(
+        <TestForm render={() => <Field type="checkbox" name="isAwesome" />} />,
+        node
+      );
+
+      expect((node.firstChild as HTMLInputElement).name).toBe('isAwesome');
+      expect((node.firstChild as HTMLInputElement).checked).toBe(true);
     });
 
     it('receives { field, form } props', () => {
@@ -350,7 +364,7 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-
+      actual;
       (global as any).console = {
         error: jest.fn(input => (output += input)),
       };
@@ -401,6 +415,8 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+
+      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -487,7 +503,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-
+      actual;
+      injected;
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}
@@ -507,6 +524,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
+      injected;
 
       ReactDOM.render(
         <TestForm
@@ -527,6 +546,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
+      injected;
 
       ReactDOM.render(
         <TestForm

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -13,7 +13,11 @@ interface TestFormValues {
 const TestForm: React.SFC<any> = p => (
   <Formik
     onSubmit={noop}
-    initialValues={{ name: 'jared', email: 'hello@reason.nyc' }}
+    initialValues={{
+      name: 'jared',
+      email: 'hello@reason.nyc',
+      isAwesome: true,
+    }}
     {...p}
   />
 );
@@ -180,6 +184,16 @@ describe('A <Field />', () => {
       );
 
       expect((node.firstChild as HTMLTextAreaElement).name).toBe('name');
+    });
+
+    it('renders checkbox type with initialValues', () => {
+      ReactDOM.render(
+        <TestForm render={() => <Field type="checkbox" name="isAwesome" />} />,
+        node
+      );
+
+      expect((node.firstChild as HTMLInputElement).name).toBe('isAwesome');
+      expect((node.firstChild as HTMLInputElement).checked).toBe(true);
     });
 
     it('receives { field, form } props', () => {
@@ -350,6 +364,7 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -401,6 +416,7 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -487,6 +503,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
+      injected;
 
       ReactDOM.render(
         <TestForm
@@ -507,6 +525,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+      actual;
+      injected;
 
       ReactDOM.render(
         <TestForm
@@ -527,7 +547,8 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-
+      actual;
+      injected;
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -541,6 +541,7 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
+
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -364,7 +364,6 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -416,7 +415,6 @@ describe('A <Field />', () => {
       let actual;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
 
       (global as any).console = {
         error: jest.fn(input => (output += input)),
@@ -503,8 +501,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
 
       ReactDOM.render(
         <TestForm
@@ -525,8 +521,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
 
       ReactDOM.render(
         <TestForm
@@ -547,8 +541,6 @@ describe('A <Field />', () => {
       let injected: any;
       const Component: React.SFC<FieldProps> = props =>
         (actual = props) && null;
-      actual;
-      injected;
       ReactDOM.render(
         <TestForm
           initialValues={{ user: { superPowers: ['Surging', 'Binding'] } }}


### PR DESCRIPTION
Previously when creating a Field with `type="????"` to create a simple HTML component we were setting the `value` prop on all input components from the values object, but with this change we set `checked` for checkboxes and radio buttons, so that the state is synced with the values object (including its initial values) so the components are controlled (in React terminology).

Addresses issues #1050 #1024 and partly #1035

