### PR TITLE
Add initialXXXX and fix isValid

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -107,19 +107,17 @@ Submitting state of the form. Returns `true` if submission is in progress and `f
 
 #### `isValid: boolean`
 
-Returns `true` if the there are no `errors`, or the result of
-`isInitialValid` the form if is in "pristine" condition (i.e. not `dirty`).
+Returns `true` if there are no `errors` (i.e. the `errors` object is empty) and `false` otherwise.
+
+> Note: `isInitialValid` was deprecated in 2.x. However, for backwards compatibility, if the `isInitialValid` prop is specified, `isValid` will return `true` if the there are no `errors`, or the result of `isInitialValid` of the form if it is in "pristine" condition (i.e. not `dirty`).
 
 #### `isValidating: boolean`
 
 Returns `true` if Formik is running validation during submission, or by calling [`validateForm`] directly `false` otherwise. To learn more about what happens with `isValidating` during the submission process, see [Form Submission](guides/form-submission.md).
 
-#### `resetForm: (nextValues?: Values) => void`
+#### `resetForm: (nextInitialState?: FormikState<Values>) => void`
 
-Imperatively reset the form. This will clear `errors` and `touched`, set
-`isSubmitting` to `false`, `isValidating` to `false`, and rerun `mapPropsToValues` with the current
-`WrappedComponent`'s `props` or what's passed as an argument. The latter is
-useful for calling `resetForm` within `componentWillReceiveProps`.
+Imperatively reset the form. If `nextInitialState` is specified, Formik will set this state as the new "initial state" and use the related values of `nextInitialState` to update the form's `initialValues` as well as `initialTouched`, `initialStatus`, `initialErrors`. This is useful for altering the initial state (i.e. "base") of the form after changes have been made. If `nextInitialState` is not defined, then Formik will reset state to the original initial state. The latter is useful for calling `resetForm` within `componentDidUpdate` or `useEffect`.
 
 #### `setErrors: (fields: { [field: string]: string }) => void`
 
@@ -282,9 +280,19 @@ Default is `false`. Control whether Formik should reset the form if
 
 ### `isInitialValid?: boolean`
 
-Default is `false`. Control the initial value of `isValid` prop prior to
+**Deprecated in 2.x, use `initialErrors` instead**
+
+Control the initial value of `isValid` prop prior to
 mount. You can also pass a function. Useful for situations when you want to
 enable/disable a submit and reset buttons on initial mount.
+
+### `initialErrors?: FormikErrors<Values>`
+
+Initial field errors of the form, Formik will make these values available to
+render methods component as `errors`.
+
+Note: `initialErrors` is not available to the higher-order component `withFormik`, use
+`mapPropsToErrors` instead.
 
 ### `initialStatus?: any`
 
@@ -292,6 +300,14 @@ An arbitrary value for the initial `status` of the form. If the form is reset, t
 
 Note: `initialStatus` is not available to the higher-order component `withFormik`, use
 `mapPropsToStatus` instead.
+
+### `initialTouched?: FormikTouched<Values>`
+
+Initial visitied fields of the form, Formik will make these values available to
+render methods component as `touched`.
+
+Note: `initialTouched` is not available to the higher-order component `withFormik`, use
+`mapPropsToTouched` instead.
 
 ### `initialValues: Values`
 

--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -75,6 +75,8 @@ for a given field in Formik state. This is to avoid needing to manually wire up 
 An object that contains relevant computed metadata about a field. More specifically,
 
 * `error?: string` - The field's error message (plucked out of `errors`)
+* `initialError?: string` - The field's initial error if the field is present in `initialErrors` (plucked out of `initialErrors`)
+* `initialTouched: boolean` - The field's initial value if the field is present in `initialTouched` (plucked out of `initialTouched`)
 * `initialValue?: any` - The field's initial value if the field is given a value in `initialValues` (plucked out of `initialValues`)
 * `touched: boolean` - Whether the field has been visited (plucked out of `touched`)
 * `value: any` - The field's value (plucked out of `values`)

--- a/docs/api/withFormik.md
+++ b/docs/api/withFormik.md
@@ -113,9 +113,29 @@ included in the `FormikBag`.
 
 ### `isInitialValid?: boolean | (props: Props) => boolean`
 
-Default is `false`. Control the initial value of `isValid` prop prior to
+**Deprecated in 2.x, use `mapPropsToErrors` instead**
+
+Control the initial value of `isValid` prop prior to
 mount. You can also pass a function. Useful for situations when you want to
 enable/disable a submit and reset buttons on initial mount.
+
+### `mapPropsToErrors?: (props: Props) => FormikErrors<Values>`
+
+If this option is specified, then Formik will transfer its results into
+updatable form state and make these values available to the new component as
+`props.errors` initially. Useful for instatiating arbitrary error state into your form. As a reminder, `props.errors` will be overwritten as soon as validation runs. Formik will also reset `props.errors` to this initial value (and this function will be re-run) if the form is reset.
+
+### `mapPropsToStatus?: (props: Props) => any`
+
+If this option is specified, then Formik will transfer its results into
+updatable form state and make these values available to the new component as
+`props.status`. Useful for storing or instatiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
+
+### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+
+If this option is specified, then Formik will transfer its results into
+updatable form state and make these values available to the new component as
+`props.errors`. Useful for instatiating arbitrary touched state (i.e. marking fields as visited) into your form. As a reminder, Formik will use this initial value (and this function will be re-run) if the form is reset.
 
 ### `mapPropsToValues?: (props: Props) => Values`
 
@@ -128,12 +148,6 @@ will map all props that are not functions to the inner component's
 
 Even if your form is not receiving any props from its parent, use
 `mapPropsToValues` to initialize your forms empty state.
-
-### `mapPropsToStatus?: (props: Props) => any`
-
-If this option is specified, then Formik will transfer its results into
-updatable form state and make these values available to the new component as
-`props.status`. Useful for storing or instatiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
 ### `validate?: (values: Values, props: Props) => FormikErrors<Values> | Promise<any>`
 

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -106,23 +106,33 @@ function formikReducer<Values>(
 export function useFormik<Values = object>({
   validateOnChange = true,
   validateOnBlur = true,
-  isInitialValid = false,
+  isInitialValid,
   ...rest
 }: FormikConfig<Values>) {
-  const props = { validateOnChange, validateOnBlur, isInitialValid, ...rest };
+  const props = { validateOnChange, validateOnBlur, ...rest };
   const initialValues = React.useRef(props.initialValues);
+  const initialErrors = React.useRef(props.initialErrors || {});
+  const initialTouched = React.useRef(props.initialTouched || {});
+  const initialStatus = React.useRef(props.initialStatus);
   const isMounted = React.useRef<boolean>(false);
   const fields = React.useRef<{
     [field: string]: {
       validate: (value: any) => string | Promise<string> | undefined;
     };
   }>({});
+
+  warning(
+    typeof isInitialValid === 'undefined',
+    'isInitialValid has been deprecated and will be removed in future versions of Formik. Please use initialErrors instead.'
+  );
+
   const [state, dispatch] = React.useReducer<
     React.Reducer<FormikState<Values>, FormikMessage<Values>>
   >(formikReducer, {
     values: props.initialValues,
-    errors: {},
-    touched: {},
+    errors: props.initialErrors || {},
+    touched: props.initialTouched || {},
+    status: props.initialStatus,
     isSubmitting: false,
     isValidating: false,
     submitCount: 0,
@@ -279,22 +289,25 @@ export function useFormik<Values = object>({
     }
   }
 
-  function handleReset() {
-    if (props.onReset) {
-      const maybePromisedOnReset = (props.onReset as any)(
-        state.values,
-        imperativeMethods
-      );
+  const handleReset = React.useCallback(
+    () => {
+      if (props.onReset) {
+        const maybePromisedOnReset = (props.onReset as any)(
+          state.values,
+          imperativeMethods
+        );
 
-      if (isPromise(maybePromisedOnReset)) {
-        (maybePromisedOnReset as Promise<any>).then(resetForm);
+        if (isPromise(maybePromisedOnReset)) {
+          (maybePromisedOnReset as Promise<any>).then(resetForm);
+        } else {
+          resetForm();
+        }
       } else {
         resetForm();
       }
-    } else {
-      resetForm();
-    }
-  }
+    },
+    [props.onReset]
+  );
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement> | undefined) {
     if (e && e.preventDefault) {
@@ -330,23 +343,47 @@ export function useFormik<Values = object>({
     return props.onSubmit(state.values, imperativeMethods);
   }
 
-  function resetForm(nextValues?: Values) {
-    const values = nextValues
-      ? nextValues
-      : initialValues.current !== null
-        ? initialValues.current
-        : props.initialValues;
+  function resetForm(nextState?: FormikState<Values>) {
+    const values =
+      nextState && nextState.values
+        ? nextState.values
+        : !!initialValues.current ? initialValues.current : props.initialValues;
+    const errors =
+      nextState && nextState.errors
+        ? nextState.values
+        : !!initialErrors.current
+          ? initialErrors.current
+          : props.initialErrors || {};
+    const touched =
+      nextState && nextState.touched
+        ? nextState.values
+        : !!initialTouched.current
+          ? initialTouched.current
+          : props.initialTouched || {};
+    const status =
+      nextState && nextState.status
+        ? nextState.status
+        : initialStatus.current ? initialStatus.current : props.initialStatus;
     initialValues.current = values;
+    initialErrors.current = errors;
+    initialTouched.current = touched;
+    initialStatus.current = status;
+
     dispatch({
       type: 'RESET_FORM',
       payload: {
-        isSubmitting: false,
-        errors: {},
-        touched: {},
-        status: undefined,
+        isSubmitting: !!nextState && !!nextState.isSubmitting,
+        errors,
+        touched,
+        status,
         values,
-        isValidating: false,
-        submitCount: 0,
+        isValidating: !!nextState && !!nextState.isValidating,
+        submitCount:
+          !!nextState &&
+          !!nextState.submitCount &&
+          typeof nextState.submitCount === 'number'
+            ? nextState.submitCount
+            : 0,
       },
     });
   }
@@ -629,12 +666,14 @@ export function useFormik<Values = object>({
     return [field, getFieldMeta<Val>(name)];
   }
 
-  function getFieldMeta<Val = any>(name: string): FieldMetaProps<Val> {
+  function getFieldMeta<Val>(name: string): FieldMetaProps<Val> {
     return {
       value: getIn(state.values, name),
       error: getIn(state.errors, name),
       touched: !!getIn(state.touched, name),
       initialValue: getIn(initialValues.current, name),
+      initialTouched: !!getIn(initialTouched.current, name),
+      initialError: getIn(initialErrors.current, name),
     };
   }
 
@@ -645,17 +684,24 @@ export function useFormik<Values = object>({
 
   const isValid = React.useMemo(
     () =>
-      dirty
-        ? state.errors && Object.keys(state.errors).length === 0
-        : isInitialValid !== false && isFunction(isInitialValid)
-          ? (isInitialValid as (props: FormikConfig<Values>) => boolean)(props)
-          : (isInitialValid as boolean),
-    [state.errors, dirty, isInitialValid]
+      typeof isInitialValid !== 'undefined'
+        ? dirty
+          ? state.errors && Object.keys(state.errors).length === 0
+          : isInitialValid !== false && isFunction(isInitialValid)
+            ? (isInitialValid as (props: FormikConfig<Values>) => boolean)(
+                props
+              )
+            : (isInitialValid as boolean)
+        : state.errors && Object.keys(state.errors).length === 0,
+    [state.errors, isInitialValid, dirty]
   );
 
   const ctx = {
     ...state,
-    initialValues: initialValues.current || props.initialValues,
+    initialValues: initialValues.current,
+    initialErrors: initialErrors.current,
+    initialTouched: initialTouched.current,
+    initialStatus: initialStatus.current,
     handleBlur,
     handleChange,
     handleReset,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -51,10 +51,16 @@ export interface FormikState<Values> {
 export interface FormikComputedProps<Values> {
   /** True if any input has been touched. False otherwise. */
   readonly dirty: boolean;
-  /** Result of isInitiallyValid on mount, then whether true values pass validation. */
+  /** True if state.errors is empty */
   readonly isValid: boolean;
-  /** initialValues */
+  /** The initial values of the form */
   readonly initialValues: Values;
+  /** The initial errors of the form */
+  readonly initialErrors: FormikErrors<Values>;
+  /** The initial visited fields of the form */
+  readonly initialTouched: FormikTouched<Values>;
+  /** The initial status of the form */
+  readonly initialStatus?: any;
 }
 
 /**
@@ -82,7 +88,7 @@ export interface FormikHelpers<Values> {
   /** Validate field value */
   validateField(field: string): void;
   /** Reset form */
-  resetForm(nextValues?: Values): void;
+  resetForm(nextState?: FormikState<Values>): void;
   /** Submit the form imperatively */
   submitForm(): void;
   /** Set Formik state, careful! */
@@ -157,6 +163,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   children?:
     | ((props: FormikProps<Values>) => React.ReactNode)
     | React.ReactNode;
+
   /**
    * Initial values of the form
    */
@@ -166,6 +173,12 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * Initial status
    */
   initialStatus?: any;
+
+  /** Initial object map of field names to specific error for that field */
+  initialErrors?: FormikErrors<Values>;
+
+  /** Initial object map of field names to whether the field has been touched */
+  initialTouched?: FormikTouched<Values>;
 
   /**
    * Reset handler
@@ -248,6 +261,10 @@ export interface FieldMetaProps<Value> {
   touched: boolean;
   /** Initial value of the field */
   initialValue?: Value;
+  /** Initial touched state of the field */
+  initialTouched: boolean;
+  /** Initial error message of the field */
+  initialError?: string;
 }
 
 /** Field input value, name, and event handlers */

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -6,6 +6,8 @@ import {
   FormikProps,
   FormikSharedConfig,
   FormikValues,
+  FormikTouched,
+  FormikErrors,
 } from './types';
 import { isFunction } from './utils';
 
@@ -49,6 +51,16 @@ export interface WithFormikConfig<
    * Map props to the form values
    */
   mapPropsToStatus?: (props: Props) => any;
+
+  /**
+   * Map props to the form touched state
+   */
+  mapPropsToTouched?: (props: Props) => FormikTouched<Values>;
+
+  /**
+   * Map props to the form touched state
+   */
+  mapPropsToErrors?: (props: Props) => FormikErrors<Values>;
 
   /**
    * @deprecated in 0.9.0 (but needed to break TS types)
@@ -155,6 +167,12 @@ export function withFormik<
             initialValues={mapPropsToValues(this.props)}
             initialStatus={
               config.mapPropsToStatus && config.mapPropsToStatus(this.props)
+            }
+            initialErrors={
+              config.mapPropsToErrors && config.mapPropsToErrors(this.props)
+            }
+            initialTouched={
+              config.mapPropsToTouched && config.mapPropsToTouched(this.props)
             }
             onSubmit={this.handleSubmit as any}
             render={this.renderFormComponent}

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -97,7 +97,7 @@ describe('<Formik>', () => {
     expect(props.values).toEqual(InitialValues);
     expect(props.errors).toEqual({});
     expect(props.dirty).toBe(false);
-    expect(props.isValid).toBe(false);
+    expect(props.isValid).toBe(true);
     expect(props.submitCount).toBe(0);
   });
 

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -75,6 +75,8 @@ describe('withFormik()', () => {
       initialValues: {
         name: 'jared',
       },
+      initialErrors: {},
+      initialTouched: {},
       values: {
         name: InitialValues.name,
       },

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -85,7 +85,7 @@ describe('withFormik()', () => {
       handleReset: expect.any(Function),
       handleSubmit: expect.any(Function),
       isSubmitting: false,
-      isValid: false,
+      isValid: true,
       isValidating: false,
       getFieldProps: expect.any(Function),
       registerField: expect.any(Function),


### PR DESCRIPTION
- Deprecate `isInitialValid` with a warning. If it is specified, old 1.x `isValid` behavior is utilized.
- `isValid` is now `true` by default.
- Add `initialErrors` and `initialTouched` props to `<Formik>`
- Add `mapPropsToErrors` and `mapPropsToTouched` to `withFormik()`
- **Breaking**: `resetForm(nextValues: Values)` to `resetForm(nextInitialState: FormikState<Values>`

I'm not convinced we actually need to change `resetForm` (and thus keep all of these as refs that can be mutated on reset)

FWIW I can't think of when you would want `initialTouched`. Open to ideas and would be happy to remove.

Closes #1133 #1116 #1148 #288 #954 #698 