### PR TITLE
[v2] Revert missing enableReinitialize in useFormik hook

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,14 +5,14 @@
     "gzipped": 11144
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 38882,
-    "minified": 18530,
-    "gzipped": 5416
+    "bundled": 38873,
+    "minified": 18521,
+    "gzipped": 5413
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 39586,
-    "minified": 19287,
-    "gzipped": 5706
+    "bundled": 39572,
+    "minified": 19272,
+    "gzipped": 5700
   },
   "dist/index.js": {
     "bundled": 33614,
@@ -20,9 +20,9 @@
     "gzipped": 5329
   },
   "dist/formik.esm.js": {
-    "bundled": 35713,
-    "minified": 18477,
-    "gzipped": 5587,
+    "bundled": 35699,
+    "minified": 18462,
+    "gzipped": 5581,
     "treeshaked": {
       "rollup": {
         "code": 352,
@@ -34,8 +34,8 @@
     }
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 138333,
-    "minified": 37480,
-    "gzipped": 12096
+    "bundled": 138319,
+    "minified": 37465,
+    "gzipped": 12091
   }
 }

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -105,6 +105,7 @@ export function useFormik<Values = object>({
   validateOnChange = true,
   validateOnBlur = true,
   isInitialValid = false,
+  enableReinitialize = false,
   ...rest
 }: FormikConfig<Values>) {
   const props = { validateOnChange, validateOnBlur, isInitialValid, ...rest };
@@ -153,6 +154,20 @@ export function useFormik<Values = object>({
       return;
     },
     [state.touched]
+  );
+
+  React.useEffect(
+    () => {
+      if (
+        enableReinitialize &&
+        isMounted.current &&
+        !isEqual(initialValues.current, props.initialValues)
+      ) {
+        initialValues.current = props.initialValues;
+        resetForm(props.initialValues);
+      }
+    },
+    [props.initialValues]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
As [this comment](https://github.com/jaredpalmer/formik/pull/1063#issuecomment-476546478) said,  the `enableReinitialize` feature of `useFormik` hook, is missing in `v2.0.1-alpha.0`, this PR might resolve this problem.