### PR TITLE
Remove redundant env check for UMD builds

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,10 +26,7 @@ const buildUmd = ({ env }) => ({
     name: 'Formik',
     format: 'umd',
     sourcemap: true,
-    file:
-      env === 'production'
-        ? `./dist/formik.umd.${env}.js`
-        : `./dist/formik.umd.${env}.js`,
+    file: `./dist/formik.umd.${env}.js`,
     exports: 'named',
     globals: {
       react: 'React',


### PR DESCRIPTION
Both states of the ternary is the same, so can be removed