### PR TITLE
Fix setIn when deep object or array is wrong type

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,7 @@ export function setIn(obj: any, path: string, value: any): any {
     const currentPath: string = pathArray[i];
     let currentObj: any = getIn(obj, pathArray.slice(0, i + 1));
 
-    if (currentObj) {
+    if (currentObj && (isObject(currentObj) || Array.isArray(currentObj))) {
       resVal = resVal[currentPath] = clone(currentObj);
     } else {
       const nextPath: string = pathArray[i + 1];

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -266,6 +266,13 @@ describe('utils', () => {
       expect(obj instanceof TestClass).toEqual(true);
       expect(newObj instanceof TestClass).toEqual(true);
     });
+
+    it('can convert primitives to objects before setting', () => {
+      const obj = { x: [{ y: true }] };
+      const newObj = setIn(obj, 'x.0.y.z', true);
+      expect(obj).toEqual({ x: [{ y: true }] });
+      expect(newObj).toEqual({ x: [{ y: { z: true } }] });
+    });
   });
 
   describe('isPromise', () => {


### PR DESCRIPTION
I encountered a bug as follows:

* Initialize a form with initial value `{ x: null }`
* Submit the form with `values: { x: null }`
* Formik touches all values onSubmit, and sets `touched: { x: true }`
* I try to edit form field `x.y`
* `setIn` tries to set `touched.x.y`, but fails with error `Cannot create property 'y' on boolean 'true'`, which occurs because `touched.x` is not an object.

This PR addresses this scenario by setting `touched.x` to `{}` before setting `touched.x.y` to `true`