### PR TITLE
Return errors in async validation instead of throwing them

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 175914,
-    "minified": 47590,
-    "gzipped": 13738
+    "bundled": 176109,
+    "minified": 47667,
+    "gzipped": 13847
   },
   "./dist/formik.cjs.production.js": {
     "bundled": 40832,
@@ -22,7 +22,7 @@
   "dist/formik.esm.js": {
     "bundled": 37278,
     "minified": 20704,
-    "gzipped": 5442,
+    "gzipped": 5440,
     "treeshaked": {
       "rollup": {
         "code": 658,

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -218,14 +218,9 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
       if (maybePromisedErrors === undefined) {
         resolve({});
       } else if (isPromise(maybePromisedErrors)) {
-        (maybePromisedErrors as Promise<any>).then(
-          () => {
-            resolve({});
-          },
-          errors => {
-            resolve(errors);
-          }
-        );
+        (maybePromisedErrors as Promise<any>).then(errors => {
+          resolve(errors);
+        });
       } else {
         resolve(maybePromisedErrors);
       }

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -442,7 +442,7 @@ describe('<Formik>', () => {
               component={Form}
               validate={() =>
                 sleep(25).then(() => {
-                  throw { name: 'error!' };
+                  return { name: 'error!' };
                 })
               }
             />

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -428,7 +428,7 @@ describe('withFormik()', () => {
           const ValidateForm = withFormik<Props, Values, Values>({
             validate: () =>
               sleep(25).then(() => {
-                throw { name: 'error!' };
+                return { name: 'error!' };
               }),
             mapPropsToValues: ({ user }) => ({ ...user }),
             handleSubmit,


### PR DESCRIPTION
PR for Issue #966

Fixes inconsistent behavior for sync and async validation. 