### PR TITLE
Add `validationContext` prop and pass to `validationSchema`

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,28 +1,28 @@
 {
   "./dist/formik.umd.production.js": {
-    "bundled": 144255,
-    "minified": 39643,
-    "gzipped": 12000
+    "bundled": 144485,
+    "minified": 39756,
+    "gzipped": 12026
   },
   "./dist/formik.umd.development.js": {
-    "bundled": 174435,
-    "minified": 50097,
-    "gzipped": 15119
+    "bundled": 174665,
+    "minified": 50210,
+    "gzipped": 15144
   },
   "./dist/formik.cjs.production.js": {
-    "bundled": 44141,
-    "minified": 22101,
-    "gzipped": 5521
+    "bundled": 44638,
+    "minified": 22214,
+    "gzipped": 5548
   },
   "./dist/formik.cjs.development.js": {
-    "bundled": 45029,
-    "minified": 23001,
-    "gzipped": 5862
+    "bundled": 45526,
+    "minified": 23114,
+    "gzipped": 5888
   },
   "dist/formik.esm.js": {
-    "bundled": 40594,
-    "minified": 22365,
-    "gzipped": 5736,
+    "bundled": 40808,
+    "minified": 22478,
+    "gzipped": 5763,
     "treeshaked": {
       "rollup": {
         "code": 802,

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -133,7 +133,7 @@ Set the touched state of a field imperatively. `field` should match the key of
 
 #### `submitForm: () => Promise`
 
-Trigger a form submission. The promise will be rejected if form is invalid. 
+Trigger a form submission. The promise will be rejected if form is invalid.
 
 #### `submitCount: number`
 
@@ -380,3 +380,7 @@ events and `change`-related methods. More specifically, when either
 [A Yup schema](https://github.com/jquense/yup) or a function that returns a Yup
 schema. This is used for validation. Errors are mapped by key to the inner
 component's `errors`. Its keys should match those of `values`.
+
+### `validationContext?: any`
+
+[A Yup context object](https://github.com/jquense/yup#mixedvalidatevalue-any-options-object-promiseany-validationerror). Pass an arbitrary set of key value pairs which will be accesible to the `validationSchema` or `validate` props.

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -246,11 +246,11 @@ export class Formik<Values = FormikValues> extends React.Component<
    */
   runValidationSchema = (values: FormikValues) => {
     return new Promise(resolve => {
-      const { validationSchema } = this.props;
+      const { validationSchema, validationContext } = this.props;
       const schema = isFunction(validationSchema)
         ? validationSchema()
         : validationSchema;
-      validateYupSchema(values, schema).then(
+      validateYupSchema(values, schema, false, validationContext).then(
         () => {
           resolve({});
         },
@@ -629,6 +629,7 @@ export class Formik<Values = FormikValues> extends React.Component<
     return {
       ...this.getFormikBag(),
       validationSchema: this.props.validationSchema,
+      validationContext: this.props.validationContext,
       validate: this.props.validate,
       initialValues: this.initialValues,
     };

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -245,10 +245,7 @@ export interface FormikRegistration {
  * State, handlers, and helpers made available to Formik's primitive components through context.
  */
 export type FormikContext<Values> = FormikProps<Values> &
-  Pick<
-    FormikConfig<Values>,
-    'validate' | 'validationSchema' | 'validationContext'
-  >;
+  Pick<FormikConfig<Values>, 'validate' | 'validationSchema'>;
 
 export interface SharedRenderProps<T> {
   /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -209,6 +209,11 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * A Yup Schema or a function that returns a Yup schema
    */
   validationSchema?: any | (() => any);
+  /**
+   * An object to be used in custom validations
+   * on the validationSchema
+   */
+  validationContext?: any;
 
   /**
    * Validation function. Must return an error object or promise that
@@ -240,7 +245,10 @@ export interface FormikRegistration {
  * State, handlers, and helpers made available to Formik's primitive components through context.
  */
 export type FormikContext<Values> = FormikProps<Values> &
-  Pick<FormikConfig<Values>, 'validate' | 'validationSchema'>;
+  Pick<
+    FormikConfig<Values>,
+    'validate' | 'validationSchema' | 'validationContext'
+  >;
 
 export interface SharedRenderProps<T> {
   /**

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -61,6 +61,11 @@ export interface WithFormikConfig<
   validationSchema?: any | ((props: Props) => any);
 
   /**
+   * A context object to pass to `validationSchema`
+   */
+  validationContext?: any;
+
+  /**
    * Validation function. Must return an error object or promise that
    * throws an error object where that object keys map to corresponding value.
    */
@@ -151,6 +156,7 @@ export function withFormik<
             {...config}
             validate={config.validate && this.validate}
             validationSchema={config.validationSchema && this.validationSchema}
+            validationContext={config.validationContext}
             initialValues={mapPropsToValues(this.props)}
             initialStatus={
               config.mapPropsToStatus && config.mapPropsToStatus(this.props)

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -504,6 +504,24 @@ describe('<Formik>', () => {
         fireEvent.submit(getByTestId('form'));
         expect(validate).toHaveBeenCalled();
       });
+
+      it('should pass validationContext to validationSchema', async () => {
+        const validate = jest.fn(() => Promise.resolve({}));
+        const validationSchema = () => ({
+          validate,
+        });
+        const { getByTestId } = renderFormik({
+          validate,
+          validationSchema,
+          validationContext: { test: 'present' },
+        });
+
+        fireEvent.submit(getByTestId('form'));
+        expect(validate).toHaveBeenCalledWith(InitialValues, {
+          abortEarly: false,
+          context: { test: 'present' },
+        });
+      });
     });
 
     describe('FormikActions', () => {

--- a/test/yupHelpers.test.ts
+++ b/test/yupHelpers.test.ts
@@ -4,6 +4,16 @@ const Yup = require('yup');
 const schema = Yup.object().shape({
   name: Yup.string('Name must be a string').required('required'),
 });
+const schemaWithContext = Yup.object().shape({
+  name: Yup.string('Name must be a string').test({
+    name: 'passed-context',
+    exclusive: true,
+    message: 'validationContext must be { test: "present" }',
+    test: function() {
+      return this.options.context.test === 'present';
+    },
+  }),
+});
 
 describe('Yup helpers', () => {
   describe('yupToFormErrors()', () => {
@@ -25,6 +35,20 @@ describe('Yup helpers', () => {
       } catch (e) {
         expect(e.name).toEqual('ValidationError');
         expect(e.errors).toEqual(['required']);
+      }
+    });
+
+    it('should validate with context', async () => {
+      try {
+        const result = await validateYupSchema(
+          { name: 'jared' },
+          schemaWithContext,
+          false,
+          { test: 'present' }
+        );
+        expect(result).toEqual({ name: 'jared' });
+      } catch (e) {
+        throw e;
       }
     });
 


### PR DESCRIPTION
This PR attempts to address the requested feature here: https://github.com/jaredpalmer/formik/issues/503 of passing some prop to the underlying Yup schema's `context` option.

I started to make `validationContext` more similar to `validationSchema` in that the prop could either be the object or a function that returns the object, similar to how `validationSchema` is either a Yup schema or a function that returns a yup schema. But, this required quite a bit more work to execute that function (if it is a function), rather than just assuming it is the context object already. It would also require stripping that function off as I have seen done with other props that are functions, such as `examples/Debug` and other places. I am willing to update this, but I wanted to get your temperature on the changes before diving into that. It seems like making that change to allowing a function increases the footprint of this PR quite a bit.

I am also not great with TS or jest, so I suspect you will have some input ons ome of those types of things as well.