### PR TITLE
Optionally show multiple validation errors per field

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -191,12 +191,20 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * A Yup Schema or a function that returns a Yup schema
    */
   validationSchema?: any | (() => any);
+  /**
+   * Additional options relating to validationSchema
+   */
+  validationSchemaOptions?: ValidationSchemaOptions;
 
   /**
    * Validation function. Must return an error object or promise that
    * throws an error object where that object keys map to corresponding value.
    */
   validate?: (values: Values) => void | object | Promise<FormikErrors<Values>>;
+}
+
+export interface ValidationSchemaOptions {
+  showMultipleFieldErrors?: boolean;
 }
 
 /**
@@ -252,7 +260,7 @@ export interface FieldMetaProps<Value> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: string | string[];
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -1091,4 +1091,21 @@ describe('<Formik>', () => {
       users: [{ firstName: 'required', lastName: 'required' }],
     });
   });
+
+  it('respects the validationSchemaOptions prop', async () => {
+    const validationSchema = Yup.object().shape({
+      firstName: Yup.string().required('required'),
+    });
+
+    const { getProps } = renderFormik({
+      initialValues: { users: [{ firstName: '' }] },
+      validationSchema,
+      validationSchemaOptions: { showMultipleFieldErrors: true },
+    });
+
+    await getProps().validateForm();
+    expect(getProps().errors).toEqual({
+      firstName: ['required'],
+    });
+  });
 });

--- a/test/yupHelpers.test.ts
+++ b/test/yupHelpers.test.ts
@@ -3,6 +3,9 @@ import { validateYupSchema, yupToFormErrors } from '../src';
 const Yup = require('yup');
 const schema = Yup.object().shape({
   name: Yup.string('Name must be a string').required('required'),
+  num: Yup.number()
+    .min(1, 'must be greater than or equal to 1')
+    .integer('must be an integer'),
 });
 
 describe('Yup helpers', () => {
@@ -11,8 +14,19 @@ describe('Yup helpers', () => {
       try {
         await schema.validate({}, { abortEarly: false });
       } catch (e) {
-        expect(yupToFormErrors(e)).toEqual({
+        expect(yupToFormErrors(e, { showMultipleFieldErrors: false })).toEqual({
           name: 'required',
+        });
+      }
+    });
+
+    it('should return an array for each field when showMultipleFieldErrors is enabled', async () => {
+      try {
+        await schema.validate({ name: '', num: 0.1 }, { abortEarly: false });
+      } catch (e) {
+        expect(yupToFormErrors(e, { showMultipleFieldErrors: true })).toEqual({
+          name: ['required'],
+          num: ['must be greater than or equal to 1', 'must be an integer'],
         });
       }
     });


### PR DESCRIPTION
This PR adds a new prop called `validationSchemaOptions` to add the feature described here:
https://github.com/jaredpalmer/formik/issues/243

Example usage:

```js
  <Formik
    validationSchema={validationSchema}
    validationSchemaOptions={{ showMultipleFieldErrors: true }}
    ...
```

`showMultipleFieldErrors` is false by default, to maintain consistency with the current behavior of returning just a single string per field.