### PR TITLE
Using updater functions for setErrors and setTouched

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -120,15 +120,18 @@ export class Formik<Values = FormikValues> extends React.Component<
   }
 
   setErrors = (errors: FormikErrors<Values>) => {
-    this.setState({ errors });
+    this.setState(() => ({ errors }));
   };
 
   setTouched = (touched: FormikTouched<Values>) => {
-    this.setState({ touched }, () => {
-      if (this.props.validateOnBlur) {
-        this.runValidations(this.state.values);
+    this.setState(
+      () => ({ touched }),
+      () => {
+        if (this.props.validateOnBlur) {
+          this.runValidations(this.state.values);
+        }
       }
-    });
+    );
   };
 
   setValues = (values: FormikState<Values>['values']) => {


### PR DESCRIPTION
These two methods are common to be used together when a remote validation field errors are tried to be applied over an existing Formik instance.
For those who don't know, setState() does not apply changes immediately. It enqueues the changes. That's why it also can receive a function as an argument. 
This function then is executed when the previously requested changes on the state had finished, that way avoiding overriding the state.
[Official React.Component - setState() docs](https://reactjs.org/docs/react-component.html#setstate)