### PR TITLE
Improve Field typings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 1. Fork this repository to your own GitHub account and then clone it to your local device.
 2. Install the dependencies: `yarn install`
 3. Run `yarn link` to link the local repo to NPM
-4. Run `yarn start` to build and watch for code changes
-5. Run `yarn test` to start Jest
-7. Then npm link this repo inside any other project on your local dev with `yarn link formik`
+4. Link Formik's React to local repo `cd node_modules/react && yarn link`
+5. Run `yarn start` to build and watch for code changes
+6. Run `yarn test` to start Jest
+7. Then npm link this repo inside any other project on your local dev with `yarn link formik && yarn link react`
 8. Then you can use your local version of Formik within your project
-

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -221,12 +221,8 @@ export const Field = <A extends PickOneConfig>({
         children
       );
     }
-    const Component = component;
-    return (
-      <Component {...legacyBag} {...props}>
-        {children}
-      </Component>
-    );
+
+    return React.createElement(component, { ...legacyBag, ...props }, children);
   }
 
   // default to input here so we can check for both `as` and `children` above
@@ -241,11 +237,6 @@ export const Field = <A extends PickOneConfig>({
     );
   }
 
-  const Component = asElement;
-  return (
-    <Component {...field} {...props}>
-      {children}
-    </Component>
-  );
+  return React.createElement(asElement, { ...field, ...props }, children);
 };
 export const FastField = Field;

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -76,9 +76,8 @@ type PickOne<T, K extends keyof T> = Pick<T, K> &
   { [P in keyof Omit<T, K>]?: never };
 type PickOneConfig =
   | PickOne<FieldConfig, 'render'>
-  | PickOne<FieldConfig, 'component'>
-  | PickOne<FieldConfig, 'as'>
-  | PickOne<FieldConfig, 'children'>;
+  | PickOne<FieldConfig, 'component' | 'children'>
+  | PickOne<FieldConfig, 'as' | 'children'>;
 
 type StrictFieldConfig<T extends PickOneConfig> = T extends {
   render: T['render'];
@@ -88,10 +87,7 @@ type StrictFieldConfig<T extends PickOneConfig> = T extends {
   ? Pick<T, 'component'> & { children?: React.ReactNode }
   : T extends { as: T['as'] }
   ? Pick<T, 'as'> & { children?: React.ReactNode }
-  : T extends { children: T['children'] }
-  ? Pick<T, 'children'>
   : T;
-
 type AddedProps<T extends FieldConfig> = T extends StringComponentConfig<
   infer U
 >

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -16,7 +16,7 @@ export interface FieldProps<V = any> {
   meta: FieldMetaProps<V>;
 }
 
-type LegacyFieldProps<V = any> = Pick<FieldProps<V>, 'field' | 'form'>;
+export type LegacyFieldProps<V = any> = Pick<FieldProps<V>, 'field' | 'form'>;
 
 type StringElements = 'select' | 'input' | 'textarea';
 
@@ -85,9 +85,7 @@ type StrictFieldConfig<T extends FieldConfig> = T extends {
   : T extends { as: T['as'] }
   ? OtherFieldConfig<'as'>
   : T extends { children: (...args: any[]) => any }
-  ? OtherFieldConfig<'children'>
-  : T extends {}
-  ? Required<FieldConfig>
+  ? OtherFieldConfig<'children'> // : T extends {} // ? Required<FieldConfig>
   : T;
 
 type AddedProps<T extends FieldConfig> = T extends StringComponentConfig<
@@ -98,7 +96,7 @@ type AddedProps<T extends FieldConfig> = T extends StringComponentConfig<
   ? Omit<P, keyof FieldInputProps<any>>
   : {};
 
-type FieldAttributes<T extends FieldConfig> = AddedProps<T> &
+export type FieldAttributes<T extends FieldConfig> = AddedProps<T> &
   StrictFieldConfig<T> &
   BaseConfig;
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -63,29 +63,29 @@ export interface FieldConfig {
   /**
    * Children render function <Field name>{props => ...}</Field>)
    */
-  children?: ((props: FieldProps) => React.ReactElement) | React.ReactNode;
+  children?: React.ReactNode | ((props: FieldProps) => React.ReactElement);
 }
 
 type StringComponentConfig<U extends StringElements> =
   | { component: U }
   | { as: U };
 
-type RenderableConfigKeys = Exclude<keyof FieldConfig, keyof BaseConfig>;
+type RenderableConfigKeys = keyof FieldConfig;
 
-type OtherFieldConfig<U extends RenderableConfigKeys> = Required<
+type SpecificFieldConfig<U extends RenderableConfigKeys> = Required<
   Pick<FieldConfig, U>
 >;
 
 type StrictFieldConfig<T extends FieldConfig> = T extends {
-  component: T['component'];
+  render: T['render'];
 }
-  ? OtherFieldConfig<'component'>
-  : T extends { render: T['render'] }
-  ? OtherFieldConfig<'render'>
+  ? SpecificFieldConfig<'render'>
+  : T extends { children: T['children'] }
+  ? SpecificFieldConfig<'children'>
+  : T extends { component: T['component'] }
+  ? SpecificFieldConfig<'component'>
   : T extends { as: T['as'] }
-  ? OtherFieldConfig<'as'>
-  : T extends { children: (...args: any[]) => any }
-  ? OtherFieldConfig<'children'> // : T extends {} // ? Required<FieldConfig>
+  ? SpecificFieldConfig<'as'>
   : T;
 
 type AddedProps<T extends FieldConfig> = T extends StringComponentConfig<
@@ -144,7 +144,7 @@ export function useField<A extends FieldConfig>(
   return getFieldProps({ name: propsOrFieldName });
 }
 
-export const Field = <A extends Partial<FieldConfig> & BaseConfig>({
+export const Field = <A extends FieldConfig>({
   validate,
   name,
   render,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -254,10 +254,9 @@ export interface SharedRenderProps<T> {
   children?: (props: T) => React.ReactNode;
 }
 
-export type GenericFieldHTMLAttributes =
-  | JSX.IntrinsicElements['input']
-  | JSX.IntrinsicElements['select']
-  | JSX.IntrinsicElements['textarea'];
+export type GenericFieldHTMLAttributes<
+  T extends 'input' | 'select' | 'textarea'
+> = JSX.IntrinsicElements[T];
 
 /** Field metadata */
 export interface FieldMetaProps<Value> {

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -45,9 +45,7 @@ function renderForm(
   };
 }
 
-const createRenderField = (
-  FieldComponent: React.ComponentType<FieldConfig>
-) => (
+const createRenderField = (FieldComponent: typeof Field) => (
   props: Partial<FieldConfig> | Partial<FastFieldConfig> = {},
   formProps?: Partial<FormikConfig<Values>>
 ) => {
@@ -106,11 +104,13 @@ describe('Field / FastField', () => {
       let injected: FieldProps[] = [];
       let asInjectedProps: FieldProps['field'] = {} as any;
 
-      const Component = (props: FieldProps) =>
-        injected.push(props) && <div data-testid="child">{TEXT}</div>;
+      const Component = (props: FieldProps) => (
+        injected.push(props), <div data-testid="child">{TEXT}</div>
+      );
 
-      const AsComponent = (props: FieldProps['field']) =>
-        (asInjectedProps = props) && <div data-testid="child">{TEXT}</div>;
+      const AsComponent = (props: FieldProps['field']) => (
+        (asInjectedProps = props), <div data-testid="child">{TEXT}</div>
+      );
 
       const { getFormProps, queryAllByText } = renderForm(
         <>
@@ -152,10 +152,13 @@ describe('Field / FastField', () => {
       let injected: FieldProps[] = [];
       let asInjectedProps: FieldProps['field'] = {} as any;
 
-      const Component = (props: FieldProps) =>
-        injected.push(props) && <div>{TEXT}</div>;
-      const AsComponent = (props: FieldProps['field']) =>
-        (asInjectedProps = props) && <div data-testid="child">{TEXT}</div>;
+      const Component = (props: FieldProps) => {
+        injected.push(props);
+        return <div>{TEXT}</div>;
+      };
+      const AsComponent = (props: FieldProps['field']) => (
+        (asInjectedProps = props), <div data-testid="child">{TEXT}</div>
+      );
 
       const { getFormProps, queryAllByText } = renderForm(
         <>
@@ -223,7 +226,7 @@ describe('Field / FastField', () => {
         component: 'textarea',
       });
 
-      expect(container.firstChild.type).toBe('textarea');
+      expect(container.firstChild.nodeName.toLowerCase()).toBe('textarea');
     });
 
     cases('assigns innerRef as a ref to string components', renderField => {
@@ -238,7 +241,7 @@ describe('Field / FastField', () => {
 
     cases('forwards innerRef to React component', renderField => {
       let injected: any; /** FieldProps ;) */
-      const Component = (props: FieldProps) => (injected = props) && null;
+      const Component = (props: FieldProps) => ((injected = props), null);
 
       const innerRef = jest.fn();
       renderField({ component: Component, innerRef });
@@ -252,7 +255,7 @@ describe('Field / FastField', () => {
         as: 'textarea',
       });
 
-      expect(container.firstChild.type).toBe('textarea');
+      expect(container.firstChild.nodeName.toLowerCase()).toBe('textarea');
     });
 
     cases('assigns innerRef as a ref to string components', renderField => {
@@ -411,7 +414,7 @@ describe('Field / FastField', () => {
     cases('warns about render prop deprecation', renderField => {
       global.console.warn = jest.fn();
       const { rerender } = renderField({
-        render: () => null,
+        render: () => <React.Fragment />,
       });
       rerender();
       expect((global.console.warn as jest.Mock).mock.calls[0][0]).toContain(


### PR DESCRIPTION
I was initially just going to fix up the use of `any` as that what the props of `Field` was, but I've also added in the inference of the props any component that you pass in through the `component` or `as` prop. This has worked quite well in a little test where a custom `Select` component requires `Array<Option>` and didn't want to have to use the children props to enforce it. It also now strongly types the HTMLAttributes when a string is passed in for the `component` or `as`.

In addition, this will restrict using both `render` and `children`.

Happy for improvements where wanted.

-----
[View rendered .github/CONTRIBUTING.md](https://github.com/Carl-Foster/formik/blob/fix/field-types/.github/CONTRIBUTING.md)