### PR TITLE
[v2] Update and document field meta prop

### DIFF
--- a/docs/api/fastfield.md
+++ b/docs/api/fastfield.md
@@ -73,14 +73,14 @@ const Basic = () => (
 
           <label htmlFor="middleInitial">Middle Initial</label>
           <FastField name="middleInitial" placeholder="F">
-            {({ field, form }) => (
+            {({ field, form, meta }) => (
               <div>
                 <input {...field} />
                 {/**
                  * This updates normally because it's from the same slice of Formik state,
                  * i.e. path to the object matches the name of this <FastField />
                  */}
-                {form.touched.middleInitial ? form.errors.middleInitial : null}
+                {meta.touched ? meta.error : null}
 
                 {/** This won't ever update since it's coming from
                  from another <Field>/<FastField>'s (i.e. firstName's) slice   */}
@@ -106,10 +106,10 @@ const Basic = () => (
            and all changes by all <Field>s and <FastField>s */}
           <label htmlFor="lastName">LastName</label>
           <Field name="lastName" placeholder="Baby">
-            {({ field, form }) => (
+            {( }) => (
               <div>
                 <input {...field} />
-                {/** Works because this is inside
+                {/**  Works because this is inside
                  of a <Field/>, which gets all updates */}
                 {form.touched.firstName && form.errors.firstName
                   ? form.errors.firstName

--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -21,8 +21,9 @@ There are 2 ways to render things with `<Field>`.
 
 `children` can either be an array of elements (e.g. `<option>` in the case of `<Field as="select">`) or a callback function (a.k.a render prop). The render props are an object containing:
 
-* `field`: An object containing `onChange`, `onBlur`, `name`, and `value` of the field
-* `form`: The Formik bag.
+* `field`: An object containing `onChange`, `onBlur`, `name`, and `value` of the field (see [`FieldInputProps`](./useField#fieldinputprops))
+* `form`: The Formik bag
+* `meta`: An object containing metadata (i.e. `value`, `touched`, `error`, and `initialValue`) about the field (see [`FieldMetaProps`](./useField#fieldmetaprops))
 
 > In Formik 0.9 to 1.x, `component` and `render` props could also be used for rendering. These have been deprecated since 2.x. While the code still lives within `<Field>`, they will show a warning in the console.
 
@@ -55,13 +56,12 @@ const Example = () => (
             {({
               field, // { name, value, onChange, onBlur }
               form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+              meta,
             }) => (
               <div>
                 <input type="text" placeholder="Email" {...field} />
-                {touched[field.name] &&
-                  errors[field.name] && (
-                    <div className="error">{errors[field.name]}</div>
-                  )}
+                {meta.touched &&
+                  meta.error && <div className="error">{meta.error}</div>}
               </div>
             )}
           </Field>
@@ -92,6 +92,7 @@ Either a React component or the name of an HTML element to render. That is, one 
 * `input`
 * `select`
 * `textarea`
+* A valid HTML element name
 * A custom React component
 
 Custom React components will be passed `onChange`, `onBlur`, `name`, and `value` plus any other props passed to directly to `<Field>`.
@@ -133,11 +134,11 @@ Either JSX elements or callback function. Same as `render`.
 
 // Or a callback function
 <Field name="firstName">
-{({ field, form }) => (
+{({ field, form, meta }) => (
   <div>
     <input type="text" {...field} placeholder="First Name"/>
-    {form.touched[field.name] &&
-      form.errors[field.name] && <div className="error">{form.errors[field.name]}</div>}
+    {meta.touched &&
+      meta.error && <div className="error">{meta.error}</div>}
   </div>
 )}
 </Field>

--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -20,7 +20,7 @@ const MyTextField = ({ label, ...props }) => {
         {label}
         <input {...field} {...props} />
       </label>
-      {meta.touch && meta.error ? (
+      {meta.touched && meta.error ? (
         <div className="error">{meta.error}</div>
       ) : null}
     </>
@@ -55,25 +55,26 @@ const Example = () => (
 
 # Reference
 
-## `useField(name: string): [FieldProps, FieldMetaProps]`
+## `useField(name: string): [FieldInputProps, FieldMetaProps]`
 
 A custom React Hook that returns a tuple (2 element array) containing `FieldProps` and `FieldMetaProps`.
 
-### `FieldProps`
+### `FieldInputProps`
 
 An object that contains:
 
-* `onChange`
-* `onBlur`
-* `value`
-* `name`
+* `name: string` - The name of the field
+* `onBlur: () => void;` - A blur event handler
+* `onChange: (e: React.ChangeEvent<any>) => void` - A change event handler
+* `value: any` - The field's value (plucked out of `values`)
 
 for a given field in Formik state. This is to avoid needing to manually wire up inputs.
 
-### `FieldMeta`
+### `FieldMetaProps`
 
 An object that contains relevant computed metadata about a field. More specifically,
 
-* `touch: boolean` - Whether the field has been visited (plucked out of `touched`)
 * `error?: string` - The field's error message (plucked out of `errors`)
-* `initialValue: any` - The field's initial value if the field is given a value in `initialValues` (plucked out of `initialValues`)
+* `initialValue?: any` - The field's initial value if the field is given a value in `initialValues` (plucked out of `initialValues`)
+* `touched: boolean` - Whether the field has been visited (plucked out of `touched`)
+* `value: any` - The field's value (plucked out of `values`)

--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -55,7 +55,7 @@ const Example = () => (
 
 # Reference
 
-## `useField(name: string): [FieldInputProps, FieldMetaProps]`
+## `useField<Value = any>(name: string): [FieldInputProps<Value>, FieldMetaProps<Value>]`
 
 A custom React Hook that returns a tuple (2 element array) containing `FieldProps` and `FieldMetaProps`.
 

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -45,12 +45,10 @@ export const MyApp: React.SFC<{}> = () => {
           <Form>
             <Field
               name="firstName"
-              render={({ field, form }: FieldProps<MyFormValues>) => (
+              render={({ field, form, meta }: FieldProps<MyFormValues>) => (
                 <div>
                   <input type="text" {...field} placeholder="First Name" />
-                  {form.touched.firstName &&
-                    form.errors.firstName &&
-                    form.errors.firstName}
+                  {meta.touched && meta.error && meta.error}
                 </div>
               )}
             />

--- a/examples/CustomInputs.js
+++ b/examples/CustomInputs.js
@@ -46,11 +46,7 @@ const SignUp = () => (
             label="Email"
             placeholder="jane@acme.com"
           />
-          <Fieldset
-            name="color"
-            label="Favorite Color"
-            component="select"
-          >
+          <Fieldset name="color" label="Favorite Color" as="select">
             <option value="">Select a Color</option>
             <option value="red">Red</option>
             <option value="green">Green</option>

--- a/examples/FastField.js
+++ b/examples/FastField.js
@@ -5,10 +5,9 @@ import { Debug } from './Debug';
 class Input extends React.Component {
   renders = 0;
   render() {
-    const { field, form, ...rest } = this.props;
     return (
       <div>
-        <input {...field} {...rest} />
+        <input {...this.props} />
         <p># of renders: {this.renders++}</p>
       </div>
     );
@@ -37,7 +36,7 @@ const Basic = () => (
           <FastField
             name="firstName"
             placeholder="Jane"
-            component={Input}
+            as={Input}
             disabled={isSubmitting}
           />
 
@@ -45,7 +44,7 @@ const Basic = () => (
           <FastField
             name="lastName"
             placeholder="Doe"
-            component={Input}
+            as={Input}
             disabled={isSubmitting}
           />
 
@@ -54,7 +53,7 @@ const Basic = () => (
             name="email"
             placeholder="jane@acme.com"
             type="email"
-            component={Input}
+            as={Input}
             disabled={isSubmitting}
           />
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -8,6 +8,8 @@ import {
   FormikTouched,
   FormikValues,
   FormikProps,
+  FieldMetaProps,
+  FieldInputProps,
 } from './types';
 import {
   isFunction,
@@ -610,23 +612,10 @@ export function useFormik<Values = object>({
     });
   }
 
-  function getFieldProps(
+  function getFieldProps<Val = any>(
     name: string,
     type: string
-  ): [
-    {
-      value: any;
-      name: string;
-      onChange: ((e: React.ChangeEvent<any>) => void);
-      onBlur: ((e: any) => void);
-    },
-    {
-      value: any;
-      error?: string | undefined;
-      touch: boolean;
-      initialValue?: any;
-    }
-  ] {
+  ): [FieldInputProps<Val>, FieldMetaProps<Val>] {
     const field = {
       name,
       value:
@@ -637,20 +626,15 @@ export function useFormik<Values = object>({
       onBlur: handleBlur,
     };
 
-    return [field, getFieldMeta(name)];
+    return [field, getFieldMeta<Val>(name)];
   }
 
-  function getFieldMeta(name: string) {
+  function getFieldMeta<Val = any>(name: string): FieldMetaProps<Val> {
     return {
       value: getIn(state.values, name),
       error: getIn(state.errors, name),
-      touch: getIn(state.touched, name),
+      touched: !!getIn(state.touched, name),
       initialValue: getIn(initialValues.current, name),
-    } as {
-      value: any;
-      error?: string;
-      touch: boolean;
-      initialValue?: any;
     };
   }
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -117,23 +117,10 @@ export interface FormikHandlers {
     ? void
     : ((e: string | React.ChangeEvent<any>) => void);
 
-  getFieldProps(
+  getFieldProps<Value = any>(
     name: string,
     type?: string
-  ): [
-    {
-      value: any;
-      name: string;
-      onChange: ((e: React.ChangeEvent<any>) => void);
-      onBlur: ((e: any) => void);
-    },
-    {
-      value: any;
-      error?: string | undefined;
-      touch: boolean;
-      initialValue?: any;
-    }
-  ];
+  ): [FieldInputProps<Value>, FieldMetaProps<Value>];
 }
 
 /**
@@ -247,6 +234,30 @@ export interface SharedRenderProps<T> {
 }
 
 export type GenericFieldHTMLAttributes =
-  | React.InputHTMLAttributes<HTMLInputElement>
-  | React.SelectHTMLAttributes<HTMLSelectElement>
-  | React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+  | JSX.IntrinsicElements['input']
+  | JSX.IntrinsicElements['select']
+  | JSX.IntrinsicElements['textarea'];
+
+/** Field metadata */
+export interface FieldMetaProps<Value> {
+  /** Value of the field */
+  value: Value;
+  /** Error message of the field */
+  error?: string;
+  /** Has the field been visited? */
+  touched: boolean;
+  /** Initial value of the field */
+  initialValue?: Value;
+}
+
+/** Field input value, name, and event handlers */
+export interface FieldInputProps<Value> {
+  /** Value of the field */
+  value: Value;
+  /** Name of the field */
+  name: string;
+  /** Change event handler */
+  onChange: FormikHandlers['handleChange'];
+  /** Blur event handler */
+  onBlur: FormikHandlers['handleBlur'];
+}

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -101,7 +101,7 @@ describe('Field / FastField', () => {
     });
   });
 
-  describe('receives { field, form } props and renders element', () => {
+  describe('receives { field, form, meta } props and renders element', () => {
     it('<Field />', () => {
       let injected: FieldProps[] = [];
       let asInjectedProps: FieldProps['field'] = {} as any;
@@ -122,12 +122,22 @@ describe('Field / FastField', () => {
       );
 
       const { handleBlur, handleChange } = getFormProps();
-      injected.forEach(props => {
+      injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
+        if (idx === 0) {
+          expect(props.meta.value).toBe('jared');
+          expect(props.meta.error).toBeUndefined();
+          expect(props.meta.touched).toBe(false);
+          expect(props.meta.initialValue).toEqual('jared');
+        } else {
+          // Ensure that we do not pass through `meta` to
+          // <Field component> or <Field render>
+          expect(props.meta).toBeUndefined();
+        }
       });
 
       expect(asInjectedProps.name).toBe('name');
@@ -157,12 +167,22 @@ describe('Field / FastField', () => {
       );
 
       const { handleBlur, handleChange } = getFormProps();
-      injected.forEach(props => {
+      injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
+        if (idx === 0) {
+          expect(props.meta.value).toBe('jared');
+          expect(props.meta.error).toBeUndefined();
+          expect(props.meta.touched).toBe(false);
+          expect(props.meta.initialValue).toEqual('jared');
+        } else {
+          // Ensure that we do not pass through `meta` to
+          // <Field component> or <Field render>
+          expect(props.meta).toBeUndefined();
+        }
       });
 
       expect(asInjectedProps.name).toBe('name');


### PR DESCRIPTION
- Add docs for field `meta`
- Fix types for `useField`
- Add tests for field `meta`
- Do not pass meta to `<Field render>` or `<Field component>` since they have been deprecated
- Rename `FieldMetaProps.touch` to `FieldMetaProps.touched` (breaking for gamma users)

Closes #343 
v2 version of #579 