### PR TITLE
Provide better typing for isInitialValid method when using withFormik

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -155,13 +155,13 @@ export interface FormikHandlers {
 /**
  * Base formik configuration/props shared between the HoC and Component.
  */
-export interface FormikSharedConfig {
+export interface FormikSharedConfig<Props = {}> {
   /** Tells Formik to validate the form on each input's onChange event */
   validateOnChange?: boolean;
   /** Tells Formik to validate the form on each input's onBlur event */
   validateOnBlur?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
-  isInitialValid?: boolean | ((props: object) => boolean | undefined);
+  isInitialValid?: boolean | ((props: Props) => boolean);
   /** Should Formik reset the form when new initialValues change */
   enableReinitialize?: boolean;
 }

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -29,7 +29,7 @@ export interface WithFormikConfig<
   Props,
   Values extends FormikValues = FormikValues,
   DeprecatedPayload = Values
-> extends FormikSharedConfig {
+> extends FormikSharedConfig<Props> {
   /**
    * Set the display name of the component. Useful for React DevTools.
    */


### PR DESCRIPTION
We want to use the props passed to our form to determine if the initial state should be valid.

At the moment because the signature is `(props: object) => boolean | undefined` we can't access our props to calculate the boolean value.

This patch is a minimal change to make `FormikSharedConfig` a generic with a default that matches the existing behaviour. We then alter `WithFormikConfig` to pass its `Props` through when extending it.