### PR TITLE
Fix race condition between components using the same field

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -81,7 +81,7 @@ export function useField<Val = any>(
   const validateFn = isAnObject
     ? (propsOrFieldName as FieldAttributes<Val>).validate
     : undefined;
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (fieldName) {
       registerField(fieldName, {
         validate: validateFn,


### PR DESCRIPTION
Fixes race condition where two mutually exclusive components use the same field.

If the teardown effect of Component A doesn't complete synchronously, Component B could register a field before having it torn down by Component A which should no longer be considered mounted.