### PR TITLE
Expose form submission errors

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -28,7 +28,7 @@ import invariant from 'tiny-warning';
 // We already used FormikActions. So we'll go all Elm-y, and use Message.
 type FormikMessage<Values> =
   | { type: 'SUBMIT_ATTEMPT' }
-  | { type: 'SUBMIT_FAILURE' }
+  | { type: 'SUBMIT_FAILURE'; payload: any }
   | { type: 'SUBMIT_SUCCESS' }
   | { type: 'SET_ISVALIDATING'; payload: boolean }
   | { type: 'SET_ISSUBMITTING'; payload: boolean }
@@ -92,6 +92,7 @@ function formikReducer<Values>(
       return {
         ...state,
         isSubmitting: false,
+        formError: msg.payload,
       };
     case 'SUBMIT_SUCCESS':
       return {
@@ -127,6 +128,7 @@ export function useFormik<Values = object>({
     isSubmitting: false,
     isValidating: false,
     submitCount: 0,
+    formError: undefined,
   });
 
   const runValidationAsEffect = React.useCallback(
@@ -362,6 +364,7 @@ export function useFormik<Values = object>({
         values,
         isValidating: false,
         submitCount: 0,
+        formError: undefined,
       },
     });
   }
@@ -615,14 +618,14 @@ export function useFormik<Values = object>({
               dispatch({ type: 'SUBMIT_SUCCESS' });
             }
           })
-          .catch(_errors => {
+          .catch(errors => {
             if (isMounted.current) {
-              dispatch({ type: 'SUBMIT_FAILURE' });
+              dispatch({ type: 'SUBMIT_FAILURE', payload: errors });
             }
           });
       } else if (isMounted.current) {
         // ^^^ Make sure Formik is still mounted before calling setState
-        dispatch({ type: 'SUBMIT_FAILURE' });
+        dispatch({ type: 'SUBMIT_FAILURE', payload: undefined });
       }
     });
   }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -43,6 +43,8 @@ export interface FormikState<Values> {
   status?: any;
   /** Number of times user tried to submit the form */
   submitCount: number;
+  /** Global form submission error */
+  formError: any;
 }
 
 /**


### PR DESCRIPTION
Hi people,

I have been super excited about formik hooks, it's awesome. But I also noticed that I was often using a pattern that I think can be part of the default formik API.

I very often write code that looks like that to handle errors:
```js
const [error, setError] = useState<Error | null>(null);
const { /* ... */ } = useFormik({
  // ...
  onSubmit: async values => {
    try {
      await doSomeAsyncStuff(values) // Mostly API calls
    } catch (err) {
      setError(err)
    }
  },
});
```

I am pretty sure there could be a better way.

I just provided a quick POC, but it is really a quick draft to start the conversation.

Cheers,