### PR TITLE
Allow errors to be type "any" rather than "string"

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -284,7 +284,7 @@ There are also imperative helper methods provided to you via Formik's render/inj
 
 ## Displaying Error Messages
 
-@todo
+The easiest way to display error messages is with Formik's [`<ErrorMessage />`](api/errormessage.md) component.
 
 ## Frequently Asked Questions
 
@@ -296,15 +296,22 @@ If `isValidating` prop is `true`
 </details>
 
 <details>
-<summary>Can I return `null` as an error message?</summary>
+<summary>How do I test validation?</summary>
 
-No. Use `undefined` instead. Formik uses `undefined` to represent empty states. If you use `null`, several parts of Formik's computed props (e.g. `isValid` for example), will not work as expected.
+Formik has extensive unit tests for Yup validation so you do not need to test that. However, if you are rolling your own validation functions, you should simply unit test those. If you do need to test Formik's execution you should use the imperative `validateForm` and `validateField` methods respectively.
 
 </details>
 
 <details>
-<summary>How do I test validation?</summary>
+<summary>Which should I use to represent a field with no error: `null`, or `undefined`?</summary>
 
-Formik has extensive unit tests for Yup validation so you do not need to test that. However, if you are rolling your own validation functions, you should simply unit test those. If you do need to test Formik's execution you should use the imperative `validateForm` and `validateField` methods respectively.
+Formik uses `undefined` to represent empty states, so you should use `undefined` to represent a field with no error. If you use `null`, several parts of Formik's computed props (e.g. `isValid` for example), will not work as expected.
+
+</details>
+
+<details>
+<summary>Can I return objects or React elements as error messages, instead of strings?</summary>
+
+Yes, you can provide whatever data type you want for error messages (other than `undefined`, which indicates a field has no error). However, if you are using Yup for validation, it does require custom messages to be strings. And if you are using the Formik `<ErrorMessage>` component, your error message must be something that can be rendered directly by React.
 
 </details>

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -8,12 +8,9 @@ export interface FormikValues {
 
 /**
  * An object containing error messages whose keys correspond to FormikValues.
- * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
 export type FormikErrors<Values> = {
-  [K in keyof Values]?: Values[K] extends object
-    ? FormikErrors<Values[K]>
-    : string
+  [K in keyof Values]?: Values[K] extends object ? FormikErrors<Values[K]> : any
 };
 
 /**

--- a/test/types.test.tsx
+++ b/test/types.test.tsx
@@ -1,14 +1,10 @@
 import { FormikTouched, FormikErrors } from '../src';
+import React, { Fragment, ReactNode } from 'react';
 
 describe('Formik Types', () => {
-  describe('FormikTouched', () => {
-    type Values = {
-      id: string;
-      social: {
-        facebook: string;
-      };
-    };
+  type Values = { id: string; social: { facebook: string } };
 
+  describe('FormikTouched', () => {
     it('it should infer nested object structure of touched property from Values', () => {
       const touched: FormikTouched<Values> = {
         id: true,
@@ -25,13 +21,15 @@ describe('Formik Types', () => {
       const facebook: boolean | undefined = touched.social!.facebook;
       expect(facebook).toBe(true);
     });
+  });
 
+  describe('FormikErrors', () => {
     it('it should infer nested object structure of error property from Values', () => {
       const errors: FormikErrors<Values> = {
         id: 'error',
         social: { facebook: 'error' },
       };
-      // type touched = {
+      // type errors = {
       //    id?: {} | undefined;
       //    social?: {
       //        facebook?: {} | undefined;
@@ -41,6 +39,14 @@ describe('Formik Types', () => {
       expect(id).toBe('error');
       const facebook: {} | undefined = errors.social!.facebook;
       expect(facebook).toBe('error');
+    });
+
+    it('it should optionally support non-string types as error messages (for i18n support)', () => {
+      const errors: FormikErrors<Values, ReactNode> = {
+        id: <Fragment>error</Fragment>,
+      };
+      const id: ReactNode = errors.id;
+      expect(React.isValidElement(id)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
This allows React components to be provided as error
messages, which is especially helpful for usage with
i18n frameworks.

Fixes #1292