### PR TITLE
:sparkles:(FieldArray) pass rest props down

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -291,12 +291,19 @@ class FieldArrayInner<Values = {}> extends React.Component<
         validationSchema: _validationSchema,
         ...restOfFormik
       },
+
+      ...rest
     } = this.props;
 
-    const props: FieldArrayRenderProps = {
+    const fieldArrayRenderProps: FieldArrayRenderProps = {
       ...arrayHelpers,
       form: restOfFormik,
       name,
+    };
+
+    const props = {
+        ...rest,
+        ...fieldArrayRenderProps
     };
 
     return component


### PR DESCRIPTION
### What

pass FieldArray rest props down to component/renderProps/children

### Why

```jsx
<FieldArray
   initialValue={{ name: 'foo' }}
   component={CustomComponent}
/>

const CustomComponent = (props) => {
    const { push, initialValue } = props;
    return (
       // snips

       <button onClick={() => push(intitialValue)}>Add</button>
    );
}
```

### Current Workaround

```jsx
const passDown = {
  initialValue: { name: 'foo' },
};

<FieldArray
   component={(p: any) => <CustomComponent {...p} {...passDown} />}
/>
```