### PR TITLE
Example of FieldArray component prop in TypeScript

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -52,6 +52,66 @@ export const MyApp: React.SFC<{}> = () => {
 };
 ```
 
+#### Component props (`<Formik />` and `<FieldArray />`)
+
+```typescript
+import * as React from 'react'
+import { Field, FieldArray, Form, Formik, FormikActions, getIn } from 'formik'
+
+interface MyFormValues {
+  friends: string[]
+}
+
+export const FriendList = () => (
+  <div>
+    <h1>Friend List</h1>
+    <Formik
+      initialValues={{
+        friends: ['jared', 'ian', 'brent', 'beau'],
+      }}
+      onSubmit={(
+        values: MyFormValues,
+        actions: FormikActions<MyFormValues>
+      ) => {
+        console.log({ values, actions })
+        alert(JSON.stringify(values, null, 2))
+        actions.setSubmitting(false)
+      }}
+    >
+      {({ isSubmitting }) => (
+        <Form>
+          <FieldArray name="friends" component={FriendsFieldArray} />
+          <button type="submit" disabled={isSubmitting}>
+            Save
+          </button>
+        </Form>
+      )}
+    </Formik>
+  </div>
+)
+
+const FriendsFieldArray = (arrayHelpers: FieldArrayRenderProps) => {
+  const values = getIn(arrayHelpers.form.values, arrayHelpers.name);
+  return (
+    <div>
+      {values.map(
+        (firstName: string, i: number) => (
+          <div key={i}>
+            <label htmlFor={`${arrayHelpers.name}.${i}`}>Friend Name</label>
+            <Field
+              id={`${arrayHelpers.name}.${i}`}
+              name={`${arrayHelpers.name}.${i}`}
+            />
+            <button onClick={() => arrayHelpers.remove(i)}>Remove</button>
+          </div>
+        )
+      )}
+      <button onClick={() => arrayHelpers.push('')}>Add Friend</button>
+    </div>
+  )
+}
+```
+
 #### `withFormik()`
 
 ```typescript

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -242,21 +242,21 @@ export interface FormikRegistration {
 export type FormikContext<Values> = FormikProps<Values> &
   Pick<FormikConfig<Values>, 'validate' | 'validationSchema'>;
 
-export interface SharedRenderProps<T> {
+export interface SharedRenderProps<P> {
   /**
    * Field component to render. Can either be a string like 'select' or a component.
    */
-  component?: string | React.ComponentType<T | void>;
+  component?: string | React.ComponentType<P>;
 
   /**
    * Render prop (works like React router's <Route render={props =>} />)
    */
-  render?: ((props: T) => React.ReactNode);
+  render?: ((props: P) => React.ReactNode);
 
   /**
    * Children render function <Field name>{props => ...}</Field>)
    */
-  children?: ((props: T) => React.ReactNode);
+  children?: ((props: P) => React.ReactNode);
 }
 
 export type GenericFieldHTMLAttributes =

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { FieldArray, Formik, isFunction } from '../src';
+import { FieldArray, Formik, isFunction, FieldArrayRenderProps } from '../src';
 
 // tslint:disable-next-line:no-empty
 const noop = () => {};
@@ -22,7 +22,7 @@ describe('<FieldArray />', () => {
   });
 
   it('renders component with array helpers as props', () => {
-    const TestComponent = (arrayProps: any) => {
+    const TestComponent = (arrayProps: FieldArrayRenderProps) => {
       expect(isFunction(arrayProps.push)).toBeTruthy();
       return null;
     };


### PR DESCRIPTION
This is an example using similar code/content from elsewhere in the docs. 

This PR also fixes a bug in the `src/types.ts` file where when using a component prop (such as `<FieldArray name="foo" component={FooFieldArray} />` would cause the following error:

> Type '{ name: string; component: (arrayHelpers: FieldArrayRenderProps) => Element; }' is not assignable to type 'IntrinsicAttributes & { name: string; validateOnChange?: boolean | undefined; } & SharedRenderProps<FieldArrayRenderProps> & { children?: ReactNode; }'.
  Property 'component' does not exist on type 'IntrinsicAttributes & { name: string; validateOnChange?: boolean | undefined; } & SharedRenderProps<FieldArrayRenderProps> & { children?: ReactNode; }'.