### PR TITLE
Add shouldValidate argument to setTouched and setValues methods

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -161,9 +161,11 @@ Set `touched` imperatively.
 
 You can also explicitly prevent/skip validation by passing a second argument as `false`.
 
-#### `setValues: (fields: { [field: string]: any }) => void`
+#### `setValues: (fields: { [field: string]: any }, shouldValidate?: boolean) => void`
 
 Set `values` imperatively.
+
+You can also explicitly prevent/skip validation by passing a second argument as `false`.
 
 #### `status?: any`
 

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -155,9 +155,11 @@ use it to pass API responses back into your component in `handleSubmit`.
 
 Set `isSubmitting` imperatively.
 
-#### `setTouched: (fields: { [field: string]: boolean }) => void`
+#### `setTouched: (fields: { [field: string]: boolean }, shouldValidate?: boolean) => void`
 
 Set `touched` imperatively.
+
+You can also explicitly prevent/skip validation by passing a second argument as `false`.
 
 #### `setValues: (fields: { [field: string]: any }) => void`
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -134,9 +134,12 @@ export class Formik<Values = FormikValues> extends React.Component<
     });
   };
 
-  setValues = (values: FormikState<Values>['values']) => {
+  setValues = (
+    values: FormikState<Values>['values'],
+    shouldValidate: boolean = true
+  ) => {
     this.setState({ values }, () => {
-      if (this.props.validateOnChange) {
+      if (this.props.validateOnChange && shouldValidate) {
         this.runValidations(values);
       }
     });

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -123,9 +123,12 @@ export class Formik<Values = FormikValues> extends React.Component<
     this.setState({ errors });
   };
 
-  setTouched = (touched: FormikTouched<Values>) => {
+  setTouched = (
+    touched: FormikTouched<Values>,
+    shouldValidate: boolean = true
+  ) => {
     this.setState({ touched }, () => {
-      if (this.props.validateOnBlur) {
+      if (this.props.validateOnBlur && shouldValidate) {
         this.runValidations(this.state.values);
       }
     });

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -78,7 +78,7 @@ export interface FormikActions<Values> {
   /** Manually set isSubmitting */
   setSubmitting(isSubmitting: boolean): void;
   /** Manually set touched object */
-  setTouched(touched: FormikTouched<Values>): void;
+  setTouched(touched: FormikTouched<Values>, shouldValidate?: boolean): void;
   /** Manually set values object  */
   setValues(values: Values): void;
   /** Set value of form field directly */

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -80,7 +80,7 @@ export interface FormikActions<Values> {
   /** Manually set touched object */
   setTouched(touched: FormikTouched<Values>, shouldValidate?: boolean): void;
   /** Manually set values object  */
-  setValues(values: Values): void;
+  setValues(values: Values, shouldValidate?: boolean): void;
   /** Set value of form field directly */
   setFieldValue(
     field: keyof Values & string,

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -533,6 +533,14 @@ describe('<Formik>', () => {
         expect(validate).not.toHaveBeenCalled();
       });
 
+      it('setValues should NOT run validations when shouldValidate is false', () => {
+        const validate = jest.fn();
+        const { getProps } = renderFormik({ validate });
+
+        getProps().setValues({ name: 'ian' }, false);
+        expect(validate).not.toHaveBeenCalled();
+      });
+
       it('setFieldValue sets value by key', () => {
         const { getProps } = renderFormik();
 

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -582,6 +582,14 @@ describe('<Formik>', () => {
         expect(validate).not.toHaveBeenCalled();
       });
 
+      it('setTouched should NOT run validations when shouldValidate is false', () => {
+        const validate = jest.fn(() => ({}));
+        const { getProps } = renderFormik({ validate });
+
+        getProps().setTouched({ name: true }, false);
+        expect(validate).not.toHaveBeenCalled();
+      });
+
       it('setFieldTouched sets touched by key', () => {
         const { getProps } = renderFormik();
 


### PR DESCRIPTION
To be consistent with `setFieldTouched`. Also I found use-case where it is needed:

When you validate part of the form using custom validate logic, you need to set errors and touched fields without validating whole form.