### PR TITLE
Only show deprecation warnings when Field mounts

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 130946,
-    "minified": 35155,
-    "gzipped": 11144
+    "bundled": 132052,
+    "minified": 35565,
+    "gzipped": 11247
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 38873,
-    "minified": 18521,
-    "gzipped": 5413
+    "bundled": 40886,
+    "minified": 19704,
+    "gzipped": 5819
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 39572,
-    "minified": 19272,
-    "gzipped": 5700
+    "bundled": 41440,
+    "minified": 20329,
+    "gzipped": 6044
   },
   "dist/index.js": {
     "bundled": 33614,
@@ -20,9 +20,9 @@
     "gzipped": 5329
   },
   "dist/formik.esm.js": {
-    "bundled": 35699,
-    "minified": 18462,
-    "gzipped": 5581,
+    "bundled": 37409,
+    "minified": 19625,
+    "gzipped": 5929,
     "treeshaked": {
       "rollup": {
         "code": 352,
@@ -34,8 +34,8 @@
     }
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 138319,
-    "minified": 37465,
-    "gzipped": 12091
+    "bundled": 140019,
+    "minified": 38427,
+    "gzipped": 12410
   }
 }

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -7,7 +7,7 @@ import {
 } from './types';
 import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren } from './utils';
-import warning from 'tiny-warning';
+import invariant from 'tiny-warning';
 
 export interface FieldProps<V = any> {
   field: FieldInputProps<V>;
@@ -69,7 +69,7 @@ export type FieldAttributes<T> = GenericFieldHTMLAttributes & FieldConfig & T;
 export function useField<Val = any>(name: string, type?: string) {
   const formik = useFormikContext();
 
-  warning(
+  invariant(
     formik,
     'useField() / <Field /> must be used underneath a <Formik> component or withFormik() higher order component'
   );
@@ -92,35 +92,32 @@ export function Field({
     ...formik
   } = useFormikContext();
 
-  warning(
-    !!render,
-    `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, 
-        replace 
-          <Field name="${name}" render={({field, form}) => ...} />
-        with
-          <Field name="${name}">{({field, form, meta}) => ...}</Field>
-    `
-  );
+  React.useEffect(() => {
+    invariant(
+      !render,
+      `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Field name="${name}" render={({field, form}) => ...} /> with <Field name="${name}">{({field, form, meta}) => ...}</Field>`
+    );
 
-  warning(
-    !!component,
-    '<Field component> has been deprecated and will be removed in future versions of Formik. Use <Formik as> instead. Note that with the `as` prop, all props are passed directly through and not grouped in `field` object key.'
-  );
+    invariant(
+      !component,
+      '<Field component> has been deprecated and will be removed in future versions of Formik. Use <Formik as> instead. Note that with the `as` prop, all props are passed directly through and not grouped in `field` object key.'
+    );
 
-  warning(
-    !!is && !!children && isFunction(children),
-    'You should not use <Field as> and <Field children> as a function in the same <Field> component; <Field as> will be ignored.'
-  );
+    invariant(
+      !(is && children && isFunction(children)),
+      'You should not use <Field as> and <Field children> as a function in the same <Field> component; <Field as> will be ignored.'
+    );
 
-  warning(
-    !!component && children && isFunction(children),
-    'You should not use <Field as> and <Field children> as a function in the same <Field> component; <Field as> will be ignored.'
-  );
+    invariant(
+      !(component && children && isFunction(children)),
+      'You should not use <Field component> and <Field children> as a function in the same <Field> component; <Field component> will be ignored.'
+    );
 
-  warning(
-    !!render && !!children && !isEmptyChildren(children),
-    'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
-  );
+    invariant(
+      !(render && children && !isEmptyChildren(children)),
+      'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
+    );
+  }, []);
 
   React.useEffect(
     () => {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -23,7 +23,7 @@ import {
   makeCancelable,
 } from './utils';
 import { FormikProvider } from './FormikContext';
-import warning from 'tiny-warning';
+import invariant from 'tiny-warning';
 
 // We already used FormikActions. So we'll go all Elm-y, and use Message.
 type FormikMessage<Values> =
@@ -330,7 +330,7 @@ export function useFormik<Values = object>({
         activeElement !== null &&
         activeElement instanceof HTMLButtonElement
       ) {
-        warning(
+        invariant(
           activeElement.attributes &&
             activeElement.attributes.getNamedItem('type'),
           'You submitted a Formik form using a button with an unspecified `type` attribute.  Most browsers default button elements to `type="submit"`. If this is not a submit button, please add `type="button"`.'
@@ -734,7 +734,7 @@ function warnAboutMissingIdentifier({
   handlerName: string;
 }) {
   console.warn(
-    `Warning: Formik called \`${handlerName}\`, but you forgot to pass an \`id\` or \`name\` attribute to your input:
+    `invariant: Formik called \`${handlerName}\`, but you forgot to pass an \`id\` or \`name\` attribute to your input:
     ${htmlContent}
     Formik cannot determine which value to update. For more info see https://github.com/jaredpalmer/formik#${documentationAnchorLink}
   `

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -388,22 +388,43 @@ describe('Field / FastField', () => {
     cases('warns if component is a string', renderField => {
       global.console.warn = jest.fn();
 
-      renderField({
+      const { rerender } = renderField({
         component: 'select',
       });
-
+      rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'
       );
     });
 
-    cases('warns if component is fn', renderField => {
+    cases('warns about compnent prop deprecation', renderField => {
       global.console.warn = jest.fn();
-
-      renderField({
+      const { rerender } = renderField({
         component: () => null,
       });
+      rerender();
+      expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
+        'deprecated'
+      );
+    });
 
+    cases('warns about render prop deprecation', renderField => {
+      global.console.warn = jest.fn();
+      const { rerender } = renderField({
+        render: () => null,
+      });
+      rerender();
+      expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
+        'deprecated'
+      );
+    });
+
+    cases('warns if component is fn', renderField => {
+      global.console.warn = jest.fn();
+      const { rerender } = renderField({
+        component: () => null,
+      });
+      rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'
       );
@@ -414,11 +435,27 @@ describe('Field / FastField', () => {
       renderField => {
         global.console.warn = jest.fn();
 
-        renderField({
+        const { rerender } = renderField({
           component: 'select',
           children: () => <option value="Jared">{TEXT}</option>,
         });
+        rerender();
+        expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
+          'Warning:'
+        );
+      }
+    );
 
+    cases(
+      'warns if both string as prop and children as a function',
+      renderField => {
+        global.console.warn = jest.fn();
+
+        const { rerender } = renderField({
+          as: 'select',
+          children: () => <option value="Jared">{TEXT}</option>,
+        });
+        rerender();
         expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
           'Warning:'
         );
@@ -430,11 +467,11 @@ describe('Field / FastField', () => {
       renderField => {
         global.console.warn = jest.fn();
 
-        renderField({
+        const { rerender } = renderField({
           component: () => null,
           children: () => <option value="Jared">{TEXT}</option>,
         });
-
+        rerender();
         expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
           'Warning:'
         );
@@ -444,11 +481,11 @@ describe('Field / FastField', () => {
     cases('warns if both string component and render', renderField => {
       global.console.warn = jest.fn();
 
-      renderField({
+      const { rerender } = renderField({
         component: 'textarea',
         render: () => <option value="Jared">{TEXT}</option>,
       });
-
+      rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'
       );
@@ -457,11 +494,11 @@ describe('Field / FastField', () => {
     cases('warns if both non-string component and render', renderField => {
       global.console.warn = jest.fn();
 
-      renderField({
+      const { rerender } = renderField({
         component: () => null,
         render: () => <option value="Jared">{TEXT}</option>,
       });
-
+      rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'
       );
@@ -470,11 +507,11 @@ describe('Field / FastField', () => {
     cases('warns if both children and render', renderField => {
       global.console.warn = jest.fn();
 
-      renderField({
+      const { rerender } = renderField({
         children: <div>{TEXT}</div>,
         render: () => <div>{TEXT}</div>,
       });
-
+      rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'
       );


### PR DESCRIPTION
- Only run Field deprecation warnings one time on mount
- Rename `warning` imports to `invariant` because I can never remember if the condition should be truthy or falsy