### PR TITLE
Recursively validateYupSchema. Fix #1520

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -934,7 +934,7 @@ function prepareDataForValidation<T extends FormikValues>(
             return value !== '' ? value : undefined;
           }
         });
-      } else if (typeof values[key] === 'object') {
+      } else if (typeof values[key] === 'object' && values[key] !== null) {
         data[key] = prepareDataForValidation(values[key]);
       } else {
         data[key] = values[key] !== '' ? values[key] : undefined;

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -899,7 +899,6 @@ export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
   }
   return errors;
 }
-
 /**
  * Validate a yup schema.
  */
@@ -909,17 +908,39 @@ export function validateYupSchema<T extends FormikValues>(
   sync: boolean = false,
   context: any = {}
 ): Promise<Partial<T>> {
-  let validateData: FormikValues = {};
-  for (let k in values) {
-    if (values.hasOwnProperty(k)) {
-      const key = String(k);
-      validateData[key] = values[key] !== '' ? values[key] : undefined;
-    }
-  }
+  const validateData: FormikValues = prepareDataForValidation(values);
   return schema[sync ? 'validateSync' : 'validate'](validateData, {
     abortEarly: false,
     context: context,
   });
+}
+
+/**
+ * Recursively prepare values.
+ */
+function prepareDataForValidation<T extends FormikValues>(
+  values: T
+): FormikValues {
+  let data: FormikValues = {};
+  for (let k in values) {
+    if (values.hasOwnProperty(k)) {
+      const key = String(k);
+      if (Array.isArray(values[key]) === true) {
+        data[key] = values[key].map((value: any) => {
+          if (Array.isArray(value) === true || typeof value === 'object') {
+            return prepareDataForValidation(value);
+          } else {
+            return value !== '' ? value : undefined;
+          }
+        });
+      } else if (typeof values[key] === 'object') {
+        data[key] = prepareDataForValidation(values[key]);
+      } else {
+        data[key] = values[key] !== '' ? values[key] : undefined;
+      }
+    }
+  }
+  return data;
 }
 
 /**

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -899,6 +899,7 @@ export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
   }
   return errors;
 }
+
 /**
  * Validate a yup schema.
  */

--- a/test/yupHelpers.test.ts
+++ b/test/yupHelpers.test.ts
@@ -3,6 +3,15 @@ import { validateYupSchema, yupToFormErrors } from '../src';
 const Yup = require('yup');
 const schema = Yup.object().shape({
   name: Yup.string('Name must be a string').required('required'),
+  field: Yup.string('Field must be a string'),
+});
+const nestedSchema = Yup.object().shape({
+  object: Yup.object().shape({
+    nestedField: Yup.string('Field must be a string'),
+    nestedArray: Yup.array().of(
+      Yup.string('Field must be a string').nullable()
+    ),
+  }),
 });
 
 describe('Yup helpers', () => {
@@ -33,6 +42,45 @@ describe('Yup helpers', () => {
         const result = await validateYupSchema({ name: 1 }, schema);
         expect(result).not.toEqual({ name: 1 });
         expect(result).toEqual({ name: '1' });
+      } catch (e) {
+        throw e;
+      }
+    });
+
+    it('should set undefined empty strings', async () => {
+      try {
+        const result = await validateYupSchema(
+          { name: 'foo', field: '' },
+          schema
+        );
+        expect(result.field).toBeUndefined();
+      } catch (e) {
+        throw e;
+      }
+    });
+
+    it('should set undefined nested empty strings', async () => {
+      try {
+        const result = await validateYupSchema(
+          { name: 'foo', object: { nestedField: '' } },
+          nestedSchema
+        );
+        expect(result.object!.nestedField).toBeUndefined();
+      } catch (e) {
+        throw e;
+      }
+    });
+
+    it('should set undefined nested empty strings', async () => {
+      try {
+        const result = await validateYupSchema(
+          {
+            name: 'foo',
+            object: { nestedField: 'swag', nestedArray: ['', 'foo', 'bar'] },
+          },
+          nestedSchema
+        );
+        expect(result.object!.nestedArray!).toEqual([undefined, 'foo', 'bar']);
       } catch (e) {
         throw e;
       }


### PR DESCRIPTION
I ran into #1520 while developing with Formik and fixed the issue by making the validateYupSchema preparing datas recursively with support of objects and arrays.