### PR TITLE
documentation - enableReinitialize - note suggestion

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -275,8 +275,8 @@ Default is `false`. Control whether Formik should reset the form if
 `initialValues` changes (using deep equality).
 
 Note: `enableReinitialize` will break the form `initialValues`, 
-meaning the form won't be pristine anymore, but dirty. You shouldn't 
-render form until all props are fetched by using a Loader, for instance. 
+meaning the form won't stay pristine. You shouldn't 
+render the form until all props are fetched (by using a Loader, for instance). 
 Also, remember that `enableReinitialize` will re-render your form and all 
 chidren components when the props change, so try not using it in production 
 if you are not sure how to use it.

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -274,6 +274,13 @@ don’t use both in the same `<Formik>`.
 Default is `false`. Control whether Formik should reset the form if
 `initialValues` changes (using deep equality).
 
+Note: `enableReinitialize` will break the form `initialValues`, 
+meaning the form won't be pristine anymore, but dirty. You shouldn't 
+render form until all props are fetched by using a Loader, for instance. 
+Also, remember that `enableReinitialize` will re-render your form and all 
+chidren components when the props change, so try not using it in production 
+if you are not sure how to use it.
+
 ### `isInitialValid?: boolean`
 
 **Deprecated in 2.x, use `initialErrors` instead**

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -274,12 +274,11 @@ don’t use both in the same `<Formik>`.
 Default is `false`. Control whether Formik should reset the form if
 `initialValues` changes (using deep equality).
 
-Note: `enableReinitialize` will break the form `initialValues`, 
-meaning the form won't stay pristine. You shouldn't render the form 
-until all props are fetched (by using a Loader, for instance). 
-Also, remember that `enableReinitialize` will re-render your form and all 
-chidren components when the props change, so try not using it in production 
-if you are not sure how to use it.
+Note: `enableReinitialize` will change the form `initialValues`.
+You shouldn't render the form until all props are fetched 
+(by using a Loader, for instance). Also, remember that `enableReinitialize` 
+will re-render your form and all chidren components when the props change, 
+so try not using it in production if you are not sure how to use it.
 
 ### `isInitialValid?: boolean`
 

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -275,8 +275,8 @@ Default is `false`. Control whether Formik should reset the form if
 `initialValues` changes (using deep equality).
 
 Note: `enableReinitialize` will break the form `initialValues`, 
-meaning the form won't stay pristine. You shouldn't 
-render the form until all props are fetched (by using a Loader, for instance). 
+meaning the form won't stay pristine. You shouldn't render the form 
+until all props are fetched (by using a Loader, for instance). 
 Also, remember that `enableReinitialize` will re-render your form and all 
 chidren components when the props change, so try not using it in production 
 if you are not sure how to use it.

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -274,11 +274,11 @@ don’t use both in the same `<Formik>`.
 Default is `false`. Control whether Formik should reset the form if
 `initialValues` changes (using deep equality).
 
-Note: `enableReinitialize` will change the form `initialValues`.
-You shouldn't render the form until all props are fetched 
-(by using a Loader, for instance). Also, remember that `enableReinitialize` 
-will re-render your form and all chidren components when the props change, 
-so try not using it in production if you are not sure how to use it.
+Note: `enableReinitialize` will change the form `initialValues`. 
+Remember that `enableReinitialize` will re-render your form 
+and all chidren components when the props change, so you 
+shouldn't render the form until all props are fetched 
+(by using a Loader, for instance).
 
 ### `isInitialValid?: boolean`
 


### PR DESCRIPTION
At work we had performance issue, we have a pretty big form that was having a hard time to load, around 10 seconds, and one of the main reason was the use of this prop, causing ~10 re-renders on mount, now only 1. so I recommand using this prop to debug your form and remove it after. btw, the other thing we did was adding more memoize functions and selectors (store redux). now the form loads in 2-3 seconds, which is great considering how many values it has.

edit: also, #181 this is an issue to have a prop that will keep the form `dirty` when `enableReinitialize` is triggered instead of reapplying `pristine`, could make it worse. It's useful to know for a big form if the user can leave the page, so by looking at the form status `pristine`. I think the solution is not using the `enableReinitialize`, and keeping at the same time the pristine state of the form.