### PR TITLE
iOS UX fix for form submittal

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -10,8 +10,12 @@ export type FormikFormProps = Pick<
 >;
 
 export function Form(props: FormikFormProps) {
+  // iOS needs an "action" attribute for nice input: https://stackoverflow.com/a/39485162/406725
+  // We default the action to "#" in case the preventDefault fails (just updates the URL hash)
+  const { action, ...rest } = props;
+  const _action = action || "#"
   const { handleReset, handleSubmit } = useFormikContext();
-  return <form onSubmit={handleSubmit} onReset={handleReset} {...props} />;
+  return <form onSubmit={handleSubmit} onReset={handleReset} action={_action} {...rest} />;
 }
 
 Form.displayName = 'Form';


### PR DESCRIPTION
iOS requires an `action` prop for `form` elements to add the `Go` action on the keyboard input.

Read: https://stackoverflow.com/a/39485162/406725