### PR TITLE
Fix `array.splice is not a function` errors when using array-like for errors

### DIFF
--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -59,32 +59,58 @@ export interface ArrayHelpers {
  * Some array helpers!
  */
 export const move = (array: any[], from: number, to: number) => {
-  const copy = [...(array || [])];
+  const copy = copyArrayLike(array);
   const value = copy[from];
   copy.splice(from, 1);
   copy.splice(to, 0, value);
   return copy;
 };
 
-export const swap = (array: any[], indexA: number, indexB: number) => {
-  const copy = [...(array || [])];
+export const swap = (
+  arrayLike: ArrayLike<any>,
+  indexA: number,
+  indexB: number
+) => {
+  const copy = copyArrayLike(arrayLike);
   const a = copy[indexA];
   copy[indexA] = copy[indexB];
   copy[indexB] = a;
   return copy;
 };
 
-export const insert = (array: any[], index: number, value: any) => {
-  const copy = [...(array || [])];
+export const insert = (
+  arrayLike: ArrayLike<any>,
+  index: number,
+  value: any
+) => {
+  const copy = copyArrayLike(arrayLike);
   copy.splice(index, 0, value);
   return copy;
 };
 
-export const replace = (array: any[], index: number, value: any) => {
-  const copy = [...(array || [])];
+export const replace = (
+  arrayLike: ArrayLike<any>,
+  index: number,
+  value: any
+) => {
+  const copy = copyArrayLike(arrayLike);
   copy[index] = value;
   return copy;
 };
+
+const copyArrayLike = (arrayLike: ArrayLike<any>) => {
+  if (!arrayLike) {
+    return [];
+  } else if (Array.isArray(arrayLike)) {
+    return [...arrayLike];
+  } else {
+    const maxIndex = Object.keys(arrayLike)
+      .map(key => parseInt(key))
+      .reduce((max, el) => (el > max ? el : max), 0);
+    return Array.from({ ...arrayLike, length: maxIndex + 1 });
+  }
+};
+
 class FieldArrayInner<Values = {}> extends React.Component<
   FieldArrayConfig & { formik: FormikContext<Values> },
   {}
@@ -150,7 +176,10 @@ class FieldArrayInner<Values = {}> extends React.Component<
 
   push = (value: any) =>
     this.updateArrayField(
-      (array: any[]) => [...(array || []), cloneDeep(value)],
+      (arrayLike: ArrayLike<any>) => [
+        ...copyArrayLike(arrayLike),
+        cloneDeep(value),
+      ],
       false,
       false
     );
@@ -227,7 +256,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
     this.updateArrayField(
       // so this gets call 3 times
       (array?: any[]) => {
-        const copy = array ? [...array] : [];
+        const copy = array ? copyArrayLike(array) : [];
         if (!result) {
           result = copy[index];
         }

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -355,4 +355,42 @@ describe('<FieldArray />', () => {
       expect(formikBag.values.friends).toEqual(expected);
     });
   });
+
+  describe('given array-like object representing errors', () => {
+    it('should run arrayHelpers successfully', () => {
+      let formikBag: any;
+      let arrayHelpers: any;
+      ReactDOM.render(
+        <TestForm
+          render={(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        />,
+        node
+      );
+
+      formikBag.setErrors({ friends: { 2: ['Field error'] } });
+
+      arrayHelpers.push('michael');
+      const el = arrayHelpers.pop();
+      arrayHelpers.swap(0, 2);
+      arrayHelpers.insert(1, 'michael');
+      arrayHelpers.replace(1, 'brian');
+      arrayHelpers.unshift('michael');
+      arrayHelpers.remove(1);
+
+      const expected = ['michael', 'brian', 'andrea', 'jared'];
+      expect(el).toEqual('michael');
+      expect(formikBag.values.friends).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
This change fixes behaviour of arrayHelpers when errors are represented by array-like object.

Fixes: https://github.com/jaredpalmer/formik/issues/1158