### PR TITLE
Allow re-initialize of errors and touched

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -386,17 +386,17 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       enableReinitialize &&
       isMounted.current === true
     ) {
-      var needReset = false;
+      const needReset = false;
       if (!isEqual(initialValues.current, props.initialValues)) {
         initialValues.current = props.initialValues;
         needReset = true;
       }
       if (!isEqual(initialErrors.current, props.initialErrors)) {
-        initialErrors.current = props.initialErrors;
+        initialErrors.current = props.initialErrors || emptyErrors;
         needReset = true;
       }
       if (!isEqual(initialTouched.current, props.initialTouched)) {
-        initialTouched.current = props.initialTouched;
+        initialTouched.current = props.initialTouched || emptyTouched;
         needReset = true;
       }
       if (needReset) {

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -399,6 +399,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         initialTouched.current = props.initialTouched || emptyTouched;
         needReset = true;
       }
+      if (!isEqual(initialStatus.current, props.initialStatus)) {
+        initialStatus.current = props.initialStatus;
+        needReset = true;
+      }
       if (needReset) {
         resetForm();
       }

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -407,7 +407,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         resetForm();
       }
     }
-  }, [enableReinitialize, props.initialValues, props.initialErrors, props.initialTouched, resetForm]);
+  }, [enableReinitialize, props.initialValues, props.initialErrors, props.initialTouched, props.initialStatus, resetForm]);
 
   const validateField = useEventCallback((name: string) => {
     // This will efficiently validate a single field by avoiding state

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -384,13 +384,26 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   React.useEffect(() => {
     if (
       enableReinitialize &&
-      isMounted.current === true &&
-      !isEqual(initialValues.current, props.initialValues)
+      isMounted.current === true
     ) {
-      initialValues.current = props.initialValues;
-      resetForm();
+      var needReset = false;
+      if (!isEqual(initialValues.current, props.initialValues)) {
+        initialValues.current = props.initialValues;
+        needReset = true;
+      }
+      if (!isEqual(initialErrors.current, props.initialErrors)) {
+        initialErrors.current = props.initialErrors;
+        needReset = true;
+      }
+      if (!isEqual(initialTouched.current, props.initialTouched)) {
+        initialTouched.current = props.initialTouched;
+        needReset = true;
+      }
+      if (needReset) {
+        resetForm();
+      }
     }
-  }, [enableReinitialize, props.initialValues, resetForm]);
+  }, [enableReinitialize, props.initialValues, props.initialErrors, props.initialTouched, resetForm]);
 
   const validateField = useEventCallback((name: string) => {
     // This will efficiently validate a single field by avoiding state

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -386,7 +386,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       enableReinitialize &&
       isMounted.current === true
     ) {
-      const needReset = false;
+      let needReset = false;
       if (!isEqual(initialValues.current, props.initialValues)) {
         initialValues.current = props.initialValues;
         needReset = true;


### PR DESCRIPTION
Motivation of this PR - to be able to pass errors to formik store from the outside via props, without using callbacks. `errors` and related `touched` objects passed by formik to render function are supposed to be created by `mapPropsToErrors` and `mapPropsToTouched` functions in case when `enableReinitialize` flag is set to true. For example, this config should work:
```
withFormik({
  mapPropsToErrors: (props) => {
    return props.newErrors;
  },
  mapPropsToTouched: (props) => {
        return props.newTouched;
  },
  enableReinitialize: true,
});
```
Currently, when using `mapPropsToErrors` and `mapPropsToTouched` from `withFormik` hoc, values returned by that functions are actually ignored - `resetForm` does not use them. Similar issue - status.