### PR TITLE
Fix arrayHelper `insert` and alterTouched falsy behavior

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -130,7 +130,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
                 updateErrors(getIn(prevState.errors, name))
               )
             : prevState.errors,
-          touched: updateTouched
+          touched: alterTouched
             ? setIn(
                 prevState.touched,
                 name,


### PR DESCRIPTION
- Apply changes from @marcel-devdude in #1092 
- Fix a bug from which `state.touched` would have been altered even if `alterTouched` was falsy.
