### PR TITLE
Add functional setValues()

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 141423,
+    "bundled": 141459,
     "minified": 39046,
     "gzipped": 11848
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 171603,
+    "bundled": 171639,
     "minified": 49483,
     "gzipped": 14950
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 42377,
+    "bundled": 42414,
     "minified": 21477,
     "gzipped": 5386
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 43265,
+    "bundled": 43302,
     "minified": 22360,
     "gzipped": 5725
   },

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -163,9 +163,9 @@ Set `isSubmitting` imperatively.
 
 Set `touched` imperatively.
 
-#### `setValues: (fields: { [field: string]: any }) => void`
+#### `setValues: (fields: { [field: string]: any } | Function) => void`
 
-Set `values` imperatively.
+Set `values` imperatively. Can receive a function, akin to functional `this.setState`;
 
 #### `status?: any`
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -130,12 +130,18 @@ export class Formik<Values = FormikValues> extends React.Component<
     });
   };
 
-  setValues = (values: FormikState<Values>['values']) => {
-    this.setState({ values }, () => {
+  setValues = (nextState: FormikState<Values>['values']) => {
+    const callback = () => {
       if (this.props.validateOnChange) {
-        this.runValidations(values);
+        this.runValidations(nextState);
       }
-    });
+    };
+
+    if (typeof nextState === 'function') {
+      return this.setState(({values}) => ({values: nextState(values)}), callback)
+    }
+
+    this.setState({ values: nextState }, callback);
   };
 
   setStatus = (status?: any) => {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -518,6 +518,13 @@ describe('<Formik>', () => {
         expect(getProps().values.name).toEqual('ian');
       });
 
+      it('can receive a function', () => {
+        const { getProps } = renderFormik();
+
+        getProps().setValues((state: any) => ({ name: state.name + ' leto' }));
+        expect(getProps().values.name).toEqual('jared leto');
+      });
+
       it('setValues should run validations when validateOnChange is true (default)', () => {
         const validate = jest.fn(() => ({}));
         const { getProps } = renderFormik({ validate });


### PR DESCRIPTION
`setValues` can now receive a function akin to functional `this.setState`. The function receives `values` object 
 from the previous state and must return a new `values` object for the next state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaredpalmer/formik/1255)
<!-- Reviewable:end -->
