### PR TITLE
Fixes #1489: Allow error value to be any

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -11,9 +11,7 @@ export interface FormikValues {
  * Should be always be and object of strings, but any is allowed to support i18n libraries.
  */
 export type FormikErrors<Values> = {
-  [K in keyof Values]?: Values[K] extends object
-    ? FormikErrors<Values[K]>
-    : string
+  [K in keyof Values]?: any;
 };
 
 /**


### PR DESCRIPTION
See https://github.com/jaredpalmer/formik/issues/1489

The current typing of errors is incorrect, Formik allows setting error state to more than a string. In my case, I need to set the value to a `JSX.Element`.