### PR TITLE
Feature/yup validation context

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -394,3 +394,9 @@ events and `change`-related methods. More specifically, when either
 [A Yup schema](https://github.com/jquense/yup) or a function that returns a Yup
 schema. This is used for validation. Errors are mapped by key to the inner
 component's `errors`. Its keys should match those of `values`.
+
+### `validationSchemaContext?: Record<string, any> | ((values. Values) => Record<string, any>)`
+
+An object or a function that gets the current field values and returns an object that is passed as a context to the validation Schema.
+It can be used to reference an external value in Yup `when` (must be prefixed with `$`) or, returning the passed values in the function form,
+to reach in Yup `when` outside of siblings and descendants.

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -200,10 +200,14 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         const schema = isFunction(validationSchema)
           ? validationSchema(field)
           : validationSchema;
+        const validationSchemaContext = props.validationSchemaContext;
+        const schemaContext = isFunction(validationSchemaContext)
+          ? validationSchemaContext(values)
+          : validationSchemaContext;
         let promise =
           field && schema.validateAt
-            ? schema.validateAt(field, values)
-            : validateYupSchema(values, schema);
+            ? schema.validateAt(field, values, { context: schemaContext })
+            : validateYupSchema(values, schema, undefined, schemaContext);
         promise.then(
           () => {
             resolve(emptyErrors);

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -206,6 +206,12 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * A Yup Schema or a function that returns a Yup schema
    */
   validationSchema?: any | (() => any);
+  /**
+   * An object or a function that returns an object that will be used as Yup context
+   */
+  validationSchemaContext?:
+    | Record<string, any>
+    | ((values: Values) => Record<string, any>);
 
   /**
    * Validation function. Must return an error object or promise that

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -73,6 +73,13 @@ export interface WithFormikConfig<
   validationSchema?: any | ((props: Props) => any);
 
   /**
+   * An object or a function that returns an object that will be used as Yup context
+   */
+  validationSchemaContext?:
+    | Record<string, any>
+    | ((values: Values) => Record<string, any>);
+
+  /**
    * Validation function. Must return an error object or promise that
    * throws an error object where that object keys map to corresponding value.
    */


### PR DESCRIPTION
This is for https://github.com/jaredpalmer/formik/issues/503 and takes again from https://github.com/jaredpalmer/formik/pull/522
It adds a validationSchemaContext property tha can be an object or a function taking the current values and returning an object. The object will be used as a Yup context in validation, allowing yup functions like when to refer to external values or field valus outside from siblings and descendants.