### PR TITLE
Refactor tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "raw-loader": "^0.5.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
+    "react-testing-library": "^5.2.3",
     "rimraf": "^2.6.2",
     "rollup": "^0.66.4",
     "rollup-plugin-babel": "^4.0.3",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+declare module 'react-testing-library';
 declare module 'enzyme';
 declare module 'enzyme-adapter-react-16';
 declare module 'react-lifecycles-compat' {

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,6 +194,11 @@
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@storybook/addon-actions@3.4.8":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.8.tgz#557bae7c7cc60be9d5199ff972b028de8b574f92"
@@ -3799,6 +3804,15 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom-testing-library@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.12.0.tgz#45c33124fe6a347410117802a367d3291514fe6f"
+  integrity sha512-eWykEDuKmffXOUKvv4IK00krvC4m+V2/y137M1YccWanUlfUzqS1+3eqm3GMC9qMqCJugfHWn6OpIaQd9rwqcw==
+  dependencies:
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^23.6.0"
+    wait-for-expect "^1.0.0"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -8947,6 +8961,13 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-testing-library@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.2.3.tgz#c3be44bfa5eb1ba2acc1fb218785c40ebbdfe8ed"
+  integrity sha512-Bw52++7uORuIQnL55lK/WQfppqAc9+8yFG4lWUp/kmSOvYDnt8J9oI5fNCfAGSQi9iIhAv9aNsI2G5rtid0nrA==
+  dependencies:
+    dom-testing-library "^3.12.0"
+
 react-transition-group@^2.0.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
@@ -11119,6 +11140,11 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.1.tgz#73ab346ed56ed2ef66c380a59fd623755ceac0ce"
+  integrity sha512-TPZMSxGWUl2DWmqdspLDEy97/S1Mqq0pzbh2A7jTq0WbJurUb5GKli+bai6ayeYdeWTF0rQNWZmUvCVZ9gkrfA==
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
In order to safely finish #1005 (v2) and #1063, we really need to make sure the test suite is sound. It's been kind of rotting since 0.8 -> 0.9 when we introduced the render prop. Prior to that, enzyme was the only way to test the hoc. 

**Goals**
- Replace airbnb/enzyme with [react-testing-library](https://github.com/kentcdodds/react-testing-library)
- Remove all event simulations outside of tests for `handleSubmit`,  `handleReset`, `handleBlur`, and `handleChange`
- Remove/unify duplicative tests between `withFormik()` and `<Formik />` (with factory)
- Remove/unify test suite for `<Field>` and `<FastField>` (with factory)