### PR TITLE
Refactor handleSubmit, FormikActions, FormikComputedProps tests

### DIFF
--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -917,99 +917,131 @@ describe('<Formik> alt', () => {
       });
     });
   });
-});
 
-describe('<Formik>', () => {
   describe('FormikComputedProps', () => {
     it('should compute dirty as soon as any input is touched', () => {
-      const tree = shallow(BasicForm);
-      expect(tree.find(Form).props().dirty).toBe(false);
-      tree.setState({ values: { name: 'ian' } });
-      expect(tree.find(Form).props().dirty).toBe(true);
+      let injected: any;
+      render(
+        <Formik initialValues={InitialValues} onSubmit={noop}>
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
+      );
+
+      expect(injected.dirty).toBeFalsy();
+      injected.setValues({ name: 'ian' });
+      expect(injected.dirty).toBeTruthy();
     });
 
     it('should compute isValid if isInitialValid is present and returns true', () => {
-      const tree = shallow(
+      let injected: any;
+      render(
         <Formik
-          initialValues={{ name: 'jared' }}
+          initialValues={InitialValues}
           onSubmit={noop}
-          component={Form}
           isInitialValid={() => true}
-        />
+        >
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
       );
-      expect(tree.find(Form).props().dirty).toBe(false);
-      expect(tree.find(Form).props().isValid).toBe(true);
+
+      expect(injected.dirty).toBeFalsy();
+      expect(injected.isValid).toBeTruthy();
     });
 
     it('should compute isValid if isInitialValid is present and returns false', () => {
-      const tree = shallow(
+      let injected: any;
+      render(
         <Formik
-          initialValues={{ name: 'jared' }}
+          initialValues={InitialValues}
           onSubmit={noop}
-          component={Form}
           isInitialValid={() => false}
-        />
+        >
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
       );
-      expect(tree.find(Form).props().dirty).toBe(false);
-      expect(tree.find(Form).props().isValid).toBe(false);
+
+      expect(injected.dirty).toBeFalsy();
+      expect(injected.isValid).toBeFalsy();
     });
 
     it('should compute isValid if isInitialValid boolean is present and set to true', () => {
-      const tree = shallow(
+      let injected: any;
+      render(
         <Formik
-          initialValues={{ name: 'jared' }}
+          initialValues={InitialValues}
           onSubmit={noop}
-          component={Form}
           isInitialValid={true}
-        />
+        >
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
       );
-      expect(tree.find(Form).props().dirty).toBe(false);
-      expect(tree.find(Form).props().isValid).toBe(true);
+
+      expect(injected.dirty).toBeFalsy();
+      expect(injected.isValid).toBeTruthy();
     });
 
     it('should compute isValid if isInitialValid is present and set to false', () => {
-      const tree = shallow(
+      let injected: any;
+      render(
         <Formik
-          initialValues={{ name: 'jared' }}
+          initialValues={InitialValues}
           onSubmit={noop}
-          component={Form}
           isInitialValid={false}
-        />
+        >
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
       );
-      expect(tree.find(Form).props().dirty).toBe(false);
-      expect(tree.find(Form).props().isValid).toBe(false);
+
+      expect(injected.dirty).toBeFalsy();
+      expect(injected.isValid).toBeFalsy();
     });
 
     it('should compute isValid if the form is dirty and there are errors', () => {
-      const tree = shallow(BasicForm);
-      tree.setState({ values: { name: 'ian' }, errors: { name: 'Required!' } });
-      expect(tree.find(Form).props().dirty).toBe(true);
-      expect(tree.find(Form).props().isValid).toBe(false);
+      let injected: any;
+      render(
+        <Formik initialValues={InitialValues} onSubmit={noop}>
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
+      );
+
+      injected.setValues({ name: 'ian' });
+      injected.setErrors({ name: 'Required!' });
+
+      expect(injected.dirty).toBeTruthy();
+      expect(injected.isValid).toBeFalsy();
     });
 
     it('should compute isValid if the form is dirty and there are not errors', () => {
-      const tree = shallow(BasicForm);
-      tree.setState({ values: { name: 'ian' } });
-      expect(tree.find(Form).props().dirty).toBe(true);
-      expect(tree.find(Form).props().isValid).toBe(true);
+      let injected: any;
+      render(
+        <Formik initialValues={InitialValues} onSubmit={noop}>
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
+      );
+
+      injected.setValues({ name: 'ian' });
+
+      expect(injected.dirty).toBeTruthy();
+      expect(injected.isValid).toBeTruthy();
     });
 
-    it('should increase submitCount after submitting the form', async () => {
-      const tree = shallow(BasicForm);
-      expect(tree.find(Form).props().submitCount).toBe(0);
-      await tree
-        .find(Form)
-        .props()
-        .submitForm();
-      expect(
-        tree
-          .update()
-          .find(Form)
-          .props().submitCount
-      ).toBe(1);
+    it('should increase submitCount after submitting the form', () => {
+      let injected: any;
+      const { getByTestId } = render(
+        <Formik initialValues={InitialValues} onSubmit={noop}>
+          {formikProps => (injected = formikProps) && <Form {...formikProps} />}
+        </Formik>
+      );
+      const form = getByTestId('form');
+
+      expect(injected.submitCount).toBe(0);
+      fireEvent.submit(form);
+      expect(injected.submitCount).toBe(1);
     });
   });
+});
 
+describe('<Formik>', () => {
   describe('componentDidUpdate', () => {
     let form: any, initialValues: any;
     beforeEach(() => {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -653,6 +653,269 @@ describe('<Formik> alt', () => {
         expect(validate).toHaveBeenCalled();
       });
     });
+
+    describe('FormikActions', () => {
+      it('setValues sets values', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setValues({ name: 'ian' });
+        expect(injected.values.name).toEqual('ian');
+      });
+
+      it('setValues should run validations when validateOnChange is true (default)', () => {
+        const validate = jest.fn(() => ({}));
+        let injected: any;
+        render(
+          <Formik
+            initialValues={{ name: 'jared' }}
+            onSubmit={noop}
+            validate={validate}
+            validateOnChange={true}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+        injected.setValues({ name: 'ian' });
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('setValues should NOT run validations when validateOnChange is false', () => {
+        const validate = jest.fn();
+        let injected: any;
+        render(
+          <Formik
+            initialValues={{ name: 'jared' }}
+            onSubmit={noop}
+            validate={validate}
+            validateOnChange={false}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+        injected.setValues({ name: 'ian' });
+        expect(validate).not.toHaveBeenCalled();
+      });
+
+      it('setFieldValue sets value by key', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldValue('name', 'ian');
+        expect(injected.values.name).toEqual('ian');
+      });
+
+      it('setFieldValue should run validations when validateOnChange is true (default)', () => {
+        const validate = jest.fn(() => ({}));
+
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldValue('name', 'ian');
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('setFieldValue should NOT run validations when validateOnChange is false', () => {
+        const validate = jest.fn();
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+            validateOnChange={false}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldValue('name', 'ian');
+        expect(validate).not.toHaveBeenCalled();
+      });
+
+      it('setTouched sets touched', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setTouched({ name: true });
+        expect(injected.touched).toEqual({ name: true });
+      });
+
+      it('setTouched should NOT run validations when validateOnChange is true (default)', () => {
+        const validate = jest.fn(() => ({}));
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setTouched({ name: true });
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('setTouched should run validations when validateOnBlur is false', () => {
+        const validate = jest.fn(() => ({}));
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+            validateOnBlur={false}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setTouched({ name: true });
+        expect(validate).not.toHaveBeenCalled();
+      });
+
+      it('setFieldTouched sets touched by key', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldTouched('name', true);
+        expect(injected.touched).toEqual({ name: true });
+        expect(injected.dirty).toBe(false);
+
+        injected.setFieldTouched('name', false);
+        expect(injected.touched).toEqual({ name: false });
+        expect(injected.dirty).toBe(false);
+      });
+
+      it('setFieldTouched should run validations when validateOnBlur is true (default)', () => {
+        const validate = jest.fn(() => ({}));
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldTouched('name', true);
+        expect(validate).toHaveBeenCalled();
+      });
+
+      it('setFieldTouched should NOT run validations when validateOnBlur is false', () => {
+        const validate = jest.fn(() => ({}));
+        let injected: any;
+        render(
+          <Formik
+            initialValues={InitialValues}
+            onSubmit={noop}
+            validate={validate}
+            validateOnBlur={false}
+          >
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldTouched('name', true);
+        expect(validate).not.toHaveBeenCalled();
+      });
+
+      it('setErrors sets error object', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setErrors({ name: 'Required' });
+        expect(injected.errors.name).toEqual('Required');
+      });
+
+      it('setFieldError sets error by key', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        injected.setFieldError('name', 'Required');
+        expect(injected.errors.name).toEqual('Required');
+      });
+
+      it('setStatus sets status object', () => {
+        let injected: any;
+        render(
+          <Formik initialValues={InitialValues} onSubmit={noop}>
+            {formikProps =>
+              (injected = formikProps) && <Form {...formikProps} />
+            }
+          </Formik>
+        );
+
+        const status = 'status';
+        injected.setStatus(status);
+
+        expect(injected.status).toEqual(status);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
For some reason I couldn't get this test - https://github.com/jaredpalmer/formik/pull/1089/files#diff-a09101aa3d073a58459f3eb56b452b29R545 passing. 

When I change `onSubmit`'s `jest.fn()` to something simple as `() => console.log('called')`, then I can see it being called in the console. Spy function however is failing. 