### PR TITLE
Swap setSubmitting(false) and next(values)

### DIFF
--- a/examples/MultistepWizard.js
+++ b/examples/MultistepWizard.js
@@ -42,9 +42,9 @@ class Wizard extends React.Component {
     if (isLastPage) {
       return onSubmit(values, bag);
     } else {
-      this.next(values);
       bag.setTouched({});
       bag.setSubmitting(false);
+      this.next(values);
     }
   };
 


### PR DESCRIPTION
This prevents the next page from mounting with isSubmitting === true then quickly rerendering when isSubmitting === false