### PR TITLE
Callbacks in ArrayHelpers

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 141423,
-    "minified": 39046,
-    "gzipped": 11848
+    "bundled": 141574,
+    "minified": 39116,
+    "gzipped": 11865
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 171603,
-    "minified": 49483,
-    "gzipped": 14950
+    "bundled": 171754,
+    "minified": 49553,
+    "gzipped": 14964
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 42377,
-    "minified": 21477,
-    "gzipped": 5386
+    "bundled": 42591,
+    "minified": 21547,
+    "gzipped": 5410
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 43265,
-    "minified": 22360,
-    "gzipped": 5725
+    "bundled": 43479,
+    "minified": 22430,
+    "gzipped": 5748
   },
   "dist/formik.esm.js": {
-    "bundled": 39126,
-    "minified": 21749,
-    "gzipped": 5602,
+    "bundled": 39273,
+    "minified": 21819,
+    "gzipped": 5626,
     "treeshaked": {
       "rollup": {
         "code": 771,

--- a/docs/api/fieldarray.md
+++ b/docs/api/fieldarray.md
@@ -175,14 +175,16 @@ _NOTE_: In Formik v0.12 / 1.0, a new `meta` prop may be added to `Field` and `Fi
 
 The following methods are made available via render props.
 
-* `push: (obj: any) => void`: Add a value to the end of an array
-* `swap: (indexA: number, indexB: number) => void`: Swap two values in an array
-* `move: (from: number, to: number) => void`: Move an element in an array to another index
-* `insert: (index: number, value: any) => void`: Insert an element at a given index into the array
-* `unshift: (value: any) => number`: Add an element to the beginning of an array and return its length
-* `remove<T>(index: number): T | undefined`: Remove an element at an index of an array and return it
-* `pop<T>(): T | undefined`: Remove and return value from the end of the array
-* `replace: (index: number, value: any) => void`: Replace a value at the given index into the array
+* `push: (obj: any, cb?: Function) => void`: Add a value to the end of an array
+* `swap: (indexA: number, indexB: number, cb?: Function) => void`: Swap two values in an array
+* `move: (from: number, to: number, cb?: Function) => void`: Move an element in an array to another index
+* `insert: (index: number, value: any, cb?: Function) => void`: Insert an element at a given index into the array
+* `unshift: (value: any, cb?: Function) => number`: Add an element to the beginning of an array and return its length
+* `remove<T>(index: number, cb?: Function): T | undefined`: Remove an element at an index of an array and return it
+* `pop<T>(cb?: Function): T | undefined`: Remove and return value from the end of the array
+* `replace: (index: number, value: any, cb?: Function) => void`: Replace a value at the given index into the array
+
+All the mentioned methods support callbacks.
 
 ## FieldArray render methods
 

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -22,37 +22,37 @@ export type FieldArrayConfig = {
 } & SharedRenderProps<FieldArrayRenderProps>;
 export interface ArrayHelpers {
   /** Imperatively add a value to the end of an array */
-  push: (obj: any) => void;
+  push: (obj: any, cb?: Function) => void;
   /** Curried fn to add a value to the end of an array */
-  handlePush: (obj: any) => () => void;
+  handlePush: (obj: any, cb?: Function) => () => void;
   /** Imperatively swap two values in an array */
-  swap: (indexA: number, indexB: number) => void;
+  swap: (indexA: number, indexB: number, cb?: Function) => void;
   /** Curried fn to swap two values in an array */
-  handleSwap: (indexA: number, indexB: number) => () => void;
+  handleSwap: (indexA: number, indexB: number, cb?: Function) => () => void;
   /** Imperatively move an element in an array to another index */
-  move: (from: number, to: number) => void;
+  move: (from: number, to: number, cb?: Function) => void;
   /** Imperatively move an element in an array to another index */
-  handleMove: (from: number, to: number) => () => void;
+  handleMove: (from: number, to: number, cb?: Function) => () => void;
   /** Imperatively insert an element at a given index into the array */
-  insert: (index: number, value: any) => void;
+  insert: (index: number, value: any, cb?: Function) => void;
   /** Curried fn to insert an element at a given index into the array */
-  handleInsert: (index: number, value: any) => () => void;
+  handleInsert: (index: number, value: any, cb?: Function) => () => void;
   /** Imperatively replace a value at an index of an array  */
-  replace: (index: number, value: any) => void;
+  replace: (index: number, value: any, cb?: Function) => void;
   /** Curried fn to replace an element at a given index into the array */
-  handleReplace: (index: number, value: any) => () => void;
+  handleReplace: (index: number, value: any, cb?: Function) => () => void;
   /** Imperatively add an element to the beginning of an array and return its length */
-  unshift: (value: any) => number;
+  unshift: (value: any, cb?: Function) => number;
   /** Curried fn to add an element to the beginning of an array */
-  handleUnshift: (value: any) => () => void;
+  handleUnshift: (value: any, cb?: Function) => () => void;
   /** Curried fn to remove an element at an index of an array */
-  handleRemove: (index: number) => () => void;
+  handleRemove: (index: number, cb?: Function) => () => void;
   /** Curried fn to remove a value from the end of the array */
-  handlePop: () => () => void;
+  handlePop: (cb?: Function) => () => void;
   /** Imperatively remove and element at an index of an array */
-  remove<T>(index: number): T | undefined;
+  remove<T>(index: number, cb?: Function): T | undefined;
   /** Imperatively remove and return value from the end of the array */
-  pop<T>(): T | undefined;
+  pop<T>(cb?: Function): T | undefined;
 }
 
 /**
@@ -103,7 +103,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   updateArrayField = (
     fn: Function,
     alterTouched: boolean,
-    alterErrors: boolean
+    alterErrors: boolean,
+    cb?: Function
   ) => {
     const {
       name,
@@ -129,54 +130,67 @@ class FieldArrayInner<Values = {}> extends React.Component<
         if (validateOnChange) {
           validateForm();
         }
+        cb && cb();
       }
     );
   };
 
-  push = (value: any) =>
-    this.updateArrayField(
+  push = (value: any, cb?: Function) => {
+    return this.updateArrayField(
       (array: any[]) => [...(array || []), cloneDeep(value)],
       false,
-      false
+      false,
+      cb
     );
+  };
 
-  handlePush = (value: any) => () => this.push(value);
+  handlePush = (value: any, cb?: Function) => () => this.push(value, cb);
 
-  swap = (indexA: number, indexB: number) =>
+  swap = (indexA: number, indexB: number, cb?: Function) =>
     this.updateArrayField(
       (array: any[]) => swap(array, indexA, indexB),
       true,
-      true
+      true,
+      cb
     );
 
-  handleSwap = (indexA: number, indexB: number) => () =>
-    this.swap(indexA, indexB);
+  handleSwap = (indexA: number, indexB: number, cb?: Function) => () =>
+    this.swap(indexA, indexB, cb);
 
-  move = (from: number, to: number) =>
-    this.updateArrayField((array: any[]) => move(array, from, to), true, true);
+  move = (from: number, to: number, cb?: Function) =>
+    this.updateArrayField(
+      (array: any[]) => move(array, from, to),
+      true,
+      true,
+      cb
+    );
 
-  handleMove = (from: number, to: number) => () => this.move(from, to);
+  handleMove = (from: number, to: number, cb?: Function) => () =>
+    this.move(from, to, cb);
 
-  insert = (index: number, value: any) =>
+  insert = (index: number, value: any, cb?: Function) =>
     this.updateArrayField(
       (array: any[]) => insert(array, index, value),
       true,
-      true
+      true,
+      cb
     );
 
-  handleInsert = (index: number, value: any) => () => this.insert(index, value);
+  handleInsert = (index: number, value: any, cb?: Function) => () =>
+    this.insert(index, value, cb);
 
-  replace = (index: number, value: any) =>
+  replace = (index: number, value: any, cb?: Function) =>
     this.updateArrayField(
       (array: any[]) => replace(array, index, value),
       false,
-      false
+      false,
+      cb
     );
 
-  handleReplace = (index: number, value: any) => () =>
-    this.replace(index, value);
+  handleReplace = (index: number, value: any, cb?: Function) => () =>
+    this.replace(index, value, cb);
 
-  unshift = (value: any) => {
+  unshift = (value: any, cb?: Function) => {
     let length = -1;
     this.updateArrayField(
       (array: any[]) => {
@@ -187,14 +201,15 @@ class FieldArrayInner<Values = {}> extends React.Component<
         return arr;
       },
       true,
-      true
+      true,
+      cb
     );
     return length;
   };
 
-  handleUnshift = (value: any) => () => this.unshift(value);
+  handleUnshift = (value: any, cb?: Function) => () => this.unshift(value, cb);
 
-  remove<T>(index: number): T {
+  remove<T>(index: number, cb?: Function): T {
     // We need to make sure we also remove relevant pieces of `touched` and `errors`
     let result: any;
     this.updateArrayField(
@@ -210,15 +225,17 @@ class FieldArrayInner<Values = {}> extends React.Component<
         return copy;
       },
       true,
-      true
+      true,
+      cb
     );
 
     return result;
   }
 
-  handleRemove = (index: number) => () => this.remove<any>(index);
+  handleRemove = (index: number, cb?: Function) => () =>
+    this.remove<any>(index, cb);
 
-  pop<T>(): T {
+  pop<T>(cb?: Function): T {
     // Remove relevant pieces of `touched` and `errors` too!
     let result: any;
     this.updateArrayField(
@@ -231,13 +248,14 @@ class FieldArrayInner<Values = {}> extends React.Component<
         return tmp;
       },
       true,
-      true
+      true,
+      cb
     );
 
     return result;
   }
 
-  handlePop = () => () => this.pop<any>();
+  handlePop = (cb?: Function) => () => this.pop<any>(cb);
 
   render() {
     const arrayHelpers: ArrayHelpers = {


### PR DESCRIPTION
It refers to the feature request #1253.

It should fix the async behaviour. 
Here an example [https://codesandbox.io/s/5267w2v4m4](example) of the problem which users can face.

With this solution, you should be able to call methods of ArrayHelpers passing as second parameter a callback.
