### PR TITLE
Adds onlySubmitted as a prop for ErrorMessage component

### DIFF
--- a/docs/api/errormessage.md
+++ b/docs/api/errormessage.md
@@ -107,6 +107,12 @@ Either a React component or the name of an HTML element to render. If not specif
 
 A field's name in Formik state. To access nested objects or arrays, name can also accept lodash-like dot path like `social.facebook` or `friends[0].firstName`
 
+### `onlySubmitted`
+
+`onlySubmitted?: boolean`
+
+Will only show the error message if the form has been submitted before.
+
 ### `render`
 
 `render?: (error: string) => React.ReactNode`

--- a/src/ErrorMessage.tsx
+++ b/src/ErrorMessage.tsx
@@ -5,6 +5,7 @@ import { connect } from './connect';
 
 export interface ErrorMessageProps {
   name: string;
+  onlySubmitted?: boolean;
   className?: string;
   component?: string | React.ComponentType;
   children?: ((errorMessage: string) => React.ReactNode);
@@ -22,6 +23,7 @@ class ErrorMessageImpl extends React.Component<
         getIn(props.formik.errors, this.props.name) ||
       getIn(this.props.formik.touched, this.props.name) !==
         getIn(props.formik.touched, this.props.name) ||
+      this.props.formik.submitCount !== props.formik.submitCount ||
       Object.keys(this.props).length !== Object.keys(props).length
     ) {
       return true;
@@ -31,12 +33,20 @@ class ErrorMessageImpl extends React.Component<
   }
 
   render() {
-    let { component, formik, render, children, name, ...rest } = this.props;
+    let {
+      component,
+      formik,
+      render,
+      onlySubmitted,
+      children,
+      name,
+      ...rest
+    } = this.props;
 
     const touch = getIn(formik.touched, name);
     const error = getIn(formik.errors, name);
 
-    return !!touch && !!error
+    return !!touch && !!error && (onlySubmitted ? !!formik.submitCount : true)
       ? render
         ? isFunction(render) ? render(error) : null
         : children

--- a/test/ErrorMessage.test.tsx
+++ b/test/ErrorMessage.test.tsx
@@ -48,4 +48,35 @@ describe('<ErrorMessage />', () => {
     // Renders after being visited with an error.
     expect(actual).toEqual(message);
   });
+  it('only show when onSubmitted', async () => {
+    let actual: any; /** ErrorMessage ;) */
+    let actualFProps: any;
+    let message = 'Wrong';
+    ReactDOM.render(
+      <TestForm
+        render={(fProps: FormikProps<TestFormValues>) => {
+          actualFProps = fProps;
+          return (
+            <div>
+              <ErrorMessage name="email" onlySubmitted>
+                {props => (actual = props) || <div>{props}</div>}
+              </ErrorMessage>
+            </div>
+          );
+        }}
+      />,
+      node
+    );
+
+    actualFProps.setFieldError('email', message);
+    expect(actual).toEqual(undefined);
+
+    actualFProps.setFieldTouched('email');
+    expect(actual).toEqual(undefined);
+
+    actualFProps.handleSubmit();
+
+    // Renders after being submitted.
+    expect(actual).toEqual(message);
+  });
 });


### PR DESCRIPTION
This allows only showing an error message after the form was submitted (`!!submitCount`).

I'm cool if the name isn't clear enough, suggestions welcome (onlyAfterSubmitted?)