### PR TITLE
Stricter typing for FormikActions resetForm method

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -100,7 +100,7 @@ export interface FormikActions<Values> {
   /** Validate field value */
   validateField(field: string): void;
   /** Reset form */
-  resetForm(nextValues?: any): void;
+  resetForm(nextValues?: Values): void;
   /** Submit the form imperatively */
   submitForm(): void;
   /** Set Formik state, careful! */


### PR DESCRIPTION
Adjust `FormikActions` `resetForm` typing to disallow passing an arbitrary value.

Fixes #1110 