### PR TITLE
Add warning when formik ctx is empty in connect

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -116,11 +116,8 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
   componentDidMount() {
     // Register the Field with the parent Formik. Parent will cycle through
     // registered Field's validate fns right prior to submit
-
-    const { name, formik: { registerField } } = this.props;
-
-    if (registerField) {
-      registerField(name, this);
+    if (this.props.formik.registerField) {
+      this.props.formik.registerField(this.props.name, this);
     }
   }
 
@@ -138,10 +135,8 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
   }
 
   componentWillUnmount() {
-    const { name, formik: { unregisterField } } = this.props;
-
-    if (unregisterField) {
-      unregisterField(name);
+    if (this.props.formik.unregisterField) {
+      this.props.formik.unregisterField(this.props.name);
     }
   }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -116,7 +116,12 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
   componentDidMount() {
     // Register the Field with the parent Formik. Parent will cycle through
     // registered Field's validate fns right prior to submit
-    this.props.formik.registerField(this.props.name, this);
+
+    const { name, formik: { registerField } } = this.props;
+
+    if (registerField) {
+      registerField(name, this);
+    }
   }
 
   componentDidUpdate(
@@ -133,7 +138,11 @@ class FieldInner<Values = {}, Props = {}> extends React.Component<
   }
 
   componentWillUnmount() {
-    this.props.formik.unregisterField(this.props.name);
+    const { name, formik: { unregisterField } } = this.props;
+
+    if (unregisterField) {
+      unregisterField(name);
+    }
   }
 
   render() {

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import createContext from 'create-react-context';
 import { FormikContext } from './types';
 import warning from 'tiny-warning';
-import isEmpty from 'lodash/isEmpty';
 
 export const {
   Provider: FormikProvider,
@@ -21,7 +20,7 @@ export function connect<OuterProps, Values = {}>(
     <FormikConsumer>
       {formik => {
         warning(
-          isEmpty(formik),
+          !formik,
           `Formik context is undefined, please verify you are rendering <Form>, <Field>, <FastField> or <FieldArray> inside <Formik>. Component name: ${
             Comp.name
           }`

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import createContext from 'create-react-context';
 import { FormikContext } from './types';
+import warning from 'tiny-warning';
+import isEmpty from 'lodash/isEmpty';
 
 export const {
   Provider: FormikProvider,
@@ -17,9 +19,19 @@ export function connect<OuterProps, Values = {}>(
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (
     <FormikConsumer>
-      {formik => <Comp {...props} formik={formik} />}
+      {formik => {
+        warning(
+          isEmpty(formik),
+          `Formik context is undefined, please verify you are rendering <Form>, <Field>, <FastField> or <FieldArray> inside <Formik>. Component name: ${
+            Comp.name
+          }`
+        );
+
+        return <Comp {...props} formik={formik} />;
+      }}
     </FormikConsumer>
   );
+
   const componentDisplayName =
     Comp.displayName ||
     Comp.name ||

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -58,8 +58,27 @@ const createRenderField = (
   };
 };
 
+const createRenderFieldWithoutFormikCtx = (
+  FieldComponent: React.ComponentClass<FieldConfig>
+) => (props: Partial<FieldConfig> | Partial<FastFieldConfig> = {}) => {
+  let injected: FieldProps | FastFieldProps;
+
+  if (!props.children && !props.render && !props.component) {
+    props.children = (fieldProps: FieldProps | FastFieldProps) =>
+      (injected = fieldProps) && null;
+  }
+
+  return {
+    getProps() {
+      return injected;
+    },
+    ...render(<FieldComponent name="name" {...props} />),
+  };
+};
+
 const renderField = createRenderField(Field);
 const renderFastField = createRenderField(FastField);
+const renderFieldWithoutFormikCtx = createRenderFieldWithoutFormikCtx(Field);
 
 function cases(
   title: string,
@@ -317,6 +336,19 @@ describe('Field / FastField', () => {
       global.console.warn = jest.fn();
 
       renderField({
+        children: <div>{TEXT}</div>,
+        render: () => <div>{TEXT}</div>,
+      });
+
+      expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
+        'Warning:'
+      );
+    });
+
+    cases('warns if Formik context is undefined', () => {
+      global.console.warn = jest.fn();
+
+      renderFieldWithoutFormikCtx({
         children: <div>{TEXT}</div>,
         render: () => <div>{TEXT}</div>,
       });

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -58,27 +58,8 @@ const createRenderField = (
   };
 };
 
-const createRenderFieldWithoutFormikCtx = (
-  FieldComponent: React.ComponentClass<FieldConfig>
-) => (props: Partial<FieldConfig> | Partial<FastFieldConfig> = {}) => {
-  let injected: FieldProps | FastFieldProps;
-
-  if (!props.children && !props.render && !props.component) {
-    props.children = (fieldProps: FieldProps | FastFieldProps) =>
-      (injected = fieldProps) && null;
-  }
-
-  return {
-    getProps() {
-      return injected;
-    },
-    ...render(<FieldComponent name="name" {...props} />),
-  };
-};
-
 const renderField = createRenderField(Field);
 const renderFastField = createRenderField(FastField);
-const renderFieldWithoutFormikCtx = createRenderFieldWithoutFormikCtx(Field);
 
 function cases(
   title: string,
@@ -348,10 +329,9 @@ describe('Field / FastField', () => {
     cases('warns if Formik context is undefined', () => {
       global.console.warn = jest.fn();
 
-      renderFieldWithoutFormikCtx({
-        children: <div>{TEXT}</div>,
-        render: () => <div>{TEXT}</div>,
-      });
+      const content = <div>{TEXT}</div>;
+
+      render(<Field name="name" children={content} render={() => content} />);
 
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(
         'Warning:'


### PR DESCRIPTION
Related to #1368 and then #1467, I added the warn when `formik` is empty in `connect`. Also added some checks on `Field` to avoid crashes, but maybe we should let it crash and warn, not one or another.