### PR TITLE
Accessors for FieldArray

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -299,6 +299,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
       name,
     };
 
+    restOfFormik.registerFieldArrayHelpers(name, arrayHelpers);
+
     return component
       ? React.createElement(component as any, props)
       : render

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -25,7 +25,7 @@ import {
   getIn,
   makeCancelable,
 } from './utils';
-import { ArrayHelpers } from 'formik';
+import { ArrayHelpers } from './FieldArray';
 
 export class Formik<Values = FormikValues> extends React.Component<
   FormikConfig<Values>,

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -25,6 +25,7 @@ import {
   getIn,
   makeCancelable,
 } from './utils';
+import { ArrayHelpers } from 'formik';
 
 export class Formik<Values = FormikValues> extends React.Component<
   FormikConfig<Values>,
@@ -48,6 +49,9 @@ export class Formik<Values = FormikValues> extends React.Component<
   fields: {
     [field: string]: React.Component<any>;
   };
+  fieldArrayHelpers: {
+    [field: string]: ArrayHelpers;
+  };
   validator: any;
 
   constructor(props: FormikConfig<Values>) {
@@ -63,6 +67,7 @@ export class Formik<Values = FormikValues> extends React.Component<
     };
     this.didMount = false;
     this.fields = {};
+    this.fieldArrayHelpers = {};
     this.initialValues = props.initialValues || ({} as any);
     warning(
       !(props.component && props.render),
@@ -82,6 +87,10 @@ export class Formik<Values = FormikValues> extends React.Component<
 
   registerField = (name: string, Comp: React.Component<any>) => {
     this.fields[name] = Comp;
+  };
+
+  registerFieldArrayHelpers = (name: string, arrayHelpers: ArrayHelpers) => {
+    this.fieldArrayHelpers[name] = arrayHelpers;
   };
 
   unregisterField = (name: string) => {
@@ -118,6 +127,10 @@ export class Formik<Values = FormikValues> extends React.Component<
       this.resetForm(this.props.initialValues);
     }
   }
+
+  getFieldArrayHelpers = (field: string) => {
+    return getIn(this.fieldArrayHelpers, field);
+  };
 
   setErrors = (errors: FormikErrors<Values>) => {
     this.setState({ errors });
@@ -574,6 +587,7 @@ export class Formik<Values = FormikValues> extends React.Component<
 
   getFormikActions = (): FormikActions<Values> => {
     return {
+      getFieldArrayHelpers: this.getFieldArrayHelpers,
       resetForm: this.resetForm,
       submitForm: this.submitForm,
       validateForm: this.validateForm,
@@ -612,6 +626,7 @@ export class Formik<Values = FormikValues> extends React.Component<
       ...this.getFormikComputedProps(),
       // Field needs to communicate with Formik during resets
       registerField: this.registerField,
+      registerFieldArrayHelpers: this.registerFieldArrayHelpers,
       unregisterField: this.unregisterField,
       handleBlur: this.handleBlur,
       handleChange: this.handleChange,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ArrayHelpers } from 'formik';
 /**
  * Values of fields in the form
  */
@@ -66,6 +67,7 @@ export interface FormikComputedProps<Values> {
  * Formik state helpers
  */
 export interface FormikActions<Values> {
+  getFieldArrayHelpers(field: keyof Values & string): ArrayHelpers | undefined;
   /** Manually set top level status. */
   setStatus(status?: any): void;
   /**
@@ -233,6 +235,7 @@ export type FormikProps<Values> = FormikSharedConfig &
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {
   registerField(name: string, Comp: React.Component<any>): void;
+  registerFieldArrayHelpers(name: string, arrayHelpers: ArrayHelpers): void;
   unregisterField(name: string): void;
 }
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ArrayHelpers } from 'formik';
+import { ArrayHelpers } from './FieldArray';
 /**
  * Values of fields in the form
  */


### PR DESCRIPTION
The goal of this PR is to expose `ArrayHelpers` outside of FieldArray's `render` method.  It would be convenient to be able to just pass around FormikProps and call `myForm.getFieldArrayHelpers(myFieldName)` when necessary.  Similarly to form values and errors, the array helpers could also be accessed via `myForm.fieldArrayHelpers`.  What are your thoughts on these two API modifications?  Development is not complete, I'm looking for feedback on the initial concept and the API modifications.