### PR TITLE
upgrade react-fast-compare to get bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.topath": "4.5.2",
     "prop-types": "^15.6.1",
-    "react-fast-compare": "^1.0.0",
+    "react-fast-compare": "^2.0.1",
     "tslib": "^1.9.3",
     "warning": "^3.0.0"
   },


### PR DESCRIPTION
`react-fast-compare@2.0.1` fixed a major bug for some versions of react ([changelog](https://github.com/FormidableLabs/react-fast-compare/blob/master/CHANGELOG.md)). There are some _small_ behavior changes that come with that, so we'll make sure tests still pass.