### PR TITLE
Make validateForm internally cancellable

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 139806,
-    "minified": 38380,
-    "gzipped": 11675
+    "bundled": 140683,
+    "minified": 38717,
+    "gzipped": 11775
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 170994,
-    "minified": 49225,
-    "gzipped": 14819
+    "bundled": 171871,
+    "minified": 49562,
+    "gzipped": 14933
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 41035,
-    "minified": 20880,
-    "gzipped": 5230
+    "bundled": 41827,
+    "minified": 21259,
+    "gzipped": 5344
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 41923,
-    "minified": 21763,
-    "gzipped": 5576
+    "bundled": 42715,
+    "minified": 22142,
+    "gzipped": 5690
   },
   "dist/formik.esm.js": {
-    "bundled": 37921,
-    "minified": 21175,
-    "gzipped": 5458,
+    "bundled": 38661,
+    "minified": 21531,
+    "gzipped": 5570,
     "treeshaked": {
       "rollup": {
         "code": 766,

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -96,8 +96,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   constructor(props: FieldArrayConfig & { formik: FormikContext<Values> }) {
     super(props);
     // We need TypeScript generics on these, so we'll bind them in the constructor
-    this.remove = this.remove.bind(this);
-    this.pop = this.pop.bind(this);
+    this.remove = this.remove.bind(this) as any;
+    this.pop = this.pop.bind(this) as any;
   }
 
   updateArrayField = (

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -101,7 +101,7 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
     this.didMount = false;
 
     // Cancel validation on unmount.
-    if (this.validator !== null) {
+    if (this.validator) {
       this.validator();
     }
   }
@@ -265,7 +265,7 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   runValidations = (
     values: FormikValues = this.state.values
   ): Promise<FormikErrors<Values>> => {
-    if (this.validator !== null) {
+    if (this.validator) {
       this.validator();
     }
     this.setState({ isValidating: true });

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -267,8 +267,9 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   ): Promise<FormikErrors<Values>> => {
     if (this.validator) {
       this.validator();
+    } else {
+      this.setState({ isValidating: true });
     }
-    this.setState({ isValidating: true });
     const [promise, cancel] = makeCancelable(
       Promise.all([
         this.runFieldLevelValidations(values),

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -282,10 +282,12 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
       })
     );
     this.validator = cancel;
-    return promise.then((combinedErrors: FormikErrors<Values>) => {
-      this.setState({ isValidating: false, errors: combinedErrors });
-      return combinedErrors;
-    });
+    return promise
+      .then((combinedErrors: FormikErrors<Values>) => {
+        this.setState({ isValidating: false, errors: combinedErrors });
+        return combinedErrors;
+      })
+      .catch(x => x);
   };
 
   handleChange = (

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -23,6 +23,7 @@ import {
   setNestedObjectValues,
   getActiveElement,
   getIn,
+  makeCancelable,
 } from './utils';
 
 export class Formik<Values = object, ExtraProps = {}> extends React.Component<
@@ -47,6 +48,7 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   fields: {
     [field: string]: React.Component<any>;
   };
+  validator: any;
 
   constructor(props: FormikConfig<Values> & ExtraProps) {
     super(props);
@@ -97,6 +99,11 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
     // @see https://github.com/jaredpalmer/formik/issues/597
     // @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
     this.didMount = false;
+
+    // Cancel validation on unmount.
+    if (this.validator !== null) {
+      this.validator();
+    }
   }
 
   componentDidUpdate(prevProps: Readonly<FormikConfig<Values> & ExtraProps>) {
@@ -258,21 +265,25 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   runValidations = (
     values: FormikValues = this.state.values
   ): Promise<FormikErrors<Values>> => {
+    if (this.validator !== null) {
+      this.validator();
+    }
     this.setState({ isValidating: true });
-    return Promise.all([
-      this.runFieldLevelValidations(values),
-      this.props.validationSchema ? this.runValidationSchema(values) : {},
-      this.props.validate ? this.runValidateHandler(values) : {},
-    ]).then(([fieldErrors, schemaErrors, handlerErrors]) => {
-      const combinedErrors = deepmerge.all<FormikErrors<Values>>(
-        [fieldErrors, schemaErrors, handlerErrors],
-        { arrayMerge }
-      );
-
-      if (this.didMount) {
-        this.setState({ isValidating: false, errors: combinedErrors });
-      }
-
+    const [promise, cancel] = makeCancelable(
+      Promise.all([
+        this.runFieldLevelValidations(values),
+        this.props.validationSchema ? this.runValidationSchema(values) : {},
+        this.props.validate ? this.runValidateHandler(values) : {},
+      ]).then(([fieldErrors, schemaErrors, handlerErrors]) => {
+        return deepmerge.all<FormikErrors<Values>>(
+          [fieldErrors, schemaErrors, handlerErrors],
+          { arrayMerge }
+        );
+      })
+    );
+    this.validator = cancel;
+    return promise.then((combinedErrors: FormikErrors<Values>) => {
+      this.setState({ isValidating: false, errors: combinedErrors });
       return combinedErrors;
     });
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,3 +148,27 @@ export function getActiveElement(doc?: Document): Element | null {
     return doc.body;
   }
 }
+
+/**
+ * Make a promise cancellable by @istarkov
+ * @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+ */
+export function makeCancelable<T extends Promise<any>>(
+  promise: T
+): [T, () => void] {
+  let hasCanceled: boolean = false;
+
+  const wrappedPromise: any = new Promise((resolve, reject) => {
+    promise.then(
+      val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)),
+      error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
+    );
+  });
+
+  return [
+    wrappedPromise,
+    function cancel() {
+      hasCanceled = true;
+    },
+  ];
+}

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -89,7 +89,7 @@ export function withFormik<
         vanillaProps.hasOwnProperty(k) &&
         typeof vanillaProps[k] !== 'function'
       ) {
-        val[k] = vanillaProps[k];
+        (val as any)[k] = vanillaProps[k];
       }
     }
     return val as Values;


### PR DESCRIPTION
Closes #671 #1026

This makes internal validation cancellable, thus avoiding cascading renders caused by async work.