### PR TITLE
FieldArray docs: Add missing dot in example

### DIFF
--- a/docs/api/fieldarray.md
+++ b/docs/api/fieldarray.md
@@ -86,9 +86,8 @@ You can also iterate through an array of objects, by following a convention of `
       <div>
         {values.friends.map((friend, index) => (
           <div key={index}>
-            <Field name={`friends[${index}]name`} />
-            <Field name={`friends.${index}.age`} /> // both these conventions do
-            the same
+            <Field name={`friends[${index}].name`} />
+            <Field name={`friends.${index}.age`} /> // both these conventions do the same
             <button type="button" onClick={() => arrayHelpers.remove(index)}>
               -
             </button>


### PR DESCRIPTION
It seems like there's a small typo in the docs for FieldArray, namely a missing dot for getting a property from an example object.
Also I removed a line break which is confusing since it breaks a sentence.