### PR TITLE
[Docs] Remove extraneous Markdown markers in docs

### DIFF
--- a/docs/api/fastfield.md
+++ b/docs/api/fastfield.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/fast
 
 ## Before we start
 
-`<FastField />` is meant for performance _optimization_. However, you really do not need to use it until you do. Only proceed if you are familiar with how React's [`shouldComponentUpdate()`](https://reactjs.org/docs/react-component.html#shouldcomponentupdate) works. You have been warned.\*\*
+`<FastField />` is meant for performance _optimization_. However, you really do not need to use it until you do. Only proceed if you are familiar with how React's [`shouldComponentUpdate()`](https://reactjs.org/docs/react-component.html#shouldcomponentupdate) works. You have been warned.
 
 **No. Seriously. Please review the following parts of the official React documentation before continuing**
 


### PR DESCRIPTION
This PR remove extraneous `**` in the `<FastField>` docs (see screenshot below).

![image](https://user-images.githubusercontent.com/2587348/56095437-33b82400-5edd-11e9-9946-501af61605f1.png)

Thanks for your work by the way, Formik is so good 😊