### PR TITLE
Throw validation errors from submitForm

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -657,7 +657,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         } else if (!!isMounted.current) {
           // ^^^ Make sure Formik is still mounted before calling setState
           dispatch({ type: 'SUBMIT_FAILURE' });
-          return;
+          throw combinedErrors;
         }
         return;
       }

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -575,6 +575,18 @@ describe('<Formik>', () => {
         fireEvent.submit(getByTestId('form'));
         expect(validate).toHaveBeenCalled();
       });
+
+      it('should not submit the form if validate function rejects with an error', async () => {
+        const onSubmit = jest.fn();
+        const validationSchema = Yup.object().shape({
+          field: Yup.string().required('required'),
+        });
+
+        const { getProps } = renderFormik({ onSubmit, validationSchema });
+        await expect(getProps().submitForm()).rejects.toEqual({
+          field: 'required',
+        });
+      });
     });
 
     describe('FormikActions', () => {
@@ -1072,7 +1084,9 @@ describe('<Formik>', () => {
     expect(getProps().isSubmitting).toBe(true);
     expect(getProps().isValidating).toBe(true);
     // do it again async
-    await validatePromise;
+    try {
+      await validatePromise;
+    } catch (err) {}
     // now both should be false because validation failed
     expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);


### PR DESCRIPTION
This will throw the validation errors from `submitForm()`

Fixes #1810 