### PR TITLE
[v2] Breaking: Change async validate to resolve errors

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -56,9 +56,9 @@ const BasicExample = () => (
 
 There are three ways to render things with `<Formik />`
 
-* `<Formik component>`
-* `<Formik render>`
-* `<Formik children>`
+- `<Formik component>`
+- `<Formik render>`
+- `<Formik children>`
 
 All three render methods will be passed the same props:
 
@@ -131,7 +131,7 @@ Set the touched state of a field imperatively. `field` should match the key of
 
 #### `submitForm: () => Promise`
 
-Trigger a form submission. The promise will be rejected if form is invalid. 
+Trigger a form submission. The promise will be rejected if form is invalid.
 
 #### `submitCount: number`
 
@@ -359,7 +359,7 @@ const validate = values => {
 };
 ```
 
-* Asynchronous and return a Promise that's error in an `errors` object
+- Asynchronous and return a Promise that's resolves to an object containing `errors`
 
 ```js
 // Async Validation
@@ -372,9 +372,7 @@ const validate = values => {
       errors.username = 'Nice try';
     }
     // ...
-    if (Object.keys(errors).length) {
-      throw errors;
-    }
+    return errors;
   });
 };
 ```

--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -4,7 +4,7 @@ title: useField()
 custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/usefield.md
 ---
 
-`useField` is a custom React hook that will automagically help you hook up inputs to Formik. You can and should use it build your own custom input primitives.
+`useField` is a custom React hook that will automagically help you hook up inputs to Formik. You can and should use it build your own custom input primitives. There are 2 ways to use it.
 
 ## Example
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -17,8 +17,8 @@ Form-level validation is useful because you have complete access to all of your 
 
 There are 2 ways to do form-level validation with Formik:
 
-* `<Formik validate>` and `withFormik({ validate: ... })`
-* `<Formik validationSchema>` and `withFormik({ validationSchema: ... })`
+- `<Formik validate>` and `withFormik({ validate: ... })`
+- `<Formik validationSchema>` and `withFormik({ validationSchema: ... })`
 
 #### `validate`
 
@@ -50,9 +50,7 @@ const validate = (values, props /* only available when using withFormik */) => {
       errors.username = 'Nice try';
     }
     // ...
-    if (Object.keys(errors).length) {
-      throw errors;
-    }
+    return errors;
   });
 };
 ```
@@ -262,25 +260,25 @@ You can control when Formik runs validation by changing the values of `<Formik v
 
 **After "change" events/methods** (things that update`values`)
 
-* `handleChange`
-* `setFieldValue`
-* `setValues`
+- `handleChange`
+- `setFieldValue`
+- `setValues`
 
 **After "blur" events/methods** (things that update `touched`)
 
-* `handleBlur`
-* `setTouched`
-* `setFieldTouched`
+- `handleBlur`
+- `setTouched`
+- `setFieldTouched`
 
 **Whenever submission is attempted**
 
-* `handleSubmit`
-* `submitForm`
+- `handleSubmit`
+- `submitForm`
 
 There are also imperative helper methods provided to you via Formik's render/injected props which you can use to imperatively call validation.
 
-* `validateForm`
-* `validateField`
+- `validateForm`
+- `validateField`
 
 ## Displaying Error Messages
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -68,7 +68,7 @@ export type FieldAttributes<T> = GenericFieldHTMLAttributes & FieldConfig & T;
 
 export function useField<Val = any>(name: string, type?: string) {
   const formik = useFormikContext();
-  if (process.env.NODE_ENV !== 'production') {
+  if (__DEV__) {
     invariant(
       formik,
       'useField() / <Field /> must be used underneath a <Formik> component or withFormik() higher order component'
@@ -93,7 +93,7 @@ export function Field({
   } = useFormikContext();
 
   React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (__DEV__) {
       invariant(
         !render,
         `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Field name="${name}" render={({field, form}) => ...} /> with <Field name="${name}">{({field, form, meta}) => ...}</Field>`

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -47,7 +47,7 @@ export interface FieldConfig {
   /**
    * Validate a single field value independently
    */
-  validate?: (value: any) => string | Promise<void> | undefined;
+  validate?: (value: any) => string | Promise<string | void> | undefined;
 
   /**
    * Field name

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -68,7 +68,7 @@ export type FieldAttributes<T> = GenericFieldHTMLAttributes & FieldConfig & T;
 
 export function useField<Val = any>(name: string, type?: string) {
   const formik = useFormikContext();
-  if (__DEV__) {
+  if (process.env.NODE_ENV !== 'production') {
     invariant(
       formik,
       'useField() / <Field /> must be used underneath a <Formik> component or withFormik() higher order component'
@@ -93,7 +93,7 @@ export function Field({
   } = useFormikContext();
 
   React.useEffect(() => {
-    if (__DEV__) {
+    if (process.env.NODE_ENV !== 'production') {
       invariant(
         !render,
         `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Field name="${name}" render={({field, form}) => ...} /> with <Field name="${name}">{({field, form, meta}) => ...}</Field>`

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -162,7 +162,7 @@ function useFormikInternal<Values = object>({
 
   const runValidateHandler = React.useCallback(
     (values: Values, field?: string): Promise<FormikErrors<Values>> => {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         const maybePromisedErrors = (props.validate as any)(values, field);
         if (!maybePromisedErrors) {
           resolve(emptyErrors);
@@ -175,7 +175,7 @@ function useFormikInternal<Values = object>({
               console.warn(
                 'Your validate function threw an error. In Formik 2.x, your validate function should resolve to an object if there are validation errors (instead of throwing them).'
               );
-              reject(realError);
+              throw realError;
             }
           );
         } else {
@@ -191,7 +191,7 @@ function useFormikInternal<Values = object>({
    */
   const runValidationSchema = React.useCallback(
     (values: Values, field?: string) => {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         const validationSchema = props.validationSchema;
         const schema = isFunction(validationSchema)
           ? validationSchema(field)
@@ -206,14 +206,14 @@ function useFormikInternal<Values = object>({
           },
           (err: any) => {
             // Yup will throw a validation error if validation fails. We catch those and
-            // turn them into Formik errors. We can sniff is something is a Yup error
+            // resolve them into Formik errors. We can sniff is something is a Yup error
             // by checking error.name.
             // @see https://github.com/jquense/yup#validationerrorerrors-string--arraystring-value-any-path-string
             if (err.name === 'ValidationError') {
               resolve(yupToFormErrors(err));
             } else {
-              // We reject any other errors
-              reject(err);
+              // We throw any other errors
+              throw err;
             }
           }
         );

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -164,7 +164,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     (values: Values, field?: string): Promise<FormikErrors<Values>> => {
       return new Promise((resolve, reject) => {
         const maybePromisedErrors = (props.validate as any)(values, field);
-        if (!maybePromisedErrors) {
+        if (maybePromisedErrors == null) {
+          // use loose null check here on purpose
           resolve(emptyErrors);
         } else if (isPromise(maybePromisedErrors)) {
           (maybePromisedErrors as Promise<any>).then(

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -152,8 +152,8 @@ function useFormikInternal<Values = object>({
     React.Reducer<FormikState<Values>, FormikMessage<Values>>
   >(formikReducer, {
     values: props.initialValues,
-    errors: props.initialErrors || {},
-    touched: props.initialTouched || {},
+    errors: props.initialErrors || emptyErrors,
+    touched: props.initialTouched || emptyTouched,
     status: props.initialStatus,
     isSubmitting: false,
     isValidating: false,
@@ -169,7 +169,7 @@ function useFormikInternal<Values = object>({
         } else if (isPromise(maybePromisedErrors)) {
           (maybePromisedErrors as Promise<any>).then(
             errors => {
-              resolve(errors || {});
+              resolve(errors || emptyErrors);
             },
             realError => {
               if (process.env.NODE_ENV !== 'production') {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -171,15 +171,15 @@ function useFormikInternal<Values = object>({
             errors => {
               resolve(errors || emptyErrors);
             },
-            realError => {
+            actualException => {
               if (process.env.NODE_ENV !== 'production') {
                 console.warn(
                   `Warning: An unhandled error was caught during validation in <Formik validate />`,
-                  realError
+                  actualException
                 );
               }
 
-              reject(realError);
+              reject(actualException);
             }
           );
         } else {

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -369,7 +369,7 @@ describe('Field / FastField', () => {
     cases(
       'runs validation when validateField is called (ASYNC)',
       async renderField => {
-        const validate = jest.fn(() => Promise.reject('Error!'));
+        const validate = jest.fn(() => Promise.resolve('Error!'));
 
         const { getFormProps, rerender } = renderField({ validate });
 

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -465,22 +465,22 @@ describe('<Formik>', () => {
 
       it('should not submit the form if validate function throws an error', async () => {
         const onSubmit = jest.fn();
-        const validate = jest.fn(() => {
-          throw new Error('Oops');
-        });
+        const err = new Error('Async Error');
+        const validate = jest.fn().mockRejectedValue(err);
         const { getProps } = renderFormik({
           onSubmit,
           validate,
         });
 
-        await getProps().submitForm();
+        await expect(getProps().submitForm()).rejects.toThrow('Async Error');
 
         await wait(() => {
           expect(onSubmit).not.toBeCalled();
           expect(global.console.warn).toHaveBeenCalledWith(
             expect.stringMatching(
               /Warning: An unhandled error was caught during validation in <Formik validate ./
-            )
+            ),
+            err
           );
         });
       });
@@ -515,24 +515,20 @@ describe('<Formik>', () => {
 
       it('should not submit the form if validate function rejects with an error', async () => {
         const onSubmit = jest.fn();
-
-        const validate = jest.fn(
-          () =>
-            new Promise(() => {
-              throw new Error('Oops');
-            })
-        );
+        const err = new Error('Async Error');
+        const validate = jest.fn().mockRejectedValue(err);
 
         const { getProps } = renderFormik({ onSubmit, validate });
 
-        await getProps().submitForm();
+        await expect(getProps().submitForm()).rejects.toThrow('Async Error');
 
         await wait(() => {
           expect(onSubmit).not.toBeCalled();
           expect(global.console.warn).toHaveBeenCalledWith(
             expect.stringMatching(
               /Warning: An unhandled error was caught during validation in <Formik validate ./
-            )
+            ),
+            err
           );
         });
       });

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -462,6 +462,28 @@ describe('<Formik>', () => {
         fireEvent.submit(getByTestId('form'));
         expect(onSubmit).not.toBeCalled();
       });
+
+      it('should not submit the form if validate function throws an error', async () => {
+        const onSubmit = jest.fn();
+        const validate = jest.fn(() => {
+          throw new Error('Oops');
+        });
+        const { getProps } = renderFormik({
+          onSubmit,
+          validate,
+        });
+
+        await getProps().submitForm();
+
+        await wait(() => {
+          expect(onSubmit).not.toBeCalled();
+          expect(global.console.warn).toHaveBeenCalledWith(
+            expect.stringMatching(
+              /Warning: An unhandled error was caught during validation in <Formik validate ./
+            )
+          );
+        });
+      });
     });
 
     describe('with validate (ASYNC)', () => {
@@ -489,6 +511,30 @@ describe('<Formik>', () => {
 
         fireEvent.submit(getByTestId('form'));
         expect(onSubmit).not.toBeCalled();
+      });
+
+      it('should not submit the form if validate function rejects with an error', async () => {
+        const onSubmit = jest.fn();
+
+        const validate = jest.fn(
+          () =>
+            new Promise(() => {
+              throw new Error('Oops');
+            })
+        );
+
+        const { getProps } = renderFormik({ onSubmit, validate });
+
+        await getProps().submitForm();
+
+        await wait(() => {
+          expect(onSubmit).not.toBeCalled();
+          expect(global.console.warn).toHaveBeenCalledWith(
+            expect.stringMatching(
+              /Warning: An unhandled error was caught during validation in <Formik validate ./
+            )
+          );
+        });
       });
     });
 


### PR DESCRIPTION
- async `<Formik validate />` and `<Field validate>` should now resolve errors object or string (instead of throwing it). IIRC I kept redux-form's API when adding this initially, but this is dumb because all errors have been swallowed.
- `validationSchema` will now throw non-yup validation errors instead of swallowing them.

Both of these are breaking changes, but they are relatively small. 