### PR TITLE
Fix handling array operations when errors is an array-like object

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -85,6 +85,23 @@ export const replace = (array: any[], index: number, value: any) => {
   copy[index] = value;
   return copy;
 };
+
+const copyArray = (array?: any[]) => {
+  if (!array) {
+    return [];
+  }
+  if (isFunction(array.slice)) {
+    return [...array];
+  }
+
+  // It's an array-like object, e.g. {2: "hello"}, let's create a sparse array from it.
+  const copy = new Array();
+  Object.keys(array).forEach(k => {
+    copy[parseInt(k)] = array[parseInt(k)];
+  });
+  return copy;
+};
+
 class FieldArrayInner<Values = {}> extends React.Component<
   FieldArrayConfig & { formik: FormikContext<Values> },
   {}
@@ -200,7 +217,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
     this.updateArrayField(
       // so this gets call 3 times
       (array?: any[]) => {
-        const copy = array ? [...array] : [];
+        const copy = copyArray(array);
         if (!result) {
           result = copy[index];
         }

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -14,6 +14,14 @@ const TestForm: React.SFC<any> = p => (
   />
 );
 
+const TestObjectsForm: React.SFC<any> = p => (
+  <Formik
+    onSubmit={noop}
+    initialValues={{ friends: [{ name: 'jared' }] }}
+    {...p}
+  />
+);
+
 describe('<FieldArray />', () => {
   const node = document.createElement('div');
 
@@ -353,6 +361,150 @@ describe('<FieldArray />', () => {
       arrayHelpers.remove(1);
       const expected = ['jared', 'brent'];
       expect(formikBag.values.friends).toEqual(expected);
+    });
+
+    it('should remove a value at given index of field array with errors array', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      formikBag.setErrors({ friends: ['invalid'] });
+      arrayHelpers.remove(0);
+      const expected = ['andrea', 'brent'];
+      expect(formikBag.values.friends).toEqual(expected);
+      expect(formikBag.errors.friends).toEqual([]);
+    });
+
+    it('should remove a value at given index of field array with errors object', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      formikBag.setErrors({ friends: { 1: 'invalid', 2: 'invalid' } });
+      arrayHelpers.remove(1);
+      const expected = ['jared', 'brent'];
+      expect(formikBag.values.friends).toEqual(expected);
+      expect(formikBag.errors.friends).toEqual([undefined, 'invalid']);
+    });
+  });
+});
+
+describe('<FieldArray /> with array of objects', () => {
+  const node = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe('props.remove()', () => {
+    it('should remove a value at given index of field array', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestObjectsForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      arrayHelpers.remove(0);
+      expect(formikBag.values.friends).toEqual([]);
+    });
+
+    it('should remove a value at given index of field array with errors array', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestObjectsForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      formikBag.setErrors({ friends: [{ name: 'invalid' }] });
+      arrayHelpers.remove(0);
+      expect(formikBag.values.friends).toEqual([]);
+    });
+
+    it('should remove a value at given index of field array with errors object', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestObjectsForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      formikBag.setErrors({ friends: { 0: { name: 'invalid' } } });
+      arrayHelpers.remove(0);
+      expect(formikBag.values.friends).toEqual([]);
+      expect(formikBag.errors.friends).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Attempt to fix #1158 

Note: this is not finished yet - the logic has only been applied to `remove`, it needs to be applied to the other array operations as well (`pop`, etc.).

There are numerous ways to fix the bug, I chose to go with transforming the array-like object (`{1: "invalid"}`) into a sparse array. I don't think that's a great solution because it changes the structure of the developer-controlled `errors` object... The only advantage is that it is less code changes, because then the logic can stay the same once the object has been transformed into an array.

The other solution would be to have a different handling of array and object for all array helpers. That is a much more extensive change, I wanted to have your opinion on the direction before moving further ahead.