### PR TITLE
Add sort and handleSort to FieldArray helpers

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -41,6 +41,10 @@ export interface ArrayHelpers {
   replace: (index: number, value: any) => void;
   /** Curried fn to replace an element at a given index into the array */
   handleReplace: (index: number, value: any) => () => void;
+  /** Imperatively sort an array using given comparator */
+  sort: (comp: (a: any, b: any) => number) => void;
+  /** Curried fn to sort an array */
+  handleSort: (comp: (a: any, b: any) => number) => () => void;
   /** Imperatively add an element to the beginning of an array and return its length */
   unshift: (value: any) => number;
   /** Curried fn to add an element to the beginning of an array */
@@ -84,6 +88,9 @@ export const replace = (array: any[], index: number, value: any) => {
   const copy = [...(array || [])];
   copy[index] = value;
   return copy;
+};
+export const sort = (array: any[], comp: (a: any, b: any) => number) => {
+  return Array.prototype.slice.call(array).sort(comp);
 };
 class FieldArrayInner<Values = {}> extends React.Component<
   FieldArrayConfig & { formik: FormikContext<Values> },
@@ -176,6 +183,11 @@ class FieldArrayInner<Values = {}> extends React.Component<
   handleReplace = (index: number, value: any) => () =>
     this.replace(index, value);
 
+  sort = (comp: (a: any, b: any) => number) =>
+    this.updateArrayField((array: any[]) => sort(array, comp), false, false);
+
+  handleSort = (comp: (a: any, b: any) => number) => () => this.sort(comp);
+
   unshift = (value: any) => {
     let length = -1;
     this.updateArrayField(
@@ -247,6 +259,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
       move: this.move,
       insert: this.insert,
       replace: this.replace,
+      sort: this.sort,
       unshift: this.unshift,
       remove: this.remove,
       handlePush: this.handlePush,
@@ -255,6 +268,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
       handleMove: this.handleMove,
       handleInsert: this.handleInsert,
       handleReplace: this.handleReplace,
+      handleSort: this.handleSort,
       handleUnshift: this.handleUnshift,
       handleRemove: this.handleRemove,
     };


### PR DESCRIPTION
I needed to sort values and validate the form after this, so I thought a `sort` helper would be nice for a `FieldArray`. 

Unfortunately I couldn't test this out properly because I couldn't build the project, I keep getting errors like `../../../node_modules/@types/react/index.d.ts:2407:13 - error TS2717: Subsequent property declarations must have the same type.  Property 'view' must be of type 'SVGProps<SVGViewElement>', but here has type 'SVGProps<SVGViewElement>'` when running `yarn install`. Googled it, but solutions didn't help me at all :< 

And it also closes #801 