### PR TITLE
We should be able to get the result of submitForm

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -643,10 +643,11 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         const isActuallyValid = Object.keys(combinedErrors).length === 0;
         if (isActuallyValid) {
           return Promise.resolve(executeSubmit())
-            .then(() => {
+            .then(result => {
               if (!!isMounted.current) {
                 dispatch({ type: 'SUBMIT_SUCCESS' });
               }
+              return result;
             })
             .catch(_errors => {
               if (!!isMounted.current) {


### PR DESCRIPTION
This is a follow up of the initial PR that allowed to catch submitForm errors.
https://github.com/jaredpalmer/formik/pull/1229

I think it should be possible to write the following:

```tsx
const onCreateTodoButton = async () => {
        const createdTodo = await submitForm();
        if ( createdTodo ) {
          navigateTo("/todos/"+createdTodo.id);
        }
};
```

If possible that would be cool to not have to write the if and just expect a result, or a failure.

We could imagine having submitForm, which swallow the errors (actually store in formik state instead of throwing), for retrocompatibility/conveniency of users not needing to wire async flows

And we could have submitFormAsync which either return a result, or throws an error.