### PR TITLE
[v2]: Distinguish between high/low priority validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",
     "react-fast-compare": "^2.0.1",
+    "scheduler": "^0.14.0",
     "tiny-warning": "^1.0.2",
     "tslib": "^1.9.3"
   },

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -399,7 +399,7 @@ export function useFormik<Values = object>({
   React.useEffect(() => {
     if (
       enableReinitialize &&
-      isMounted.current != null &&
+      isMounted.current === true &&
       !isEqual(initialValues.current, props.initialValues)
     ) {
       resetForm();

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -259,9 +259,9 @@ export function useFormik<Values = object>({
       props.validationSchema ||
       props.validate ||
       (fields.current &&
-        Object.keys(fields.current).filter(
+        Object.keys(fields.current).some(
           key => !!fields.current[key].validate
-        ).length > 0),
+        )),
     [props.validate, props.validationSchema, fields]
   );
 
@@ -324,7 +324,10 @@ export function useFormik<Values = object>({
       }
       dispatch({ type: 'SET_ISVALIDATING', payload: true });
       return runAllValidations(values).then(combinedErrors => {
-        if (!!isMounted.current && !isEqual(state.errors, combinedErrors)) {
+        if (
+          isMounted.current === true &&
+          !isEqual(state.errors, combinedErrors)
+        ) {
           dispatch({ type: 'SET_ERRORS', payload: combinedErrors });
           dispatch({ type: 'SET_ISVALIDATING', payload: false });
         }

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -223,12 +223,7 @@ export function useFormik<Values = object>({
     (values: Values): Promise<FormikErrors<Values>> => {
       const fieldKeysWithValidation: string[] = Object.keys(
         fieldRegistry.current
-      ).filter(
-        f =>
-          fieldRegistry.current[f] &&
-          fieldRegistry.current[f].validate &&
-          isFunction(fieldRegistry.current[f].validate)
-      );
+      ).filter(f => isFunction(fieldRegistry.current[f].validate));
 
       // Construct an array with all of the field validation functions
       const fieldValidations: Promise<string>[] =
@@ -388,12 +383,7 @@ export function useFormik<Values = object>({
       // changes if the validation function is synchronous. It's different from
       // what is called when using validateForm.
 
-      if (
-        fieldRegistry.current !== null &&
-        fieldRegistry.current[name] &&
-        fieldRegistry.current[name].validate &&
-        isFunction(fieldRegistry.current[name].validate)
-      ) {
+      if (isFunction(fieldRegistry.current[name].validate)) {
         const value = getIn(state.values, name);
         const maybePromise = fieldRegistry.current[name].validate(value);
         if (isPromise(maybePromise)) {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -330,7 +330,7 @@ export function useFormik<Values = object>({
         ) {
           dispatch({ type: 'SET_ERRORS', payload: combinedErrors });
         }
-        if (isMounted.current != null) {
+        if (isMounted.current === true) {
           dispatch({ type: 'SET_ISVALIDATING', payload: false });
         }
         return combinedErrors;

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -216,7 +216,7 @@ export function useFormik<Values = object>({
         resolve(fieldRegistry.current[field].validate(value))
       );
     },
-    [fieldRegistry]
+    []
   );
 
   const runFieldLevelValidations = React.useCallback(
@@ -250,7 +250,7 @@ export function useFormik<Values = object>({
         }, {})
       );
     },
-    [runSingleFieldLevelValidation, fieldRegistry]
+    [runSingleFieldLevelValidation]
   );
 
   // Run all validations and return the result
@@ -422,24 +422,18 @@ export function useFormik<Values = object>({
         return Promise.resolve();
       }
     },
-    [state.values, fieldRegistry]
+    [state.values]
   );
 
-  const registerField = React.useCallback(
-    (name: string, { validate }: any) => {
-      fieldRegistry.current[name] = {
-        validate,
-      };
-    },
-    [fieldRegistry]
-  );
+  const registerField = React.useCallback((name: string, { validate }: any) => {
+    fieldRegistry.current[name] = {
+      validate,
+    };
+  }, []);
 
-  const unregisterField = React.useCallback(
-    (name: string) => {
-      delete fieldRegistry.current[name];
-    },
-    [fieldRegistry]
-  );
+  const unregisterField = React.useCallback((name: string) => {
+    delete fieldRegistry.current[name];
+  }, []);
 
   const setTouched = React.useCallback(
     (touched: FormikTouched<Values>) => {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -324,13 +324,8 @@ export function useFormik<Values = object>({
       }
       dispatch({ type: 'SET_ISVALIDATING', payload: true });
       return runAllValidations(values).then(combinedErrors => {
-        if (
-          !isEqual(state.errors, combinedErrors) &&
-          isMounted.current != null
-        ) {
+        if (!!isMounted.current && !isEqual(state.errors, combinedErrors)) {
           dispatch({ type: 'SET_ERRORS', payload: combinedErrors });
-        }
-        if (isMounted.current === true) {
           dispatch({ type: 'SET_ISVALIDATING', payload: false });
         }
         return combinedErrors;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,30 +60,6 @@ export function getActiveElement(doc?: Document): Element | null {
 }
 
 /**
- * Make a promise cancellable by @istarkov
- * @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
- */
-export function makeCancelable<T extends Promise<any>>(
-  promise: T
-): [T, () => void] {
-  let hasCanceled = false;
-
-  const wrappedPromise: any = new Promise((resolve, reject) => {
-    promise.then(
-      val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)),
-      error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
-    );
-  });
-
-  return [
-    wrappedPromise,
-    function cancel() {
-      hasCanceled = true;
-    },
-  ];
-}
-
-/**
  * Deeply get a value from an object via its path.
  */
 export function getIn(

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -3,7 +3,6 @@ import {
   setNestedObjectValues,
   isPromise,
   getActiveElement,
-  makeCancelable,
   isNaN,
 } from '../src/utils';
 
@@ -301,64 +300,6 @@ describe('utils', () => {
     it('test getActiveElement with valid document', () => {
       const result = getActiveElement(document);
       expect(result).toEqual(document.body);
-    });
-  });
-
-  describe('makeCancelable', () => {
-    it('correctly call promise without cancel', async () => {
-      const PromiseToResolve = () => {
-        return Promise.resolve('test');
-      };
-
-      const [updatedPromise] = makeCancelable(PromiseToResolve());
-
-      const result = await (() => {
-        return updatedPromise;
-      })();
-
-      expect(result).toEqual('test');
-    });
-
-    it('correctly cancel successful promise', async () => {
-      const PromiseToResolve = () => {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve('test');
-          }, 10);
-        });
-      };
-
-      const [updatedPromise, cancel] = makeCancelable(PromiseToResolve());
-
-      cancel();
-      try {
-        await (() => {
-          return updatedPromise;
-        })();
-      } catch (e) {
-        expect(e).toEqual({ isCanceled: true });
-      }
-    });
-
-    it('correctly cancel rejected promise', async () => {
-      const PromiseToResolve = () => {
-        return new Promise((_, reject) => {
-          setTimeout(() => {
-            reject('test');
-          }, 100);
-        });
-      };
-
-      const [updatedPromise, cancel] = makeCancelable(PromiseToResolve());
-
-      cancel();
-      try {
-        await (() => {
-          return updatedPromise;
-        })();
-      } catch (e) {
-        expect(e).toEqual({ isCanceled: true });
-      }
     });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,3 +34,4 @@ declare module 'deepmerge' {
     function all<T>(objects: Array<Partial<T>>, options?: Options): T;
   }
 }
+declare module 'scheduler';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9598,7 +9598,7 @@ scheduler@^0.13.6:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.14.0-alpha.0:
+scheduler@^0.14.0, scheduler@^0.14.0-alpha.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
   integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==


### PR DESCRIPTION
After thinking more deeply about useEffect in v2, I don't think `useEffect()` is suitable for modeling Formik's validation strategies. In the current version of v2, Formik is over-validating and there is no way to avoid validating on change because the "validateOnBlur"-effect depends on `state.values`. This dependency got me thinking that useEffect isn't the correct approach (furthermore, this was going to be a breaking change too).

This PR refactors validation so that it is overridable just like Formik 1.x. Furthermore, validation triggered as a side effect of an update (i.e. `handleChange`, `setFieldValue`, `setValues`, `handleBlur`, `setFieldTouched`, `setTouched`) is now wrapped in `scheduler`'s `unstable_runWithPriority`. This tells React that the resulting update to `state.errors` is low-priority (or non-user-blocking). AFAICT, this is correct model of validation for onChange/onBlur. Conversely, validation triggered imperatively or during pre-submit via `validateForm`, `validateField`, `submitForm`, `handleSubmit` is the same as it was (high-pri/user-blocking). 


In a different PR, I want to play around with removing async validation entirely from Formik. The thinking is the same as rationale as to why you should not use something like Redux for making async requests, but instead just use it a store. 


Anyways, open to ideas. I also now need to fixup the tests to flush out some stuff. 
