### PR TITLE
set initial value for ref in useEventCallback()

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -973,7 +973,7 @@ const useIsomorphicLayoutEffect =
     : React.useEffect;
 
 function useEventCallback<T extends (...args: any[]) => any>(fn: T): T {
-  const ref: any = React.useRef();
+  const ref: any = React.useRef(fn);
 
   // we copy a ref to the callback scoped to the current state/props on each render
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
This resolves jaredpalmer/formik#1824.

Added an initial value for `ref` avoiding `ref.current is undefined` error.