### PR TITLE
Update type of resetForm to accept Partial<S>

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -335,7 +335,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   const resetForm = React.useCallback(
-    (nextState?: FormikState<Values>) => {
+    (nextState?: Partial<FormikState<Values>>) => {
       const values =
         nextState && nextState.values
           ? nextState.values

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -88,7 +88,7 @@ export interface FormikHelpers<Values> {
   /** Validate field value */
   validateField(field: string): void;
   /** Reset form */
-  resetForm(nextState?: FormikState<Values>): void;
+  resetForm(nextState?: Partial<FormikState<Values>>): void;
   /** Set Formik state, careful! */
   setFormikState(
     f:


### PR DESCRIPTION
**Before**
Calling `resetForm` without passing a full state object yielded this TS error:

```Type '{ values: { email: string; }; }' is missing the following properties from type 'FormikState<{ email: string; }>': errors, touched, isSubmitting, isValidating, submitCount  TS2345```

**After**
No error when passing partial state object to `resetForm`

