### PR TITLE
Change getIn behavior so it returns `def` for empty `path` argument

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,10 @@ export function getIn(
   def?: any,
   p: number = 0
 ) {
+  if (!key || !key.length) return def;
   const path = toPath(key);
+  if (!path || !path.length) return def;
+
   while (obj && p < path.length) {
     obj = obj[path[p++]];
   }

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -4,6 +4,7 @@ import {
   isPromise,
   getActiveElement,
   isNaN,
+  getIn,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -314,5 +315,23 @@ describe('utils', () => {
       expect(isNaN('')).toBe(false);
       expect(isNaN([])).toBe(false);
     });
+  });
+});
+
+describe('getIn', () => {
+  const field = { errors: { name: 'John' } };
+  it("gets object's property value by given path", () => {
+    expect(getIn(field, 'errors')).toEqual({
+      name: 'John',
+    });
+    expect(getIn(field, 'errors.name')).toBe('John');
+    expect(getIn(field.errors, 'name')).toBe('John');
+  });
+
+  it('returns default value, if nothing was found by given path', () => {
+    expect(getIn(field, 'values.name')).toBe(undefined);
+    expect(getIn(field, 'values.name', '')).toBe('');
+    expect(getIn(field, '')).toBe(undefined);
+    expect(getIn(field, '', '')).toBe('');
   });
 });


### PR DESCRIPTION
closes #1038 

AR: 
```js
getIn({ errors: { name: 'John' } }, '') // -> { errors: { name: 'John' } }
```

ER: 
```js
getIn({ errors: { name } }, '') // -> undefined
```