### PR TITLE
Add exemptLabels to stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,8 +4,12 @@ daysUntilStale: 60
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - enhancement
   - pinned
-  - security
+  - RFC
+  - bug
+  - in progress
+  - 2.0
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Stale bot is being a little aggressive in closing issues that have been sitting due to outside commitments, extra thought, and other reasons that don't make the issue actually stale.

Adding more `exemptLabels` will prevent Stale bot from closing issues with the provided labels as they should probably remain open.

Related to #828 being closed early.