### PR TITLE
Only use isValidating during submit

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -112,7 +112,7 @@ Returns `true` if the there are no `errors`, or the result of
 
 #### `isValidating: boolean`
 
-Returns `true` if Formik is running any validation function, `false` otherwise. To learn more about what happens with `isValidating` during the submission process, see [Form Submission](guides/form-submission.md).
+Returns `true` if Formik is running validation during submission, or by calling [`validateForm`] directly `false` otherwise. To learn more about what happens with `isValidating` during the submission process, see [Form Submission](guides/form-submission.md).
 
 #### `resetForm: (nextValues?: Values) => void`
 
@@ -325,7 +325,7 @@ Validate the form's `values` with function. This function can either be:
 
 ```js
 // Synchronous validation
-const validate = (values) => {
+const validate = values => {
   let errors = {};
 
   if (!values.email) {
@@ -346,7 +346,7 @@ const validate = (values) => {
 // Async Validation
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-const validate = (values) => {
+const validate = values => {
   return sleep(2000).then(() => {
     let errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -267,9 +267,8 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   ): Promise<FormikErrors<Values>> => {
     if (this.validator) {
       this.validator();
-    } else {
-      this.setState({ isValidating: true });
     }
+
     const [promise, cancel] = makeCancelable(
       Promise.all([
         this.runFieldLevelValidations(values),
@@ -432,10 +431,11 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
         true
       ),
       isSubmitting: true,
+      isValidating: true,
       submitCount: prevState.submitCount + 1,
     }));
 
-    return this.runValidations().then(combinedErrors => {
+    return this.runValidations(this.state.values).then(combinedErrors => {
       const isValid = Object.keys(combinedErrors).length === 0;
       if (isValid) {
         this.executeSubmit();
@@ -550,11 +550,16 @@ export class Formik<Values = object, ExtraProps = {}> extends React.Component<
   setFormikState = (s: any, callback?: (() => void)) =>
     this.setState(s, callback);
 
+  validateForm = (values: Values) => {
+    this.setState({ isValidating: true });
+    return this.runValidations(values);
+  };
+
   getFormikActions = (): FormikActions<Values> => {
     return {
       resetForm: this.resetForm,
       submitForm: this.submitForm,
-      validateForm: this.runValidations,
+      validateForm: this.validateForm,
       validateField: this.validateField,
       setError: this.setError,
       setErrors: this.setErrors,


### PR DESCRIPTION
This removes the toggling of `isValidating` everywhere (change/blur) except:

- During submission
- When someone calls `validateForm` directly

Most users do not care about `isValidating` outside of the submission process, plus this constant flickering is the root of the recent performance regressions #671 #1026.