### PR TITLE
Fix for Windows Paths

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
@@ -8,7 +9,7 @@ import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
 
 const input = './compiled/index.js';
-const external = id => !id.startsWith('.') && !id.startsWith('/');
+const external = id => !id.startsWith('.') && !path.isAbsolute(id);
 const replacements = [{ original: 'lodash', replacement: 'lodash-es' }];
 const babelOptions = {
   exclude: /node_modules/,


### PR DESCRIPTION
This adds a check for `path.isAbsolute()` instead of `path.startsWith('/')`, since absolute Windows paths don't start with `/`.

Closes #1352 