### PR TITLE
Fix input type="checkbox" & type="radio"

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 176109,
-    "minified": 47667,
-    "gzipped": 13847
+    "bundled": 176829,
+    "minified": 47791,
+    "gzipped": 13868
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 40832,
-    "minified": 20783,
-    "gzipped": 5229
+    "bundled": 41492,
+    "minified": 20933,
+    "gzipped": 5244
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 41720,
-    "minified": 21666,
-    "gzipped": 5575
+    "bundled": 42380,
+    "minified": 21816,
+    "gzipped": 5590
   },
   "dist/index.js": {
-    "bundled": 38494,
-    "minified": 21814,
-    "gzipped": 5614
+    "bundled": 39050,
+    "minified": 21964,
+    "gzipped": 5630
   },
   "dist/formik.esm.js": {
-    "bundled": 37278,
-    "minified": 20704,
-    "gzipped": 5440,
+    "bundled": 37818,
+    "minified": 20838,
+    "gzipped": 5456,
     "treeshaked": {
       "rollup": {
         "code": 658,

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -166,11 +166,9 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
       validationSchema: _validationSchema,
       ...restOfFormik
     } = formik;
+
     const field = {
-      value:
-        props.type === 'radio' || props.type === 'checkbox'
-          ? props.value // React uses checked={} for these inputs
-          : getIn(formik.values, name),
+      value: getIn(formik.values, name),
       name,
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
@@ -186,11 +184,23 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
     }
 
     if (typeof component === 'string') {
-      const { innerRef, ...rest } = props;
+      const { innerRef, ...restProps } = props;
+      const { value, ...restField } = field;
+      const valueProp: { checked?: boolean; value?: typeof value } = {};
+
+      if (props.type === 'radio') {
+        valueProp.checked = value === props.value;
+      } else if (props.type === 'checkbox') {
+        valueProp.checked = value;
+      } else {
+        valueProp.value = value;
+      }
+
       return React.createElement(component as any, {
         ref: innerRef,
-        ...field,
-        ...rest,
+        ...restField,
+        ...restProps,
+        ...valueProp,
         children,
       });
     }

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -184,23 +184,18 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
     }
 
     if (typeof component === 'string') {
-      const { innerRef, ...restProps } = props;
+      const { innerRef, type, ...restProps } = props;
       const { value, ...restField } = field;
-      const valueProp: { checked?: boolean; value?: typeof value } = {};
-
-      if (props.type === 'radio') {
-        valueProp.checked = value === props.value;
-      } else if (props.type === 'checkbox') {
-        valueProp.checked = value;
-      } else {
-        valueProp.value = value;
-      }
 
       return React.createElement(component as any, {
+        type,
         ref: innerRef,
         ...restField,
         ...restProps,
-        ...valueProp,
+        ...{
+          [type === 'radio' || type === 'checkbox' ? 'checked' : 'value']:
+            type === 'radio' ? props.value === value : value,
+        },
         children,
       });
     }

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -151,11 +151,9 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
       validationSchema: _validationSchema,
       ...restOfFormik
     } = formik;
+
     const field = {
-      value:
-        props.type === 'radio' || props.type === 'checkbox'
-          ? props.value // React uses checked={} for these inputs
-          : getIn(formik.values, name),
+      value: getIn(formik.values, name),
       name,
       onChange: formik.handleChange,
       onBlur: formik.handleBlur,
@@ -171,11 +169,23 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
     }
 
     if (typeof component === 'string') {
-      const { innerRef, ...rest } = props;
+      const { innerRef, ...restProps } = props;
+      const { value, ...restField } = field;
+      const valueProp: { checked?: boolean; value?: typeof value } = {};
+
+      if (props.type === 'radio') {
+        valueProp.checked = value === props.value;
+      } else if (props.type === 'checkbox') {
+        valueProp.checked = value;
+      } else {
+        valueProp.value = value;
+      }
+
       return React.createElement(component as any, {
         ref: innerRef,
-        ...field,
-        ...rest,
+        ...restField,
+        ...restProps,
+        ...valueProp,
         children,
       });
     }

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -169,23 +169,18 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
     }
 
     if (typeof component === 'string') {
-      const { innerRef, ...restProps } = props;
+      const { innerRef, type, ...restProps } = props;
       const { value, ...restField } = field;
-      const valueProp: { checked?: boolean; value?: typeof value } = {};
-
-      if (props.type === 'radio') {
-        valueProp.checked = value === props.value;
-      } else if (props.type === 'checkbox') {
-        valueProp.checked = value;
-      } else {
-        valueProp.value = value;
-      }
 
       return React.createElement(component as any, {
+        type,
         ref: innerRef,
         ...restField,
         ...restProps,
-        ...valueProp,
+        ...{
+          [type === 'radio' || type === 'checkbox' ? 'checked' : 'value']:
+            type === 'radio' ? props.value === value : value,
+        },
         children,
       });
     }

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { cleanup, render, wait } from 'react-testing-library';
+import { fireEvent, cleanup, render, wait } from 'react-testing-library';
+
 import {
   Formik,
   Field,
@@ -10,7 +11,6 @@ import {
   FormikConfig,
   FastFieldProps,
 } from '../src';
-
 import { noop } from './testHelpers';
 
 const initialValues = { name: 'jared', email: 'hello@reason.nyc' };
@@ -53,7 +53,10 @@ const createRenderField = (
     getProps() {
       return injected;
     },
-    ...renderForm(<FieldComponent name="name" {...props} />, formProps),
+    ...renderForm(
+      <FieldComponent data-testid="input" name="name" {...props} />,
+      formProps
+    ),
   };
 };
 
@@ -180,6 +183,46 @@ describe('Field / FastField', () => {
       const innerRef = jest.fn();
       renderField({ component: Component, innerRef });
       expect(injected.innerRef).toBe(innerRef);
+    });
+
+    cases('handles type="checkbox"', renderField => {
+      const initialValues: any = {
+        name: false,
+      };
+      const { getByTestId } = renderField(
+        {
+          type: 'checkbox',
+          component: 'input',
+        },
+        { initialValues }
+      );
+
+      const input = getByTestId('input') as HTMLInputElement;
+
+      expect(input.checked).toBeFalsy();
+      fireEvent.click(input);
+      expect(input.checked).toBeTruthy();
+    });
+
+    cases('handles type="radio"', renderField => {
+      const initialValues: any = {
+        name: '',
+      };
+      const { getByTestId, debug } = renderField(
+        {
+          type: 'radio',
+          component: 'input',
+          value: 'hello',
+        },
+        { initialValues }
+      );
+
+      const input = getByTestId('input') as HTMLInputElement;
+
+      expect(input.value).toBe('hello');
+      expect(input.checked).toBeFalsy();
+      fireEvent.click(input);
+      expect(input.checked).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
I believe there is a bigger problem than what is covered here https://github.com/jaredpalmer/formik/pull/1064 and I had this PR half-done, so I finished that. ¯\_(ツ)_/¯

What (I think) we want to achieve:
- keep API of render/children/component (not string) same
- handle `checked` attribute for string components, where we have 3 scenarios

First of all, we always have to take value form `Formik` state, no matter the type

For `type="radio`:
```js
<Field type="radio" name="console" value="ps4" />
<Field type="radio" name="console" value="xbox" />
```
the `checked` property is a result of `props.value === formik.values.console`.

For `type="checkbox"`: 
 ```js
<Field type="checkbox" name="some-name"  />
```
the `checked` property is a boolean handled during `onChange` by Formik [here](https://github.com/jaredpalmer/formik/blob/master/src/Formik.tsx#L323), therefore `checked` is just `formik.values["some-name"]`.

...aaand everything else is `value`.

Update for `FastField` and tests are done as well.

Fixes https://github.com/jaredpalmer/formik/issues/1024
Fixes https://github.com/jaredpalmer/formik/issues/1050