### PR TITLE
[v2] Add handling backend errors with async submit

### DIFF
--- a/docs/api/FormikSubmitError.md
+++ b/docs/api/FormikSubmitError.md
@@ -1,0 +1,59 @@
+---
+id: FormikSubmitError
+title: FormikSubmitError
+custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/FormikSubmitError.md
+---
+
+This is a small throwable wrapper around `Error` that may be used to return submit validation errors from 
+async onSubmit. The purpose being to handle and properly display validation errors that might happen on the backend side 
+after data is sent from the client. Validation errors then should be distinguished from any other AJAX I/O problems or 
+other server errors and wrapped in `FormikSubmitError` in the form of `{ field1: 'error', field2: 'error' }` then the
+submission errors will be added to each field just like after client side validation errors are.
+
+## Example
+
+```jsx
+import React from 'react';
+import { Formik } from 'formik';
+
+async function handleSubmit(values) {
+    ajax.send(values) // send data asynchronously
+        .catch(error => {
+          if (error.validationErrors) {
+            // wrap validation errors in FormikSubmitError (these should be of field1: 'error', field2: 'error'} format)
+            throw new FormikSubmitError(error.validationErrorr);
+          } else {
+            // handle any other type of error
+          }
+        })
+}
+
+const BasicExample = () => (
+  <div>
+    <h1>My Form</h1>
+    <Formik
+      initialValues={{ name: 'jared' }}
+      onSubmit={handleSubmit}
+      render={props => (
+        <form onSubmit={props.handleSubmit}>
+          <input
+            type="text"
+            onChange={props.handleChange}
+            onBlur={props.handleBlur}
+            value={props.values.name}
+            name="name"
+          />
+          {props.errors.name && <div id="feedback">{props.errors.name}</div>}
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    />
+  </div>
+);
+```
+
+# Reference
+
+## `new FormikSubmitError(errors: { [field: string]: string }): Error`
+
+Submission errors wrapper for backend validation errors.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "deepmerge": "^2.1.1",
+    "es6-error": "^4.1.1",
     "hoist-non-react-statics": "^3.2.1",
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -21,6 +21,7 @@ import {
   makeCancelable,
 } from './utils';
 import { FormikProvider } from './FormikContext';
+import { FormikSubmitError } from './FormikSubmitError';
 import warning from 'tiny-warning';
 
 // We already used FormikActions. So we'll go all Elm-y, and use Message.
@@ -598,8 +599,11 @@ export function useFormik<Values = object>({
               dispatch({ type: 'SUBMIT_SUCCESS' });
             }
           })
-          .catch(_errors => {
+          .catch(error => {
             if (isMounted.current) {
+              if (error instanceof FormikSubmitError) {
+                dispatch({ type: 'SET_ERRORS', payload: error.errors });
+              }
               dispatch({ type: 'SUBMIT_FAILURE' });
             }
           });

--- a/src/FormikSubmitError.ts
+++ b/src/FormikSubmitError.ts
@@ -1,0 +1,11 @@
+import ExtendableError from 'es6-error';
+import { FormikErrors } from './types';
+
+export class FormikSubmitError<Values = object> extends ExtendableError {
+  errors: FormikErrors<Values>;
+
+  constructor(errors: FormikErrors<Values>) {
+    super('Submission Error Occurred');
+    this.errors = errors;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,3 +8,4 @@ export * from './types';
 export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
+export * from './FormikSubmitError';

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, cleanup, fireEvent, wait } from 'react-testing-library';
 import * as Yup from 'yup';
 
-import { Formik, FormikProps, FormikConfig } from '../src';
+import { Formik, FormikProps, FormikConfig, FormikSubmitError } from '../src';
 import { noop } from './testHelpers';
 
 jest.spyOn(global.console, 'warn');
@@ -440,6 +440,18 @@ describe('<Formik>', () => {
 
       fireEvent.submit(getByTestId('form'));
       expect(getProps().isSubmitting).toBeTruthy();
+    });
+
+    describe('with async handler', () => {
+      it('should set error if promise is rejected with FormikSubmitError', async () => {
+        const submitError = new FormikSubmitError({ email: 'Exists' });
+        const onSubmit = jest.fn(() => Promise.reject(submitError));
+        const { getProps, getByTestId } = renderFormik({ onSubmit });
+
+        fireEvent.submit(getByTestId('form'));
+        await wait(() => expect(onSubmit).toBeCalled());
+        expect(getProps().errors.email).toEqual('Exists');
+      });
     });
 
     describe('with validate (SYNC)', () => {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,6 +2,6 @@
   "docs": {
     "Getting Started": ["overview", "tutorial", "resources"],
     "Guides": ["guides/validation", "guides/arrays", "guides/typescript", "guides/react-native", "guides/form-submission"],
-    "API Reference": ["api/formik", "api/withFormik", "api/field", "api/usefield", "api/fieldarray", "api/form", "api/errormessage", "api/connect", "api/fastfield"]
+    "API Reference": ["api/formik", "api/withFormik", "api/field", "api/usefield", "api/fieldarray", "api/form", "api/errormessage", "api/connect", "api/fastfield", "api/FormikSubmitError"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3585,6 +3585,11 @@ es5-shim@^4.5.10:
   version "4.5.10"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.10.tgz#b7e17ef4df2a145b821f1497b50c25cf94026205"
 
+es6-error@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
+
 es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"


### PR DESCRIPTION
Small improvement to add custom error wrapper to handle validation errors from rejected submit promise. A little more details is in the added docs file: [docs/api/FormikSubmitError.md](https://github.com/jaredpalmer/formik/compare/hooks...LKay:lkay/async-submit-errors?expand=1#diff-cead737648972a5caf76605302da6084)