### PR TITLE
Fix invariant in useFormikContext

### DIFF
--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { FormikContext } from './types';
 import invariant from 'tiny-warning';
 
-const PrivateFormikContext = React.createContext<FormikContext<any>>({} as any);
+const PrivateFormikContext = React.createContext<FormikContext<any>>(
+  undefined as any
+);
 export const FormikProvider = PrivateFormikContext.Provider;
 export const FormikConsumer = PrivateFormikContext.Consumer;
 


### PR DESCRIPTION
Hi,

As referenced in https://github.com/jaredpalmer/formik/issues/1716 the invariant in `useFormikContext` is currently broken. As the default value of the context is `{}` it will not be interpreted as falsy by the invariant and no warning will be displayed when used outside of `<Formik>` tags.

Cheers,