### PR TITLE
Call preventDefault in handleReset

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -537,7 +537,11 @@ export class Formik<Values = FormikValues> extends React.Component<
     });
   };
 
-  handleReset = () => {
+  handleReset = (e?: React.FormEvent<HTMLFormElement>) => {
+    if (e && e.preventDefault) {
+      e.preventDefault();
+    }
+
     if (this.props.onReset) {
       const maybePromisedOnReset = (this.props.onReset as any)(
         this.state.values,

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -785,6 +785,14 @@ describe('<Formik>', () => {
       getProps().handleReset();
       expect(getProps().submitCount).toEqual(0);
     });
+
+    it('should call preventDefault()', () => {
+      const event = { preventDefault: jest.fn() };
+      const { getProps } = renderFormik();
+
+      getProps().handleReset(event);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
   });
 
   describe('componentDidUpdate', () => {


### PR DESCRIPTION
This aligns the behavior of `handleReset` with `handleSubmit`, calling `event.preventDefault()` if an event is supplied. I noticed the form's reset event had unexpected side effects otherwise, resetting `select` elements to the first option and not the controlled value.