### PR TITLE
Remove warnings from production bundle

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 141163,
-    "minified": 39817,
-    "gzipped": 11894
+    "bundled": 139806,
+    "minified": 38380,
+    "gzipped": 11675
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 170072,
+    "bundled": 170994,
     "minified": 49225,
     "gzipped": 14819
   },
@@ -25,16 +25,16 @@
     "gzipped": 5619
   },
   "dist/formik.esm.js": {
-    "bundled": 37431,
-    "minified": 20807,
-    "gzipped": 5447,
+    "bundled": 37921,
+    "minified": 21175,
+    "gzipped": 5458,
     "treeshaked": {
       "rollup": {
-        "code": 773,
-        "import_statements": 351
+        "code": 766,
+        "import_statements": 344
       },
       "webpack": {
-        "code": 3448
+        "code": 3439
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,11 +19,6 @@
     "minified": 21763,
     "gzipped": 5576
   },
-  "dist/index.js": {
-    "bundled": 38641,
-    "minified": 21911,
-    "gzipped": 5619
-  },
   "dist/formik.esm.js": {
     "bundled": 37921,
     "minified": 21175,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "all-contributors-cli": "^4.4.0",
     "awesome-typescript-loader": "^3.4.1",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
+    "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-transform-rename-import": "^2.3.0",
     "cross-env": "5.0.5",
     "doctoc": "^1.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,14 @@ import pkg from './package.json';
 const input = './compiled/index.js';
 const external = id => !id.startsWith('.') && !id.startsWith('/');
 const replacements = [{ original: 'lodash', replacement: 'lodash-es' }];
+const babelOptions = {
+  exclude: /node_modules/,
+  plugins: [
+    'annotate-pure-calls',
+    'dev-expression',
+    ['transform-rename-import', { replacements }],
+  ],
+};
 
 const buildUmd = ({ env }) => ({
   input,
@@ -31,9 +39,7 @@ const buildUmd = ({ env }) => ({
 
   plugins: [
     resolve(),
-    babel({
-      plugins: [['transform-rename-import', { replacements }]],
-    }),
+    babel(babelOptions),
     replace({
       'process.env.NODE_ENV': JSON.stringify(env),
     }),
@@ -99,16 +105,6 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [
-      resolve(),
-      babel({
-        plugins: [
-          'annotate-pure-calls',
-          ['transform-rename-import', { replacements }],
-        ],
-      }),
-      sizeSnapshot(),
-      sourceMaps(),
-    ],
+    plugins: [resolve(), babel(babelOptions), sizeSnapshot(), sourceMaps()],
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,6 +1319,10 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dev-expression@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz#d4a7beefefbb50e3f2734990a82a2486cf9eb9ee"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
dev-expression allows to add NODE_ENV conditions around invariant and
warning calls which eliminate a message in production and reduce bundle
size.