### PR TITLE
Overwritten property

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -36,7 +36,6 @@ class Index extends React.Component {
               viewBox="0 0 145 127"
               aria-hidden="true"
               style={{
-                height: 145 * 3,
                 height: 127 * 3,
                 position: 'absolute',
                 right: '36%',


### PR DESCRIPTION
If an object literal has two properties with the same name, the second property overwrites the first one, which makes the code hard to understand and error-prone.

In ECMAScript 2015 and above, as well as ECMAScript 5 non-strict mode, an object literal may define the same property multiple times, with later definitions overwriting earlier ones. In particular, if the last definition assigns a different value from earlier definitions, the earlier value is lost, which is most likely unintentional and should be avoided.