### PR TITLE
fix(formik): validation upon form submission in case of thrown errors

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,35 +1,35 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 141423,
-    "minified": 39046,
-    "gzipped": 11848
+    "bundled": 142043,
+    "minified": 39232,
+    "gzipped": 11889
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 171603,
-    "minified": 49483,
-    "gzipped": 14950
+    "bundled": 172503,
+    "minified": 49895,
+    "gzipped": 15098
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 42377,
-    "minified": 21477,
-    "gzipped": 5386
+    "bundled": 43007,
+    "minified": 21651,
+    "gzipped": 5427
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 43265,
-    "minified": 22360,
-    "gzipped": 5725
+    "bundled": 44189,
+    "minified": 22766,
+    "gzipped": 5855
   },
   "dist/formik.esm.js": {
-    "bundled": 39126,
-    "minified": 21749,
-    "gzipped": 5602,
+    "bundled": 39981,
+    "minified": 22184,
+    "gzipped": 5729,
     "treeshaked": {
       "rollup": {
-        "code": 771,
+        "code": 799,
         "import_statements": 349
       },
       "webpack": {
-        "code": 3444
+        "code": 3475
       }
     }
   }

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -186,7 +186,7 @@ Your form's values. Will have the shape of the result of `mapPropsToValues`
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-#### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
+#### `validateForm: (values?: any) => Promise<Error | FormikErrors<Values>>`
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import createContext from 'create-react-context';
+import createContext, { Context } from 'create-react-context';
 import { FormikContext } from './types';
 
+function createFormikContext<Values>(): Context<FormikContext<Values>> {
+  const defaultvalue: FormikContext<Values> = {} as FormikContext<Values>;
+  return createContext(defaultvalue);
+}
 export const {
   Provider: FormikProvider,
   Consumer: FormikConsumer,
-} = createContext<FormikContext<any>>({} as any);
+} = createFormikContext();
 
 /**
  * Connect any component to Formik context, and inject as a prop called `formik`;
@@ -17,7 +21,10 @@ export function connect<OuterProps, Values = {}>(
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (
     <FormikConsumer>
-      {formik => <Comp {...props} formik={formik} />}
+      {formik => {
+        const formikProps = formik as FormikContext<Values>;
+        return <Comp {...props} formik={formikProps} />;
+      }}
     </FormikConsumer>
   );
   const componentDisplayName =

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -96,7 +96,7 @@ export interface FormikActions<Values> {
     shouldValidate?: boolean
   ): void;
   /** Validate form values */
-  validateForm(values?: any): Promise<FormikErrors<Values>>;
+  validateForm(values?: any): Promise<Error | FormikErrors<Values>>;
   /** Validate field value */
   validateField(field: string): void;
   /** Reset form */
@@ -211,7 +211,11 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    */
   validate?: ((
     values: Values
-  ) => void | object | Promise<FormikErrors<Values>>);
+  ) =>
+    | void
+    | Error
+    | FormikErrors<Values>
+    | Promise<Error | FormikErrors<Values>>);
 }
 
 /**

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -442,13 +442,24 @@ describe('<Formik>', () => {
         await wait(() => expect(onSubmit).toBeCalled());
       });
 
-      it('should not submit the form if invalid', () => {
+      it('should not submit the form if invalid', async () => {
         const onSubmit = jest.fn();
         const validate = jest.fn(() => ({ name: 'Error!' }));
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));
-        expect(onSubmit).not.toBeCalled();
+        await wait(() => expect(onSubmit).not.toBeCalled());
+      });
+
+      it('should not submit the form if validate function throws an error', async () => {
+        const onSubmit = jest.fn();
+        const validate = jest.fn(() => {
+          throw new Error('Oops');
+        });
+        const { getByTestId } = renderFormik({ onSubmit, validate });
+
+        fireEvent.submit(getByTestId('form'));
+        await wait(() => expect(onSubmit).not.toBeCalled());
       });
     });
 
@@ -470,13 +481,27 @@ describe('<Formik>', () => {
         await wait(() => expect(onSubmit).toBeCalled());
       });
 
-      it('should not submit the form if invalid', () => {
+      it('should not submit the form if invalid', async () => {
         const onSubmit = jest.fn();
-        const validate = jest.fn(() => Promise.resolve({ name: 'Error!' }));
+        const validate = jest.fn(() => Promise.reject({ name: 'Error!' }));
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));
-        expect(onSubmit).not.toBeCalled();
+        await wait(() => expect(onSubmit).not.toBeCalled());
+      });
+
+      it('should not submit the form if validate function rejects with an error', async () => {
+        const onSubmit = jest.fn();
+        const validate = jest.fn(
+          () =>
+            new Promise(() => {
+              throw new Error('Oops');
+            })
+        );
+        const { getByTestId } = renderFormik({ onSubmit, validate });
+
+        fireEvent.submit(getByTestId('form'));
+        await wait(() => expect(onSubmit).not.toBeCalled());
       });
     });
 

--- a/website/versioned_docs/version-1.2.0/api/formik.md
+++ b/website/versioned_docs/version-1.2.0/api/formik.md
@@ -187,7 +187,7 @@ Your form's values. Will have the shape of the result of `mapPropsToValues`
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-#### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
+#### `validateForm: (values?: any) => Promise<Error | FormikErrors<Values>>`
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 

--- a/website/versioned_docs/version-1.3.2/api/formik.md
+++ b/website/versioned_docs/version-1.3.2/api/formik.md
@@ -187,7 +187,7 @@ Your form's values. Will have the shape of the result of `mapPropsToValues`
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-#### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
+#### `validateForm: (values?: any) => Promise<Error | FormikErrors<Values>>`
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 

--- a/website/versioned_docs/version-1.4.0/api/formik.md
+++ b/website/versioned_docs/version-1.4.0/api/formik.md
@@ -187,7 +187,7 @@ Your form's values. Will have the shape of the result of `mapPropsToValues`
 (if specified) or all props that are not functions passed to your wrapped
 component.
 
-#### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
+#### `validateForm: (values?: any) => Promise<Error | FormikErrors<Values>>`
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 


### PR DESCRIPTION
Fixes #1198

As described in the issue, the main problem was in the `submitForm` function

https://github.com/jaredpalmer/formik/blob/13954fdd10070f727a0259dbbf98824cb980fa92/src/Formik.tsx#L446

If `combinedErrors` is an instance of an `Error`, the check passes, **causing the form to be submitted**.

<img width="245" alt="image" src="https://user-images.githubusercontent.com/1110551/50235074-54e98780-03b7-11e9-93a1-b3f74633c845.png">

I also extended the types to return either an `Error | FormikErrors<Values>`.