### PR TITLE
Fix missing displayName for Form component

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from './connect';
+import { FormikHandlers } from './types';
 
 export type FormikFormProps = Pick<
   React.FormHTMLAttributes<HTMLFormElement>,
@@ -9,9 +10,12 @@ export type FormikFormProps = Pick<
   >
 >;
 
-const FormInner = ({ formik: { handleReset, handleSubmit }, ...props }) => (
-  <form onReset={handleReset} onSubmit={handleSubmit} {...props} />
-);
+const FormInner = ({
+  formik: { handleReset, handleSubmit },
+  ...props
+}: {
+  formik: FormikHandlers;
+}) => <form onReset={handleReset} onSubmit={handleSubmit} {...props} />;
 
 FormInner.displayName = 'Form';
 

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -9,10 +9,10 @@ export type FormikFormProps = Pick<
   >
 >;
 
-export const Form = connect<FormikFormProps>(
-  ({ formik: { handleReset, handleSubmit }, ...props }) => (
-    <form onReset={handleReset} onSubmit={handleSubmit} {...props} />
-  )
+const FormInner = ({ formik: { handleReset, handleSubmit }, ...props }) => (
+  <form onReset={handleReset} onSubmit={handleSubmit} {...props} />
 );
 
-Form.displayName = 'Form';
+FormInner.displayName = 'Form';
+
+export const Form = connect<FormikFormProps>(FormInner);


### PR DESCRIPTION
`Form` component has no `displayName`. Current code changes `displayName` of connected component, not `Form` component.

See screenshots of dev tools.

<img width="458" alt="Before" src="https://user-images.githubusercontent.com/4808043/54885291-8fb5fc80-4e8b-11e9-89c3-d33ec3b76712.png">
<img width="392" alt="After" src="https://user-images.githubusercontent.com/4808043/54885292-95134700-4e8b-11e9-8fab-d3e45f21a9d5.png">
