### PR TITLE
Add MultistepWizard example using React Router

### DIFF
--- a/examples/Debug.js
+++ b/examples/Debug.js
@@ -4,10 +4,9 @@ import { FormikConsumer } from 'formik';
 export const Debug = () => (
   <div
     style={{
-      margin: '3rem 0',
+      margin: '3rem 1rem',
       borderRadius: 4,
       background: '#f6f8fa',
-
       boxShadow: '0 0 1px  #eee inset',
     }}
   >
@@ -30,7 +29,7 @@ export const Debug = () => (
       {({ validationSchema, validate, onSubmit, ...rest }) => (
         <pre
           style={{
-            fontSize: '.65rem',
+            fontSize: '.85rem',
             padding: '.25rem .5rem',
             overflowX: 'scroll',
           }}

--- a/examples/RoutedMultistepWizard.js
+++ b/examples/RoutedMultistepWizard.js
@@ -1,0 +1,207 @@
+import React from "react";
+import { BrowserRouter as Router, Route, withRouter } from "react-router-dom";
+import { Formik, Field, ErrorMessage } from "formik";
+import { Debug } from "./Debug";
+
+const locations = ["/step/1", "/step/2"];
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const required = value => (value ? undefined : "Required");
+
+
+class WizardBase extends React.Component {
+  static Page = ({ children }) => children;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      values: props.initialValues
+    };
+  }
+
+  next = values => {
+    const { location, history } = this.props;
+    this.setState(() => ({ values }));
+
+    const nextPath = locations.indexOf(location.pathname) + 1;
+    history.push(locations[nextPath]);
+  };
+
+  previous = () => {
+    const { location, history } = this.props;
+
+    const prevPath = locations.indexOf(location.pathname) - 1;
+    history.push(locations[prevPath]);
+  };
+
+  validate = values => {
+    const { location, children } = this.props;
+
+    const page = locations.indexOf(location.pathname);
+    const activePage = React.Children.toArray(children)[page];
+    return activePage.props.validate ? activePage.props.validate(values) : {};
+  };
+
+  handleSubmit = (values, bag) => {
+    const { children, onSubmit, location } = this.props;
+    const page = locations.indexOf(location.pathname);
+    const isLastPage = page === React.Children.count(children) - 1;
+    if (isLastPage) {
+      return onSubmit(values, bag);
+    }
+    // otherwise update values from page
+    bag.setTouched({});
+    bag.setSubmitting(false);
+    this.next(values);
+  };
+
+  render() {
+    const { children, location } = this.props;
+    const { values } = this.state;
+    const page = locations.indexOf(location.pathname);
+
+    const activePage = React.Children.toArray(children)[page];
+    const isLastPage = page === React.Children.count(children) - 1;
+    return (
+      <Formik
+        initialValues={values}
+        enableReinitialize={false}
+        validate={this.validate}
+        onSubmit={this.handleSubmit}
+        render={({ values, handleSubmit, isSubmitting, handleReset }) => (
+          <form onSubmit={handleSubmit}>
+            {activePage}
+            <div className="buttons">
+              {page > 0 && (
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={this.previous}
+                >
+                  « Previous
+                </button>
+              )}
+
+              {!isLastPage && <button type="submit">Next »</button>}
+              {isLastPage && (
+                <button type="submit" disabled={isSubmitting}>
+                  Submit
+                </button>
+              )}
+            </div>
+
+            <Debug />
+          </form>
+        )}
+      />
+    );
+  }
+}
+
+const Wizard = withRouter(WizardBase);
+
+
+const App = () => (
+  <Router>
+    <div className="App">
+      <h1>Multistep / Form Wizard </h1>
+      <Route
+        path="/step"
+        render={routeProps => (
+          <Wizard
+            {...routeProps}
+            initialValues={{
+              firstName: "",
+              lastName: "",
+              email: "",
+              favoriteColor: ""
+            }}
+            onSubmit={(values, actions) => {
+              sleep(300).then(() => {
+                window.alert(JSON.stringify(values, null, 2));
+                actions.setSubmitting(false);
+              });
+            }}
+          >
+            <Wizard.Page>
+              <div>
+                <label>First Name</label>
+                <Field
+                  name="firstName"
+                  component="input"
+                  type="text"
+                  placeholder="First Name"
+                  validate={required}
+                />
+                <ErrorMessage
+                  name="firstName"
+                  component="div"
+                  className="field-error"
+                />
+              </div>
+              <div>
+                <label>Last Name</label>
+                <Field
+                  name="lastName"
+                  component="input"
+                  type="text"
+                  placeholder="Last Name"
+                  validate={required}
+                />
+                <ErrorMessage
+                  name="lastName"
+                  component="div"
+                  className="field-error"
+                />
+              </div>
+            </Wizard.Page>
+            <Wizard.Page
+              validate={values => {
+                const errors = {};
+                if (!values.email) {
+                  errors.email = "Required";
+                }
+                if (!values.favoriteColor) {
+                  errors.favoriteColor = "Required";
+                }
+                return errors;
+              }}
+            >
+              <div>
+                <label>Email</label>
+                <Field
+                  name="email"
+                  component="input"
+                  type="email"
+                  placeholder="Email"
+                />
+                <ErrorMessage
+                  name="email"
+                  component="div"
+                  className="field-error"
+                />
+              </div>
+              <div>
+                <label>Favorite Color</label>
+                <Field name="favoriteColor" component="select">
+                  <option value="">Select a Color</option>
+                  <option value="#ff0000">❤️ Red</option>
+                  <option value="#00ff00">💚 Green</option>
+                  <option value="#0000ff">💙 Blue</option>
+                </Field>
+                <ErrorMessage
+                  name="favoriteColor"
+                  component="div"
+                  className="field-error"
+                />
+              </div>
+            </Wizard.Page>
+          </Wizard>
+        )}
+      />
+    </div>
+  </Router>
+);
+
+export default App;

--- a/examples/RoutedMultistepWizard.js
+++ b/examples/RoutedMultistepWizard.js
@@ -3,6 +3,10 @@ import { BrowserRouter as Router, Route, withRouter } from "react-router-dom";
 import { Formik, Field, ErrorMessage } from "formik";
 import { Debug } from "./Debug";
 
+// the root path. locations should extend from this
+const formRootPath = "/step"
+
+// the specific path for each page
 const locations = ["/step/1", "/step/2"];
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -24,6 +28,7 @@ class WizardBase extends React.Component {
     const { location, history } = this.props;
     this.setState(() => ({ values }));
 
+    // withRouter provides current location and history.push() to go to next page
     const nextPath = locations.indexOf(location.pathname) + 1;
     history.push(locations[nextPath]);
   };
@@ -59,6 +64,7 @@ class WizardBase extends React.Component {
   render() {
     const { children, location } = this.props;
     const { values } = this.state;
+    // current page is determined by matching path in locations
     const page = locations.indexOf(location.pathname);
 
     const activePage = React.Children.toArray(children)[page];
@@ -107,7 +113,7 @@ const App = () => (
     <div className="App">
       <h1>Multistep / Form Wizard </h1>
       <Route
-        path="/step"
+        path={formRootPath}
         render={routeProps => (
           <Wizard
             {...routeProps}

--- a/examples/RoutedMultistepWizard2.js
+++ b/examples/RoutedMultistepWizard2.js
@@ -1,0 +1,125 @@
+/* eslint-disable jsx-a11y/accessible-emoji */
+import React, { Fragment } from "react";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Link,
+  Redirect
+} from "react-router-dom";
+import { Field, ErrorMessage, withFormik } from "formik";
+import { Debug } from "./Debug";
+
+
+const required = value => (value ? undefined : "Required");
+
+const Page1 = () => (
+  <Fragment>
+    <div>
+      <label>First Name</label>
+      <Field
+        name="firstName"
+        component="input"
+        type="text"
+        placeholder="First Name"
+        validate={required}
+      />
+      <ErrorMessage name="firstName" component="div" className="field-error" />
+    </div>
+    <div>
+      <label>Last Name</label>
+      <Field
+        name="lastName"
+        component="input"
+        type="text"
+        placeholder="Last Name"
+        validate={required}
+      />
+      <ErrorMessage name="lastName" component="div" className="field-error" />
+    </div>
+    <Link to="/step2">
+      <button type="button">Next »</button>
+    </Link>
+  </Fragment>
+);
+
+const Page2 = () => (
+  <Fragment>
+    <div>
+      <label>Email</label>
+      <Field name="email" component="input" type="email" placeholder="Email" />
+      <ErrorMessage name="email" component="div" className="field-error" />
+    </div>
+    <div>
+      <label>Favorite Color</label>
+      <Field name="favoriteColor" component="select">
+        <option value="">Select a Color</option>
+        <option value="#ff0000">❤️ Red</option>
+        <option value="#00ff00">💚 Green</option>
+        <option value="#0000ff">💙 Blue</option>
+      </Field>
+      <ErrorMessage
+        name="favoriteColor"
+        component="div"
+        className="field-error"
+      />
+    </div>
+    <Link to="/step1">
+      <button type="button">Previous</button>
+    </Link>
+    <button type="submit">Submit</button>
+  </Fragment>
+);
+
+const BaseForm = ({ values, handleSubmit }) => (
+  <Router>
+    <div className="App">
+      <h1>Multistep / Form Wizard </h1>
+      <form onSubmit={handleSubmit}>
+        <Switch>
+          <Route
+            path="/step1"
+            render={routeProps => <Page1 {...routeProps} />}
+          />
+          <Route
+            path="/step2"
+            render={routeProps => <Page2 {...routeProps} />}
+          />
+          <Redirect to="/step1" />
+        </Switch>
+
+        <Debug />
+      </form>
+    </div>
+  </Router>
+);
+
+export const EnhancedForm = withFormik({
+  /* setup initial values */
+  mapPropsToValues: () => ({
+    firstName: "",
+    lastName: "",
+    email: "",
+    favoriteColor: ""
+  }),
+
+  validate: (values, props) => {
+    console.log("props", props);
+    const errors = {};
+
+    if (!values.email) {
+      errors.email = "Required";
+    }
+
+    return errors;
+  },
+
+  handleSubmit: (values, { setSubmitting }) => {
+    setTimeout(() => {
+      alert(JSON.stringify(values, null, 2));
+      setSubmitting(false);
+    }, 1000);
+  },
+
+  displayName: "BaseForm"
+})(BaseForm);


### PR DESCRIPTION
This example extends the MultistepWizard by adding React Router support.

Page locations are simply `/step/1` and `/step/2`

Key benefit is that the UI then intuitively allows page navigation using back & forward buttons for a multipage form.

I'm also suggesting some Debug style tweaks. Reading 8 point on a 4K monitor is nigh impossible.