### PR TITLE
Initial context should be undefined

### DIFF
--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FormikContext } from './types';
 import invariant from 'tiny-warning';
 
-const PrivateFormikContext = React.createContext<FormikContext<any>>(undefined);
+const PrivateFormikContext = React.createContext<FormikContext<any> | undefined>(undefined);
 export const FormikProvider = PrivateFormikContext.Provider;
 export const FormikConsumer = PrivateFormikContext.Consumer;
 

--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FormikContext } from './types';
 import invariant from 'tiny-warning';
 
-const PrivateFormikContext = React.createContext<FormikContext<any>>({} as any);
+const PrivateFormikContext = React.createContext<FormikContext<any>>(undefined);
 export const FormikProvider = PrivateFormikContext.Provider;
 export const FormikConsumer = PrivateFormikContext.Consumer;
 


### PR DESCRIPTION
With object being initial value, the invariant in the `useFormikContext` never fails and causes weird errors later when the hook is actually misused.