### PR TITLE
Add a method onSubmitValidationError

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -445,12 +445,17 @@ export class Formik<Values = FormikValues> extends React.Component<
       } else if (this.didMount) {
         // ^^^ Make sure Formik is still mounted before calling setState
         this.setState({ isSubmitting: false });
+        this.executeSubmitValidationError();
       }
     });
   };
 
   executeSubmit = () => {
     this.props.onSubmit(this.state.values, this.getFormikActions());
+  };
+
+  executeSubmitValidationError = () => {
+    this.props.onSubmitValidationError();
   };
 
   handleBlur = (

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -445,7 +445,7 @@ export class Formik<Values = FormikValues> extends React.Component<
       } else if (this.didMount) {
         // ^^^ Make sure Formik is still mounted before calling setState
         this.setState({ isSubmitting: false });
-        this.executeSubmitValidationError();
+        this.executeSubmitValidationError(combinedErrors);
       }
     });
   };
@@ -454,8 +454,8 @@ export class Formik<Values = FormikValues> extends React.Component<
     this.props.onSubmit(this.state.values, this.getFormikActions());
   };
 
-  executeSubmitValidationError = () => {
-    this.props.onSubmitValidationError();
+  executeSubmitValidationError = (errors: FormikErrors<Values>) => {
+    this.props.onSubmitValidationError(errors);
   };
 
   handleBlur = (

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -209,7 +209,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Submit validation error
    */
-  onSubmitValidationError: () => void;
+  onSubmitValidationError: (errors: FormikErrors<Values>) => void;
 
   /**
    * A Yup Schema or a function that returns a Yup schema

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -205,6 +205,12 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * Submission handler
    */
   onSubmit: (values: Values, formikActions: FormikActions<Values>) => void;
+
+  /**
+   * Submit validation error
+   */
+  onSubmitValidationError: () => void;
+
   /**
    * A Yup Schema or a function that returns a Yup schema
    */

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -481,7 +481,7 @@ describe('<Formik>', () => {
 
       it('should not submit the form if invalid', async () => {
         const onSubmit = jest.fn();
-        const validate = jest.fn(() => Promise.resolve({ name: 'Error!' }));
+        const validate = jest.fn(() => Promise.reject({ name: 'Error!' }));
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -60,6 +60,7 @@ function renderFormik<V>(props?: Partial<FormikConfig<V>>) {
       <Formik
         ref={ref as any}
         onSubmit={noop as any}
+        onSubmitValidationError={noop as any}
         initialValues={InitialValues as any}
         {...props}
       >
@@ -445,6 +446,18 @@ describe('<Formik>', () => {
 
         fireEvent.submit(getByTestId('form'));
         expect(onSubmit).not.toBeCalled();
+      });
+
+      it('should call to submit validation error if the form is invalid', async () => {
+        const onSubmitValidationError = jest.fn();
+        const validate = jest.fn(() => ({ name: 'Error!' }));
+        const { getByTestId } = renderFormik({
+          onSubmitValidationError,
+          validate,
+        });
+
+        fireEvent.submit(getByTestId('form'));
+        await wait(() => expect(onSubmitValidationError).toBeCalled());
       });
     });
 

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -450,14 +450,15 @@ describe('<Formik>', () => {
 
       it('should call to submit validation error if the form is invalid', async () => {
         const onSubmitValidationError = jest.fn();
-        const validate = jest.fn(() => ({ name: 'Error!' }));
+        const error = { name: 'Error!' };
+        const validate = jest.fn(() => error);
         const { getByTestId } = renderFormik({
           onSubmitValidationError,
           validate,
         });
 
         fireEvent.submit(getByTestId('form'));
-        await wait(() => expect(onSubmitValidationError).toBeCalled());
+        await wait(() => expect(onSubmitValidationError).toBeCalledWith(error));
       });
     });
 
@@ -490,14 +491,15 @@ describe('<Formik>', () => {
 
       it('should call to submit validation error if the form is invalid', async () => {
         const onSubmitValidationError = jest.fn();
-        const validate = jest.fn(() => Promise.reject({ name: 'Error!' }));
+        const error = { name: 'Error!' };
+        const validate = jest.fn(() => Promise.reject(error));
         const { getByTestId } = renderFormik({
           onSubmitValidationError,
           validate,
         });
 
         fireEvent.submit(getByTestId('form'));
-        await wait(() => expect(onSubmitValidationError).toBeCalled());
+        await wait(() => expect(onSubmitValidationError).toBeCalledWith(error));
       });
     });
 

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -487,6 +487,18 @@ describe('<Formik>', () => {
         fireEvent.submit(getByTestId('form'));
         expect(onSubmit).not.toBeCalled();
       });
+
+      it('should call to submit validation error if the form is invalid', async () => {
+        const onSubmitValidationError = jest.fn();
+        const validate = jest.fn(() => Promise.reject({ name: 'Error!' }));
+        const { getByTestId } = renderFormik({
+          onSubmitValidationError,
+          validate,
+        });
+
+        fireEvent.submit(getByTestId('form'));
+        await wait(() => expect(onSubmitValidationError).toBeCalled());
+      });
     });
 
     describe('with validationSchema (ASYNC)', () => {

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -479,13 +479,13 @@ describe('<Formik>', () => {
         await wait(() => expect(onSubmit).toBeCalled());
       });
 
-      it('should not submit the form if invalid', () => {
+      it('should not submit the form if invalid', async () => {
         const onSubmit = jest.fn();
         const validate = jest.fn(() => Promise.resolve({ name: 'Error!' }));
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));
-        expect(onSubmit).not.toBeCalled();
+        await wait(() => expect(onSubmit).not.toBeCalled());
       });
 
       it('should call to submit validation error if the form is invalid', async () => {


### PR DESCRIPTION
Hello,

The purpose of this change is add a new method "onSubmitValidationError" to be called when the submit event is fired but you have some validation error in the form. I think it could be useful to have this method to perform some extra action outside of the form when we try to submit in a form with validation errors. 

Thank you :)