### PR TITLE
Added optional `explicitValidation` parameter to all FieldArray Helpers

### DIFF
--- a/docs/api/fieldarray.md
+++ b/docs/api/fieldarray.md
@@ -175,14 +175,14 @@ _NOTE_: In Formik v0.12 / 1.0, a new `meta` prop may be added to `Field` and `Fi
 
 The following methods are made available via render props.
 
-* `push: (obj: any) => void`: Add a value to the end of an array
-* `swap: (indexA: number, indexB: number) => void`: Swap two values in an array
-* `move: (from: number, to: number) => void`: Move an element in an array to another index
-* `insert: (index: number, value: any) => void`: Insert an element at a given index into the array
-* `unshift: (value: any) => number`: Add an element to the beginning of an array and return its length
-* `remove<T>(index: number): T | undefined`: Remove an element at an index of an array and return it
-* `pop<T>(): T | undefined`: Remove and return value from the end of the array
-* `replace: (index: number, value: any) => void`: Replace a value at the given index into the array
+* `push: (obj: any, explicitValidation?: boolean) => void`: Add a value to the end of an array. Validation can be forced on or off.
+* `swap: (indexA: number, indexB: number, explicitValidation?: boolean) => void`: Swap two values in an array. Validation can be forced on or off.
+* `move: (from: number, to: number, explicitValidation?: boolean) => void`: Move an element in an array to another index. Validation can be forced on or off.
+* `insert: (index: number, value: any, explicitValidation?: boolean) => void`: Insert an element at a given index into the array. Validation can be forced on or off.
+* `unshift: (value: any, explicitValidation?: boolean) => number`: Add an element to the beginning of an array and return its length. Validation can be forced on or off.
+* `remove<T>(index: number, explicitValidation?: boolean): T | undefined`: Remove an element at an index of an array and return it. Validation can be forced on or off.
+* `pop<T>(explicitValidation?: boolean): T | undefined`: Remove and return value from the end of the array. Validation can be forced on or off.
+* `replace: (index: number, value: any, explicitValidation?: boolean) => void`: Replace a value at the given index into the array. Validation can be forced on or off.
 
 ## FieldArray render methods
 

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -22,37 +22,53 @@ export type FieldArrayConfig = {
 } & SharedRenderProps<FieldArrayRenderProps>;
 export interface ArrayHelpers {
   /** Imperatively add a value to the end of an array */
-  push: (obj: any) => void;
+  push: (obj: any, explicitValidation?: boolean) => void;
   /** Curried fn to add a value to the end of an array */
-  handlePush: (obj: any) => () => void;
+  handlePush: (obj: any, explicitValidation?: boolean) => () => void;
   /** Imperatively swap two values in an array */
-  swap: (indexA: number, indexB: number) => void;
+  swap: (indexA: number, indexB: number, explicitValidation?: boolean) => void;
   /** Curried fn to swap two values in an array */
-  handleSwap: (indexA: number, indexB: number) => () => void;
+  handleSwap: (
+    indexA: number,
+    indexB: number,
+    explicitValidation?: boolean
+  ) => () => void;
   /** Imperatively move an element in an array to another index */
-  move: (from: number, to: number) => void;
+  move: (from: number, to: number, explicitValidation?: boolean) => void;
   /** Imperatively move an element in an array to another index */
-  handleMove: (from: number, to: number) => () => void;
+  handleMove: (
+    from: number,
+    to: number,
+    explicitValidation?: boolean
+  ) => () => void;
   /** Imperatively insert an element at a given index into the array */
-  insert: (index: number, value: any) => void;
+  insert: (index: number, value: any, explicitValidation?: boolean) => void;
   /** Curried fn to insert an element at a given index into the array */
-  handleInsert: (index: number, value: any) => () => void;
+  handleInsert: (
+    index: number,
+    value: any,
+    explicitValidation?: boolean
+  ) => () => void;
   /** Imperatively replace a value at an index of an array  */
-  replace: (index: number, value: any) => void;
+  replace: (index: number, value: any, explicitValidation?: boolean) => void;
   /** Curried fn to replace an element at a given index into the array */
-  handleReplace: (index: number, value: any) => () => void;
+  handleReplace: (
+    index: number,
+    value: any,
+    explicitValidation?: boolean
+  ) => () => void;
   /** Imperatively add an element to the beginning of an array and return its length */
-  unshift: (value: any) => number;
+  unshift: (value: any, explicitValidation?: boolean) => number;
   /** Curried fn to add an element to the beginning of an array */
-  handleUnshift: (value: any) => () => void;
+  handleUnshift: (value: any, explicitValidation?: boolean) => () => void;
   /** Curried fn to remove an element at an index of an array */
-  handleRemove: (index: number) => () => void;
+  handleRemove: (index: number, explicitValidation?: boolean) => () => void;
   /** Curried fn to remove a value from the end of the array */
-  handlePop: () => () => void;
+  handlePop: (explicitValidation?: boolean) => () => void;
   /** Imperatively remove and element at an index of an array */
-  remove<T>(index: number): T | undefined;
+  remove<T>(index: number, explicitValidation?: boolean): T | undefined;
   /** Imperatively remove and return value from the end of the array */
-  pop<T>(): T | undefined;
+  pop<T>(explicitValidation?: boolean): T | undefined;
 }
 
 /**
@@ -103,7 +119,8 @@ class FieldArrayInner<Values = {}> extends React.Component<
   updateArrayField = (
     fn: Function,
     alterTouched: boolean | Function,
-    alterErrors: boolean | Function
+    alterErrors: boolean | Function,
+    explicitValidation?: boolean
   ) => {
     const {
       name,
@@ -140,57 +157,82 @@ class FieldArrayInner<Values = {}> extends React.Component<
         };
       },
       () => {
-        if (validateOnChange) {
+        if (typeof explicitValidation === 'boolean') {
+          if (explicitValidation) {
+            validateForm();
+          }
+        } else if (validateOnChange) {
           validateForm();
         }
       }
     );
   };
 
-  push = (value: any) =>
+  push = (value: any, explicitValidation?: boolean) =>
     this.updateArrayField(
       (array: any[]) => [...(array || []), cloneDeep(value)],
       false,
-      false
+      false,
+      explicitValidation
     );
 
-  handlePush = (value: any) => () => this.push(value);
+  handlePush = (value: any, explicitValidation?: boolean) => () =>
+    this.push(value, explicitValidation);
 
-  swap = (indexA: number, indexB: number) =>
+  swap = (indexA: number, indexB: number, explicitValidation?: boolean) =>
     this.updateArrayField(
       (array: any[]) => swap(array, indexA, indexB),
       true,
-      true
+      true,
+      explicitValidation
     );
 
-  handleSwap = (indexA: number, indexB: number) => () =>
-    this.swap(indexA, indexB);
+  handleSwap = (
+    indexA: number,
+    indexB: number,
+    explicitValidation?: boolean
+  ) => () => this.swap(indexA, indexB, explicitValidation);
 
-  move = (from: number, to: number) =>
-    this.updateArrayField((array: any[]) => move(array, from, to), true, true);
+  move = (from: number, to: number, explicitValidation?: boolean) =>
+    this.updateArrayField(
+      (array: any[]) => move(array, from, to),
+      true,
+      true,
+      explicitValidation
+    );
 
-  handleMove = (from: number, to: number) => () => this.move(from, to);
+  handleMove = (from: number, to: number, explicitValidation?: boolean) => () =>
+    this.move(from, to, explicitValidation);
 
-  insert = (index: number, value: any) =>
+  insert = (index: number, value: any, explicitValidation?: boolean) =>
     this.updateArrayField(
       (array: any[]) => insert(array, index, value),
       (array: any[]) => insert(array, index, null),
-      (array: any[]) => insert(array, index, null)
+      (array: any[]) => insert(array, index, null),
+      explicitValidation
     );
 
-  handleInsert = (index: number, value: any) => () => this.insert(index, value);
+  handleInsert = (
+    index: number,
+    value: any,
+    explicitValidation?: boolean
+  ) => () => this.insert(index, value, explicitValidation);
 
-  replace = (index: number, value: any) =>
+  replace = (index: number, value: any, explicitValidation?: boolean) =>
     this.updateArrayField(
       (array: any[]) => replace(array, index, value),
       false,
-      false
+      false,
+      explicitValidation
     );
 
-  handleReplace = (index: number, value: any) => () =>
-    this.replace(index, value);
+  handleReplace = (
+    index: number,
+    value: any,
+    explicitValidation?: boolean
+  ) => () => this.replace(index, value, explicitValidation);
 
-  unshift = (value: any) => {
+  unshift = (value: any, explicitValidation?: boolean) => {
     let length = -1;
     this.updateArrayField(
       (array: any[]) => {
@@ -209,14 +251,16 @@ class FieldArrayInner<Values = {}> extends React.Component<
         const arr = array ? [null, ...array] : [null];
         if (length < 0) length = arr.length;
         return arr;
-      }
+      },
+      explicitValidation
     );
     return length;
   };
 
-  handleUnshift = (value: any) => () => this.unshift(value);
+  handleUnshift = (value: any, explicitValidation?: boolean) => () =>
+    this.unshift(value, explicitValidation);
 
-  remove<T>(index: number): T {
+  remove<T>(index: number, explicitValidation?: boolean): T {
     // We need to make sure we also remove relevant pieces of `touched` and `errors`
     let result: any;
     this.updateArrayField(
@@ -232,15 +276,17 @@ class FieldArrayInner<Values = {}> extends React.Component<
         return copy;
       },
       true,
-      true
+      true,
+      explicitValidation
     );
 
     return result;
   }
 
-  handleRemove = (index: number) => () => this.remove<any>(index);
+  handleRemove = (index: number, explicitValidation?: boolean) => () =>
+    this.remove<any>(index, explicitValidation);
 
-  pop<T>(): T {
+  pop<T>(explicitValidation?: boolean): T {
     // Remove relevant pieces of `touched` and `errors` too!
     let result: any;
     this.updateArrayField(
@@ -253,13 +299,15 @@ class FieldArrayInner<Values = {}> extends React.Component<
         return tmp;
       },
       true,
-      true
+      true,
+      explicitValidation
     );
 
     return result;
   }
 
-  handlePop = () => () => this.pop<any>();
+  handlePop = (explicitValidation?: boolean) => () =>
+    this.pop<any>(explicitValidation);
 
   render() {
     const arrayHelpers: ArrayHelpers = {


### PR DESCRIPTION
Added optional `explicitValidation` parameter to all FieldArray Helpers to allow for explicitly turning validation on or off when manipulating data. 

This can improve performance when changing a large batch of data simultaneously. `validateForm` can be called manually afterwards.