### PR TITLE
Create <Field as> and deprecate <Field component> and <Field render>

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,14 +5,14 @@
     "gzipped": 11144
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 38882,
-    "minified": 18530,
-    "gzipped": 5416
+    "bundled": 38866,
+    "minified": 18524,
+    "gzipped": 5469
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 39586,
-    "minified": 19287,
-    "gzipped": 5706
+    "bundled": 39565,
+    "minified": 19275,
+    "gzipped": 5754
   },
   "dist/index.js": {
     "bundled": 33614,
@@ -20,9 +20,9 @@
     "gzipped": 5329
   },
   "dist/formik.esm.js": {
-    "bundled": 35713,
-    "minified": 18477,
-    "gzipped": 5587,
+    "bundled": 35692,
+    "minified": 18465,
+    "gzipped": 5635,
     "treeshaked": {
       "rollup": {
         "code": 352,
@@ -34,8 +34,8 @@
     }
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 138333,
-    "minified": 37480,
-    "gzipped": 12096
+    "bundled": 138312,
+    "minified": 37468,
+    "gzipped": 12126
   }
 }

--- a/docs/api/fastfield.md
+++ b/docs/api/fastfield.md
@@ -72,10 +72,8 @@ const Basic = () => (
             form.errors.firstName && <div>{form.errors.firstName}</div>}
 
           <label htmlFor="middleInitial">Middle Initial</label>
-          <FastField
-            name="middleInitial"
-            placeholder="F"
-            render={({ field, form }) => (
+          <FastField name="middleInitial" placeholder="F">
+            {({ field, form }) => (
               <div>
                 <input {...field} />
                 {/**
@@ -102,15 +100,13 @@ const Basic = () => (
                 </button>
               </div>
             )}
-          />
+          </FastField>
 
           {/** Updates for all changes to Formik state
            and all changes by all <Field>s and <FastField>s */}
           <label htmlFor="lastName">LastName</label>
-          <Field
-            name="lastName"
-            placeholder="Baby"
-            render={({ field, form }) => (
+          <Field name="lastName" placeholder="Baby">
+            {({ field, form }) => (
               <div>
                 <input {...field} />
                 {/** Works because this is inside
@@ -120,7 +116,7 @@ const Basic = () => (
                   : null}
               </div>
             )}
-          />
+          </Field>
 
           {/** Updates for all changes to Formik state and
            all changes by all <Field>s and <FastField>s */}

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -30,15 +30,15 @@ export interface FieldConfig {
   component?:
     | string
     | React.ComponentType<FieldProps<any>>
-    | React.ComponentType<void>;
+    | React.ComponentType;
 
   /**
-   * Component to render. Can either be a string like 'select' or a component.
+   * Component to render. Can either be a string e.g. 'select', 'input', or 'textarea', or a component.
    */
   as?:
-    | string
     | React.ComponentType<FieldProps<any>['field']>
-    | React.ComponentType<void>;
+    | keyof JSX.IntrinsicElements
+    | React.ComponentType;
 
   /**
    * Render prop (works like React router's <Route render={props =>} />)

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -25,10 +25,19 @@ export interface FieldProps<V = any> {
 export interface FieldConfig {
   /**
    * Field component to render. Can either be a string like 'select' or a component.
+   * @deprecated
    */
   component?:
     | string
     | React.ComponentType<FieldProps<any>>
+    | React.ComponentType<void>;
+
+  /**
+   * Component to render. Can either be a string like 'select' or a component.
+   */
+  as?:
+    | string
+    | React.ComponentType<FieldProps<any>['field']>
     | React.ComponentType<void>;
 
   /**
@@ -82,7 +91,7 @@ export function Field({
   name,
   render,
   children,
-  as: is = 'input',
+  as: is = 'input', // `as` is reserved in typescript lol
   component,
   ...props
 }: FieldAttributes<any>) {
@@ -154,6 +163,7 @@ export function Field({
       children
     );
   }
+
   return React.createElement(is, { ...field, ...props }, children);
 }
 export const FastField = Field;

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -82,7 +82,8 @@ export function Field({
   name,
   render,
   children,
-  component = 'input',
+  as: is = 'input',
+  component,
   ...props
 }: FieldAttributes<any>) {
   const {
@@ -93,12 +94,17 @@ export function Field({
 
   warning(
     render,
-    '<Field render> has been deprecated and will be removed in future versions of Formik. Please use a function as a child instead.'
+    '<Field render> has been deprecated and will be removed in future versions of Formik. Please use a function as a child instead <Formik>{() => }</Formik>.'
   );
 
   warning(
     component && children && isFunction(children),
     'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
+  );
+
+  warning(
+    !!component,
+    '<Field component> has been deprecated and will be removed in future versions of Formik. Use <Formik as> instead. Note that with the `as` prop, all props are passed directly through (so there is no need to destructure anything).'
   );
 
   warning(
@@ -128,20 +134,26 @@ export function Field({
     return children(bag);
   }
 
-  if (typeof component === 'string') {
-    const { innerRef, ...rest } = props;
-    return React.createElement(component, {
-      ref: innerRef,
-      ...field,
-      ...rest,
-      children,
-    });
+  if (component) {
+    if (typeof component === 'string') {
+      const { innerRef, ...rest } = props;
+      return React.createElement(
+        component,
+        { ref: innerRef, ...field, ...rest },
+        children
+      );
+    }
+    return React.createElement(component, { ...bag, ...props }, children);
   }
 
-  return React.createElement(component, {
-    ...bag,
-    ...props,
-    children,
-  });
+  if (typeof is === 'string') {
+    const { innerRef, ...rest } = props;
+    return React.createElement(
+      is,
+      { ref: innerRef, ...field, ...rest },
+      children
+    );
+  }
+  return React.createElement(is, { ...field, ...props }, children);
 }
 export const FastField = Field;

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -102,22 +102,32 @@ export function Field({
   } = useFormikContext();
 
   warning(
-    render,
-    '<Field render> has been deprecated and will be removed in future versions of Formik. Please use a function as a child instead <Formik>{() => }</Formik>.'
-  );
-
-  warning(
-    component && children && isFunction(children),
-    'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
+    !!render,
+    `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, 
+        replace 
+          <Field name="${name}" render={({field, form}) => ...} />
+        with
+          <Field name="${name}">{({field, form}) => ...}</Field>
+    `
   );
 
   warning(
     !!component,
-    '<Field component> has been deprecated and will be removed in future versions of Formik. Use <Formik as> instead. Note that with the `as` prop, all props are passed directly through (so there is no need to destructure anything).'
+    '<Field component> has been deprecated and will be removed in future versions of Formik. Use <Formik as> instead. Note that with the `as` prop, all props are passed directly through and not grouped in `field` object key.'
   );
 
   warning(
-    render && children && !isEmptyChildren(children),
+    !!is && !!children && isFunction(children),
+    'You should not use <Field as> and <Field children> as a function in the same <Field> component; <Field as> will be ignored.'
+  );
+
+  warning(
+    !!component && children && isFunction(children),
+    'You should not use <Field as> and <Field children> as a function in the same <Field> component; <Field as> will be ignored.'
+  );
+
+  warning(
+    !!render && !!children && !isEmptyChildren(children),
     'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
   );
 


### PR DESCRIPTION
- Deprecate `<Field component>` and `<Field render>`. These haven't been removed. However, they will yield a warning in the console. 
- Add `<Field as>` prop which just passes related handlers and props straight through. This should make Styled Components folks happy.

Related to #1371
Closes #1407 
Closes #1408 