### PR TITLE
Warn consumers when Formik context is undefined

### DIFF
--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
 import { FormikContext } from './types';
+import invariant from 'tiny-warning';
 
 const PrivateFormikContext = React.createContext<FormikContext<any>>({} as any);
 export const FormikProvider = PrivateFormikContext.Provider;
 export const FormikConsumer = PrivateFormikContext.Consumer;
 
 export function useFormikContext<Values>() {
-  return React.useContext<FormikContext<Values>>(PrivateFormikContext);
+  const formik = React.useContext<FormikContext<Values>>(PrivateFormikContext);
+
+  invariant(
+    !formik,
+    `Formik context is undefined, please verify you are calling useFormikContext() as child of a <Formik> component.`
+  );
+
+  return formik;
 }

--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -10,7 +10,7 @@ export function useFormikContext<Values>() {
   const formik = React.useContext<FormikContext<Values>>(PrivateFormikContext);
 
   invariant(
-    !formik,
+    !!formik,
     `Formik context is undefined, please verify you are calling useFormikContext() as child of a <Formik> component.`
   );
 

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -3,6 +3,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { FormikContext } from './types';
 import { FormikConsumer } from './FormikContext';
+import invariant from 'tiny-warning';
 
 /**
  * Connect any component to Formik context, and inject as a prop called `formik`;
@@ -13,7 +14,15 @@ export function connect<OuterProps, Values = {}>(
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (
     <FormikConsumer>
-      {formik => <Comp {...props} formik={formik} />}
+      {formik => {
+        invariant(
+          !formik,
+          `Formik context is undefined, please verify you are rendering <Form>, <Field>, <FastField>, <FieldArray>, or your custom context-using component as a child of a <Formik> component. Component name: ${
+            Comp.name
+          }`
+        );
+        return <Comp {...props} formik={formik} />;
+      }}
     </FormikConsumer>
   );
   const componentDisplayName =

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -16,7 +16,7 @@ export function connect<OuterProps, Values = {}>(
     <FormikConsumer>
       {formik => {
         invariant(
-          !formik,
+          !!formik,
           `Formik context is undefined, please verify you are rendering <Form>, <Field>, <FastField>, <FieldArray>, or your custom context-using component as a child of a <Formik> component. Component name: ${
             Comp.name
           }`


### PR DESCRIPTION
Continue #1470, but for v2.

Related to #1368 and then #1467