### PR TITLE
Mimic class properties with useEventCallback

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -13,11 +13,14 @@ import SchemaValidation from '../examples/SchemaValidation';
 import SyncValidation from '../examples/SyncValidation';
 import FieldLevelValidation from '../examples/FieldLevelValidation';
 import CombinedValidations from '../examples/CombinedValidations';
+import DebouncedAutoSave from '../examples/DebouncedAutoSave';
 
 const AsyncValidationCode = require('!raw-loader!../examples/AsyncValidation')
   .default;
 const ArraysCode = require('!raw-loader!../examples/Arrays').default;
 const BasicCode = require('!raw-loader!../examples/Basic.js').default;
+const DebouncedAutoSaveCode = require('!raw-loader!../examples/DebouncedAutoSave.js')
+  .default;
 const CustomInputsCode = require('!raw-loader!../examples/CustomInputs')
   .default;
 const ErrorMessageCode = require('!raw-loader!../examples/ErrorMessage')
@@ -114,6 +117,16 @@ storiesOf('Example', module)
           <CustomInputs />
         </main>
         <Code>{cleanExample(CustomInputsCode)}</Code>
+      </div>
+    );
+  })
+  .add('Debounced AutoSave', () => {
+    return (
+      <div className="formik-example">
+        <main>
+          <DebouncedAutoSave />
+        </main>
+        <Code>{cleanExample(DebouncedAutoSaveCode)}</Code>
       </div>
     );
   })

--- a/examples/DebouncedAutoSave.js
+++ b/examples/DebouncedAutoSave.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useFormikContext, Formik, Field, Form } from 'formik';
+import { Debug } from './Debug';
+import debounce from 'just-debounce-it';
+
+const AutoSave = ({ debounceMs }) => {
+  const formik = useFormikContext();
+  const [lastSaved, setLastSaved] = React.useState(null);
+  const debouncedSubmit = React.useCallback(
+    debounce(
+      () =>
+        formik.submitForm().then(() => setLastSaved(new Date().toISOString())),
+      debounceMs
+    ),
+    [debounceMs, formik.submitForm]
+  );
+
+  React.useEffect(() => {
+    debouncedSubmit();
+  }, [debouncedSubmit, formik.values]);
+
+  return (
+    <>
+      {!!formik.isSubmitting
+        ? 'saving...'
+        : lastSaved !== null
+        ? `Last Saved: ${lastSaved}`
+        : null}
+    </>
+  );
+};
+
+const AutoSavingForm = () => (
+  <div>
+    <Formik
+      initialValues={{
+        firstName: '',
+        lastName: '',
+        email: '',
+      }}
+      onSubmit={(values, { setSubmitting }) => {
+        return new Promise(resolve =>
+          setTimeout(() => {
+            console.log('submitted', JSON.stringify(values, null, 2));
+            setSubmitting(false);
+            resolve();
+          }, 1000)
+        );
+      }}
+      render={() => (
+        <Form>
+          <h1>
+            AutoSavingForm{' '}
+            <small style={{ color: 'gray', fontSize: 11 }}>
+              <AutoSave debounceMs={300} />
+            </small>
+          </h1>
+
+          <label htmlFor="firstName">First Name</label>
+          <Field name="firstName" placeholder="Jane" />
+
+          <label htmlFor="lastName">Last Name</label>
+          <Field name="lastName" placeholder="Doe" />
+
+          <label htmlFor="email">Email</label>
+          <Field name="email" placeholder="jane@acme.com" type="email" />
+          <button type="submit">Submit</button>
+
+          <Debug />
+        </Form>
+      )}
+    />
+  </div>
+);
+
+export default AutoSavingForm;

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-hooks": "1.5.0",
     "husky": "0.14.3",
+    "just-debounce-it": "^1.1.0",
     "lint-staged": "4.0.2",
     "prettier": "^1.17.1",
     "raw-loader": "^2.0.0",

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -116,7 +116,7 @@ interface FieldRegistry {
 }
 const emptyFieldRegistry: FieldRegistry = {};
 
-export function useFormik<Values = object>({
+function useFormikInternal<Values = object>({
   validateOnChange = true,
   validateOnBlur = true,
   isInitialValid,
@@ -792,7 +792,7 @@ export function useFormik<Values = object>({
 export function Formik<Values = object, ExtraProps = {}>(
   props: FormikConfig<Values> & ExtraProps
 ) {
-  const formikbag = useFormik<Values>(props);
+  const formikbag = useFormikInternal<Values>(props);
   const { component, children, render } = props;
   return (
     <FormikProvider value={formikbag}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,6 +6887,11 @@ jsx-ast-utils@^2.0.1, jsx-ast-utils@^2.1.0:
   dependencies:
     array-includes "^3.0.3"
 
+just-debounce-it@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/just-debounce-it/-/just-debounce-it-1.1.0.tgz#8e92578effc155358a44f458c52ffbee66983bef"
+  integrity sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg==
+
 keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"


### PR DESCRIPTION
In v1, all helper methods we class properties. This meant that they were bound to the instance of the class. However, with hooks, there is no concept of `this` and each helper method is wrapped in `useCallback`. However, certain behaviors (e.g. auto-saving) are not possible because of circular `useCallback` dependencies. For example, `submitForm` depends on `values`, so if you change `values`, then `submitForm` will be different. This prevents you from debouncing `submitForm` in response to `values` because you get a brand new function on each change. Sadness.

[The suggested solution in the React docs](https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback) is to use this hook:

```jsx
function Form() {
  const [text, updateText] = useState('');
  // Will be memoized even if `text` changes:
  const handleSubmit = useEventCallback(() => {
    alert(text);
  }, [text]);

  return (
    <>
      <input value={text} onChange={e => updateText(e.target.value)} />
      <ExpensiveTree onSubmit={handleSubmit} />
    </>
  );
}

function useEventCallback(fn, dependencies) {
  const ref = useRef(() => {
    throw new Error('Cannot call an event handler while rendering.');
  });

  useEffect(() => {
    ref.current = fn;
  }, [fn, ...dependencies]);

  return useCallback(() => {
    const fn = ref.current;
    return fn();
  }, [ref]);
}
```

This PR adds this hook internally and utilizes it where necessary (on any callback that relies on `state`). It also adds a new `DebouncedAutoSave` example to the examples directory. 


