### PR TITLE
Consolidate types for field validate fn

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -4,6 +4,7 @@ import {
   GenericFieldHTMLAttributes,
   FieldMetaProps,
   FieldInputProps,
+  FieldValidate,
 } from './types';
 import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren, isObject } from './utils';
@@ -47,7 +48,7 @@ export interface FieldConfig {
   /**
    * Validate a single field value independently
    */
-  validate?: (value: any) => string | Promise<string | void> | undefined;
+  validate?: FieldValidate;
 
   /**
    * Field name

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -4,7 +4,7 @@ import {
   GenericFieldHTMLAttributes,
   FieldMetaProps,
   FieldInputProps,
-  FieldValidate,
+  FieldValidator,
 } from './types';
 import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren, isObject } from './utils';
@@ -48,7 +48,7 @@ export interface FieldConfig {
   /**
    * Validate a single field value independently
    */
-  validate?: FieldValidate;
+  validate?: FieldValidator;
 
   /**
    * Field name

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -227,7 +227,7 @@ export type FormikProps<Values> = FormikSharedConfig &
 
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {
-  registerField(name: string, fns: { validate?: FieldValidate }): void;
+  registerField(name: string, fns: { validate?: FieldValidator }): void;
   unregisterField(name: string): void;
 }
 
@@ -291,4 +291,4 @@ export interface FieldInputProps<Value> {
   onBlur: FormikHandlers['handleBlur'];
 }
 
-export type FieldValidate = (value: any) => string | Promise<string | void>;
+export type FieldValidator = (value: any) => string | Promise<string | void>;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -86,11 +86,19 @@ export interface FormikHelpers<Values> {
   /** Manually set values object  */
   setValues(values: Values): void;
   /** Set value of form field directly */
-  setFieldValue(field: keyof Values & string, value: any, shouldValidate?: boolean): void;
+  setFieldValue(
+    field: keyof Values & string,
+    value: any,
+    shouldValidate?: boolean
+  ): void;
   /** Set error message of a form field directly */
   setFieldError(field: keyof Values & string, message: string): void;
   /** Set whether field has been touched directly */
-  setFieldTouched(field: keyof Values & string, isTouched?: boolean, shouldValidate?: boolean): void;
+  setFieldTouched(
+    field: keyof Values & string,
+    isTouched?: boolean,
+    shouldValidate?: boolean
+  ): void;
   /** Validate form values */
   validateForm(values?: any): Promise<FormikErrors<Values>>;
   /** Validate field value */
@@ -219,10 +227,7 @@ export type FormikProps<Values> = FormikSharedConfig &
 
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {
-  registerField(
-    name: string,
-    fns: { validate?: (value: any) => string | Promise<void> | undefined }
-  ): void;
+  registerField(name: string, fns: { validate?: FieldValidate }): void;
   unregisterField(name: string): void;
 }
 
@@ -285,3 +290,5 @@ export interface FieldInputProps<Value> {
   /** Blur event handler */
   onBlur: FormikHandlers['handleBlur'];
 }
+
+export type FieldValidate = (value: any) => string | Promise<string | void>;


### PR DESCRIPTION
Tiny TypeScript change as the validation function had two different signatures. Run into because of #1650 and had to call `registerField` manually. Besides, it's useful to export that signature for purposes of passing a validation function along the user code.