### PR TITLE
WIP: Opinionated throttled + debounced validation

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -150,8 +150,10 @@ export interface FormikHandlers {
 export interface FormikSharedConfig<Props = {}> {
   /** Tells Formik to validate the form on each input's onChange event */
   validateOnChange?: boolean;
-  /** Tells Formik to debounce low-priority validate by a given number of milliseconds */
+  /** Tells Formik to debounce low-priority validation of long inputs by a given number of milliseconds */
   debounceValidationMs?: number;
+  /** Tells Formik to throttle low-priority validation of short inputs by a given number of milliseconds */
+  throttleValidationMs?: number;
   /** Tells Formik to validate the form on each input's onBlur event */
   validateOnBlur?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */


### PR DESCRIPTION
This adds the following opinionated, yet (probably more optimal) technique for validation:

**If an update for a field value is shorter than 5 characters or ends in a space, then run a throttled low-pri validation. Otherwise, run a debounce low-pri validation.**

Then end result is more immediate feedback on short inputs and more regimented feedback on longer inputs. 

Obviously, this is super-opinionated, but I just wanted to start a conversation. In a perfect world, this would be handled in user-land. However, the current API makes implementing something like this at the form-level very hacky. This raises another key question, which is whether this should be at the form-level or handled at the per-field level.