### PR TITLE
Set displayName on connected component (#1145)

### DIFF
--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -20,11 +20,19 @@ export function connect<OuterProps, Values = {}>(
       {formik => <Comp {...props} formik={formik} />}
     </FormikConsumer>
   );
+  const componentDisplayName =
+    Comp.displayName ||
+    Comp.name ||
+    (Comp.constructor && Comp.constructor.name) ||
+    'Component';
+
   // Assign Comp to C.WrappedComponent so we can access the inner component in tests
   // For example, <Field.WrappedComponent /> gets us <FieldInner/>
   (C as React.SFC<OuterProps> & {
     WrappedComponent: React.ReactNode;
   }).WrappedComponent = Comp;
+
+  C.displayName = `FormikConnect(${componentDisplayName})`;
 
   return hoistNonReactStatics<
     OuterProps,


### PR DESCRIPTION
Added the displayName to `connect` function as `FormikConnect(WrappedName)`.

This function doesn't have unit tests (I guess it's indirectly covered by other components), so I didn't add any. But I can do that if it's needed.