### PR TITLE
Fix Linter Errors

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -42,7 +42,7 @@ export const MyReactNativeForm = props => (
 As you can see above, the notable differences between using Formik with React
 DOM and React Native are:
 
-1.  Formik's `props.handleSubmit` is passed to a `<Button onPress={...} />`
+1.  Formik's `handleSubmit` is passed to a `<Button onPress={...} />`
     instead of HTML `<form onSubmit={...} />` component (since there is no
     `<form />` element in React Native).
-2.  `<TextInput />` uses Formik's `props.handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with React Native we can't get it automatically like in web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setFieldTouched(fieldName, bool)` as an alternative.
+2.  `<TextInput />` uses Formik's `handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with React Native we can't get it automatically like in web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setFieldTouched(fieldName, bool)` as an alternative.

--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -25,14 +25,14 @@ export const MyReactNativeForm = props => (
     initialValues={{ email: '' }}
     onSubmit={values => console.log(values)}
   >
-    {props => (
+    {({ handleChange, handleBlur, handleSubmit, values }) => (
       <View>
         <TextInput
-          onChangeText={props.handleChange('email')}
-          onBlur={props.handleBlur('email')}
-          value={props.values.email}
+          onChangeText={handleChange('email')}
+          onBlur={handleBlur('email')}
+          value={values.email}
         />
-        <Button onPress={props.handleSubmit} title="Submit" />
+        <Button onPress={handleSubmit} title="Submit" />
       </View>
     )}
   </Formik>


### PR DESCRIPTION
Calling the variable `props` is confusing linters because it's saying `handleChange` and the others are not validated props.