### PR TITLE
Missing shouldValidate parameter from typings

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -86,11 +86,11 @@ export interface FormikHelpers<Values> {
   /** Manually set values object  */
   setValues(values: Values): void;
   /** Set value of form field directly */
-  setFieldValue(field: keyof Values & string, value: any): void;
+  setFieldValue(field: keyof Values & string, value: any, shouldValidate?: boolean): void;
   /** Set error message of a form field directly */
   setFieldError(field: keyof Values & string, message: string): void;
   /** Set whether field has been touched directly */
-  setFieldTouched(field: keyof Values & string, isTouched?: boolean): void;
+  setFieldTouched(field: keyof Values & string, isTouched?: boolean, shouldValidate?: boolean): void;
   /** Validate form values */
   validateForm(values?: any): Promise<FormikErrors<Values>>;
   /** Validate field value */


### PR DESCRIPTION
The `FormikHelpers`-type is currently missing the parameter `shouldValidate?: boolean` from `setFieldValue` and `setFieldTouched`.