### PR TITLE
Let TS infer return type of getFormikContext()

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -10,7 +10,6 @@ import {
   FormikState,
   FormikTouched,
   FormikValues,
-  FormikContext,
   FormikProps,
 } from './types';
 import {
@@ -626,7 +625,7 @@ export class Formik<Values = FormikValues> extends React.Component<
     };
   };
 
-  getFormikContext = (): FormikContext<any> => {
+  getFormikContext = () => {
     return {
       ...this.getFormikBag(),
       validationSchema: this.props.validationSchema,


### PR DESCRIPTION
- Remove usage of `FormikContext<any>` type and just let TS infer the return type of `getFormikContext()`.


This will allow the Strongly Typed Fields PR (#1336  ) to exist outside of the core repo (I think).



