### PR TITLE
Fix: Promise returned from submitForm not rejected when form is inval…

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -442,9 +442,12 @@ export class Formik<Values = FormikValues> extends React.Component<
       const isValid = Object.keys(combinedErrors).length === 0;
       if (isValid) {
         this.executeSubmit();
-      } else if (this.didMount) {
-        // ^^^ Make sure Formik is still mounted before calling setState
-        this.setState({ isSubmitting: false });
+      } else {
+        if (this.didMount) {
+          // ^^^ Make sure Formik is still mounted before calling setState
+          this.setState({ isSubmitting: false });
+        }
+        throw new Error('Could not submit form, it contains errors.');
       }
     });
   };

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -447,8 +447,8 @@ export class Formik<Values = FormikValues> extends React.Component<
           // ^^^ Make sure Formik is still mounted before calling setState
           this.setState({ isSubmitting: false });
         }
-        throw new Error('Could not submit form, it contains errors.');
       }
+      return Promise.resolve(combinedErrors);
     });
   };
 

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -164,7 +164,9 @@ describe('withFormik()', () => {
       },
       myProps
     );
-    await expect(getProps().submitForm()).rejects.toBeTruthy();
+    await expect(getProps().submitForm()).resolves.toMatchObject({
+      my: 'Required',
+    });
   });
 
   it('calls handleSubmit with values, actions and custom props', async () => {

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -151,6 +151,22 @@ describe('withFormik()', () => {
     await wait(() => expect(validationSchema).toHaveBeenCalledWith(myProps));
   });
 
+  it('calls validationSchema function with props and return promise with error object', async () => {
+    const validationSchema = jest.fn(() =>
+      Yup.object({
+        my: Yup.string().required('Required'),
+      })
+    );
+    const myProps = { my: 'prop' };
+    const { getProps } = renderWithFormik(
+      {
+        validationSchema,
+      },
+      myProps
+    );
+    await expect(getProps().submitForm()).rejects.toBeTruthy();
+  });
+
   it('calls handleSubmit with values, actions and custom props', async () => {
     const handleSubmit = jest.fn();
     const myProps = { my: 'prop' };


### PR DESCRIPTION
I encountred the problem #1580 while developing with Formik and fixed the issue by throwing an Error when the schema is not valid.

The problem seems to be fixed in 2.x but also need to have a fix on the 1.5.8.