### PR TITLE
setIn keeps class inheritance for the top level object

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export function getIn(
  * @see https://github.com/developit/linkstate
  */
 export function setIn(obj: any, path: string, value: any): any {
-  let res: any = {};
+  let res: any = cloneDeep(obj);
   let resVal: any = res;
   let i = 0;
   let pathArray = toPath(path);
@@ -54,15 +54,13 @@ export function setIn(obj: any, path: string, value: any): any {
     resVal[pathArray[i]] = value;
   }
 
-  const result = { ...obj, ...res };
-
   // If the path array has a single element, the loop did not run.
   // Deleting on `resVal` had no effect in this scenario, so we delete on the result instead.
   if (i === 0 && value === undefined) {
-    delete result[pathArray[i]];
+    delete res[pathArray[i]];
   }
 
-  return result;
+  return res;
 }
 
 /**

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -235,6 +235,21 @@ describe('utils', () => {
       expect(obj).toEqual({ x: 'y' });
       expect(newObj).toEqual({ x: 'y', a: { x: { c: 'value' } } });
     });
+
+    it('should keep class inheritance for the top level object', () => {
+      class TestClass {
+        constructor(public key: string, public setObj?: any) {}
+      }
+      const obj = new TestClass('value');
+      const newObj = setIn(obj, 'setObj.nested', 'setInValue');
+      expect(obj).toEqual(new TestClass('value'));
+      expect(newObj).toEqual({
+        key: 'value',
+        setObj: { nested: 'setInValue' },
+      });
+      expect(obj instanceof TestClass).toEqual(true);
+      expect(newObj instanceof TestClass).toEqual(true);
+    });
   });
 
   describe('isPromise', () => {


### PR DESCRIPTION
setIn is causing the class inheritance of the top level object to get broken, set back to a regular Javascript object. This fixes it by cloning the original object and manipulating it instead of spreading the object and changes into a new Javascript object at the end.

This will resolve #1369