### PR TITLE
Upgrade hoist-non-react-statics to v3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "create-react-context": "^0.2.2",
     "deepmerge": "^2.1.1",
-    "hoist-non-react-statics": "^2.5.5",
+    "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",
     "prop-types": "^15.6.1",
@@ -60,6 +60,7 @@
     "@babel/core": "^7.1.2",
     "@storybook/addon-options": "^3.4.8",
     "@storybook/react": "^3.4.0",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^24.0.5",
     "@types/lodash": "^4.14.119",
     "@types/react": "^16.7.6",

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -34,10 +34,7 @@ export function connect<OuterProps, Values = {}>(
 
   C.displayName = `FormikConnect(${componentDisplayName})`;
 
-  return hoistNonReactStatics<
-    OuterProps,
-    OuterProps & { formik: FormikContext<Values> }
-  >(
+  return hoistNonReactStatics(
     C,
     Comp as React.ComponentClass<OuterProps & { formik: FormikContext<Values> }> // cast type to ComponentClass (even if SFC)
   );

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -162,7 +162,7 @@ export function withFormik<
       }
     }
 
-    return hoistNonReactStatics<OuterProps, OuterProps & FormikProps<Values>>(
+    return hoistNonReactStatics(
       C,
       Component as React.ComponentClass<OuterProps & FormikProps<Values>> // cast type to ComponentClass (even if SFC)
     ) as React.ComponentClass<OuterProps>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -4745,9 +4753,12 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+hoist-non-react-statics@3.3.0, hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -8099,6 +8110,11 @@ react-inspector@^2.2.2:
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
+
+react-is@^16.7.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This pull request is meant to fix issues arising from older versions of `hoist-non-react-statics` hoisting the `contextType` static property when using the `connect()` or `withFormik()` HOCs:

```
Warning: FormikConnect(ComponentInner): Function components do not support contextType.
```

This issue was fixed in `hoist-non-react-statics@3.1.0` in https://github.com/mridgway/hoist-non-react-statics/pull/62