### PR TITLE
Feature/improve validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ You can play with Formik in your web browser with these live online playgrounds.
 * [Sync Validation](https://codesandbox.io/s/q8yRqQMp)
 * [Building your own input primitives](https://codesandbox.io/s/qJR4ykJk)
 * Working with 3rd-party inputs:
-  - [react-select-v1](https://codesandbox.io/s/jRzE53pqR)
-  - [react-select-v2](https://codesandbox.io/s/73jj9zom96)
-  - [Draft.js](https://codesandbox.io/s/QW1rqjBLl)
+  * [react-select-v1](https://codesandbox.io/s/jRzE53pqR)
+  * [react-select-v2](https://codesandbox.io/s/73jj9zom96)
+  * [Draft.js](https://codesandbox.io/s/QW1rqjBLl)
 * [Accessing React lifecycle functions](https://codesandbox.io/s/pgD4DLypy)
 * [React Native](https://snack.expo.io/@ferrannp/react-native-x-formik)
 * [TypeScript](https://codesandbox.io/s/8y578o8152)

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -64,7 +64,10 @@ export interface FieldConfig {
   /**
    * Validate a single field value independently
    */
-  validate?: ((value: any) => string | Promise<void> | undefined);
+  validate?: ((
+    value: any,
+    context: Object
+  ) => string | Promise<void> | undefined);
 
   /**
    * Field name

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -360,6 +360,7 @@ export class Formik<Values = FormikValues> extends React.Component<
             if (this.props.validateOnChange) {
               this.runValidations(setIn(this.state.values, field!, val), {
                 field,
+                on: 'change',
               });
             }
           }
@@ -451,16 +452,18 @@ export class Formik<Values = FormikValues> extends React.Component<
       submitCount: prevState.submitCount + 1,
     }));
 
-    return this.runValidations(this.state.values).then(combinedErrors => {
-      this.setState({ isValidating: false });
-      const isValid = Object.keys(combinedErrors).length === 0;
-      if (isValid) {
-        this.executeSubmit();
-      } else if (this.didMount) {
-        // ^^^ Make sure Formik is still mounted before calling setState
-        this.setState({ isSubmitting: false });
+    return this.runValidations(this.state.values, { on: 'submit' }).then(
+      combinedErrors => {
+        this.setState({ isValidating: false });
+        const isValid = Object.keys(combinedErrors).length === 0;
+        if (isValid) {
+          this.executeSubmit();
+        } else if (this.didMount) {
+          // ^^^ Make sure Formik is still mounted before calling setState
+          this.setState({ isSubmitting: false });
+        }
       }
-    });
+    );
   };
 
   executeSubmit = () => {
@@ -488,7 +491,7 @@ export class Formik<Values = FormikValues> extends React.Component<
       }));
 
       if (this.props.validateOnBlur) {
-        this.runValidations(this.state.values, { field });
+        this.runValidations(this.state.values, { field, on: 'blur' });
       }
     };
 

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -138,6 +138,40 @@ describe('<Formik>', () => {
       expect(injected.values.name).toEqual('ian');
     });
 
+    it('send field context to validation onchange', () => {
+      const validate = jest.fn(() => {});
+      const { getByTestId } = render(
+        <Formik
+          initialValues={{ name: '' }}
+          validate={validate}
+          onSubmit={noop}
+        >
+          {({ handleChange, handleBlur }) => (
+            <input
+              name="name"
+              onChange={handleChange}
+              onBlur={handleBlur}
+              data-testid="name-input"
+            />
+          )}
+        </Formik>
+      );
+      const input = getByTestId('name-input');
+      fireEvent.change(input, {
+        persist: noop,
+        target: {
+          name: 'name',
+          value: 'ian',
+        },
+      });
+      fireEvent.blur(input);
+      expect(validate).toHaveBeenCalledTimes(2);
+      expect(validate.mock.calls).toEqual([
+        [{ name: 'ian' }, { field: 'name' }],
+        [{ name: 'ian' }, { field: 'name' }],
+      ]);
+    });
+
     it('updates values via `name` instead of `id` attribute when both are present', () => {
       const { getProps, getByTestId } = renderFormik();
 


### PR DESCRIPTION
Added a second argument (context) to "**validate**" method to help us run validation based on "context" object. This will help us in cases like async validation that takes time and run on every onChange. After the change, We can now run the validation onChange of a target field only. 