### PR TITLE
Resetting a form using the nextState-argument sets errors and touched to nextState.values

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -320,13 +320,13 @@ export function useFormik<Values = object>({
           : props.initialValues;
       const errors =
         nextState && nextState.errors
-          ? nextState.values
+          ? nextState.errors
           : initialErrors.current
           ? initialErrors.current
           : props.initialErrors || {};
       const touched =
         nextState && nextState.touched
-          ? nextState.values
+          ? nextState.touched
           : initialTouched.current
           ? initialTouched.current
           : props.initialTouched || {};


### PR DESCRIPTION
When using the `nextState` argument when resetting a form the `errors` and `touched` properties are both set to `nextState.values` instead of the values specified in `nextState`.