### PR TITLE
Let user drop props through FieldArray, like Field

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -12,6 +12,7 @@ import { getIn, isEmptyChildren, isFunction, setIn } from './utils';
 export type FieldArrayRenderProps = ArrayHelpers & {
   form: FormikProps<any>;
   name: string;
+  [key: string]: any;
 };
 
 export type FieldArrayConfig = {
@@ -19,7 +20,10 @@ export type FieldArrayConfig = {
   name: string;
   /** Should field array validate the form AFTER array updates/changes? */
   validateOnChange?: boolean;
+  /** Allow users to pass props through to component/render/children */
+  [key: string]: any;
 } & SharedRenderProps<FieldArrayRenderProps>;
+
 export interface ArrayHelpers {
   /** Imperatively add a value to the end of an array */
   push: (obj: any) => void;
@@ -202,12 +206,16 @@ class FieldArrayInner<Values = {}> extends React.Component<
       },
       (array: any[]) => {
         const arr = array ? [null, ...array] : [null];
-        if (length < 0) length = arr.length;
+        if (length < 0) {
+          length = arr.length;
+        }
         return arr;
       },
       (array: any[]) => {
         const arr = array ? [null, ...array] : [null];
-        if (length < 0) length = arr.length;
+        if (length < 0) {
+          length = arr.length;
+        }
         return arr;
       }
     );
@@ -291,9 +299,12 @@ class FieldArrayInner<Values = {}> extends React.Component<
         validationSchema: _validationSchema,
         ...restOfFormik
       },
+      validateOnChange,
+      ...passedProps // grab any props dropped in by a user
     } = this.props;
 
     const props: FieldArrayRenderProps = {
+      ...passedProps,
       ...arrayHelpers,
       form: restOfFormik,
       name,

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -37,6 +37,26 @@ describe('<FieldArray />', () => {
     );
   });
 
+  it('renders component and passes exra props down', () => {
+    const TestComponent = (props: any) => {
+      expect(props.userProps === 'test');
+      return null;
+    };
+
+    ReactDOM.render(
+      <TestForm
+        component={() => (
+          <FieldArray
+            name="friends"
+            userProp="test"
+            component={TestComponent}
+          />
+        )}
+      />,
+      node
+    );
+  });
+
   it('renders with render callback with array helpers as props', () => {
     ReactDOM.render(
       <TestForm


### PR DESCRIPTION
I've read #561, #693 and while you can user render and a closure to accomplish it, it would be nice if `<FieldArray />` would pass all props down to a `component` prop.

This PR implements it pretty naively, but please do consider adding it!

I'm happy to make edits or build the typings out better if it helps.