### PR TITLE
Allow callbacks to be passed to formik functions that set state

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 176109,
-    "minified": 47667,
-    "gzipped": 13847
+    "bundled": 176101,
+    "minified": 47655,
+    "gzipped": 13834
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 40832,
-    "minified": 20783,
-    "gzipped": 5229
+    "bundled": 40820,
+    "minified": 20771,
+    "gzipped": 5214
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 41720,
-    "minified": 21666,
-    "gzipped": 5575
+    "bundled": 41708,
+    "minified": 21654,
+    "gzipped": 5559
   },
   "dist/index.js": {
-    "bundled": 38494,
-    "minified": 21814,
-    "gzipped": 5614
+    "bundled": 38456,
+    "minified": 21802,
+    "gzipped": 5599
   },
   "dist/formik.esm.js": {
-    "bundled": 37278,
-    "minified": 20704,
-    "gzipped": 5440,
+    "bundled": 37240,
+    "minified": 20692,
+    "gzipped": 5425,
     "treeshaked": {
       "rollup": {
         "code": 658,

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -111,42 +111,51 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
     }
   }
 
-  setErrors = (errors: FormikErrors<Values>) => {
-    this.setState({ errors });
+  setErrors = (errors: FormikErrors<Values>, callback?: (() => void)) => {
+    this.setState({ errors }, callback);
   };
 
-  setTouched = (touched: FormikTouched<Values>) => {
+  setTouched = (touched: FormikTouched<Values>, callback?: (() => void)) => {
     this.setState({ touched }, () => {
       if (this.props.validateOnBlur) {
         this.runValidations(this.state.values);
       }
-    });
-  };
-
-  setValues = (values: FormikState<Values>['values']) => {
-    this.setState({ values }, () => {
-      if (this.props.validateOnChange) {
-        this.runValidations(values);
+      if (callback) {
+        callback();
       }
     });
   };
 
-  setStatus = (status?: any) => {
-    this.setState({ status });
+  setValues = (
+    values: FormikState<Values>['values'],
+    callback?: (() => void)
+  ) => {
+    this.setState({ values }, () => {
+      if (this.props.validateOnChange) {
+        this.runValidations(values);
+      }
+      if (callback) {
+        callback();
+      }
+    });
   };
 
-  setError = (error: any) => {
+  setStatus = (status?: any, callback?: (() => void)) => {
+    this.setState({ status }, callback);
+  };
+
+  setError = (error: any, callback?: (() => void)) => {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(
         `Warning: Formik\'s setError(error) is deprecated and may be removed in future releases. Please use Formik\'s setStatus(status) instead. It works identically. For more info see https://github.com/jaredpalmer/formik#setstatus-status-any--void`
       );
     }
-    this.setState({ error });
+    this.setState({ error }, callback);
   };
 
-  setSubmitting = (isSubmitting: boolean) => {
+  setSubmitting = (isSubmitting: boolean, callback?: (() => void)) => {
     if (this.didMount) {
-      this.setState({ isSubmitting });
+      this.setState({ isSubmitting }, callback);
     }
   };
 
@@ -360,7 +369,8 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   setFieldValue = (
     field: string,
     value: any,
-    shouldValidate: boolean = true
+    shouldValidate: boolean = true,
+    callback?: (() => void)
   ) => {
     if (this.didMount) {
       // Set form field by name
@@ -372,6 +382,9 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
         () => {
           if (this.props.validateOnChange && shouldValidate) {
             this.runValidations(this.state.values);
+          }
+          if (callback) {
+            callback();
           }
         }
       );
@@ -475,7 +488,8 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   setFieldTouched = (
     field: string,
     touched: boolean = true,
-    shouldValidate: boolean = true
+    shouldValidate: boolean = true,
+    callback?: (() => void)
   ) => {
     // Set touched field by name
     this.setState(
@@ -487,16 +501,26 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
         if (this.props.validateOnBlur && shouldValidate) {
           this.runValidations(this.state.values);
         }
+        if (callback) {
+          callback();
+        }
       }
     );
   };
 
-  setFieldError = (field: string, message: string | undefined) => {
+  setFieldError = (
+    field: string,
+    message: string | undefined,
+    callback?: (() => void)
+  ) => {
     // Set form field by name
-    this.setState(prevState => ({
-      ...prevState,
-      errors: setIn(prevState.errors, field, message),
-    }));
+    this.setState(
+      prevState => ({
+        ...prevState,
+        errors: setIn(prevState.errors, field, message),
+      }),
+      callback
+    );
   };
 
   resetForm = (nextValues?: Values) => {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -518,6 +518,15 @@ describe('<Formik>', () => {
         expect(getProps().values.name).toEqual('ian');
       });
 
+      it('setValues executes a callback', () => {
+        const { getProps } = renderFormik();
+        const mockCallback = jest.fn();
+
+        getProps().setValues({ name: 'rachel' }, mockCallback);
+        expect(getProps().values.name).toEqual('rachel');
+        expect(mockCallback.mock.calls.length).toEqual(1);
+      });
+
       it('setValues should run validations when validateOnChange is true (default)', () => {
         const validate = jest.fn(() => ({}));
         const { getProps } = renderFormik({ validate });
@@ -544,6 +553,15 @@ describe('<Formik>', () => {
         expect(getProps().values.name).toEqual('ian');
       });
 
+      it('setFieldValue executes a callback', () => {
+        const { getProps } = renderFormik();
+        const mockCallback = jest.fn();
+
+        getProps().setFieldValue('name', 'rachel', true, mockCallback);
+        expect(getProps().values.name).toEqual('rachel');
+        expect(mockCallback.mock.calls.length).toEqual(1);
+      });
+
       it('setFieldValue should run validations when validateOnChange is true (default)', () => {
         const validate = jest.fn(() => ({}));
         const { getProps } = renderFormik({ validate });
@@ -568,6 +586,14 @@ describe('<Formik>', () => {
 
         getProps().setTouched({ name: true });
         expect(getProps().touched).toEqual({ name: true });
+      });
+
+      it('setTouched accepts and calls a callback function', () => {
+        const { getProps } = renderFormik();
+        const mockCallback = jest.fn();
+
+        getProps().setTouched({ name: true }, mockCallback);
+        expect(mockCallback.mock.calls.length).toEqual(1);
       });
 
       it('setTouched should NOT run validations when validateOnChange is true (default)', () => {
@@ -621,11 +647,29 @@ describe('<Formik>', () => {
         expect(getProps().errors.name).toEqual('Required');
       });
 
+      it('setErrors executes the callback', () => {
+        const { getProps } = renderFormik();
+
+        const mockCallback = jest.fn();
+        getProps().setErrors({ name: 'Required' }, mockCallback);
+        expect(getProps().errors.name).toEqual('Required');
+        expect(mockCallback.mock.calls.length).toEqual(1);
+      });
+
       it('setFieldError sets error by key', () => {
         const { getProps } = renderFormik();
 
         getProps().setFieldError('name', 'Required');
         expect(getProps().errors.name).toEqual('Required');
+      });
+
+      it('setFieldError sets executes the callback', () => {
+        const { getProps } = renderFormik();
+        const mockCallback = jest.fn();
+
+        getProps().setFieldError('name', 'Required', mockCallback);
+        expect(getProps().errors.name).toEqual('Required');
+        expect(mockCallback.mock.calls.length).toEqual(1);
       });
 
       it('setStatus sets status object', () => {


### PR DESCRIPTION
Affects:
setErrors, setValues, setTouched
setFieldErrors, setFieldValues, setFieldTouched

This allows much greater flexibility when using these functions and resolves #529