### PR TITLE
Stop eating validation errors

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -195,15 +195,15 @@ export function useFormik<Values extends FormikValues = FormikValues>({
    */
   const runValidationSchema = React.useCallback(
     (values: Values, field?: string): Promise<FormikErrors<Values>> => {
+      const validationSchema = props.validationSchema;
+      const schema = isFunction(validationSchema)
+        ? validationSchema(field)
+        : validationSchema;
+      const promise =
+        field && schema.validateAt
+          ? schema.validateAt(field, values)
+          : validateYupSchema(values, schema);
       return new Promise((resolve, reject) => {
-        const validationSchema = props.validationSchema;
-        const schema = isFunction(validationSchema)
-          ? validationSchema(field)
-          : validationSchema;
-        let promise =
-          field && schema.validateAt
-            ? schema.validateAt(field, values)
-            : validateYupSchema(values, schema);
         promise.then(
           () => {
             resolve(emptyErrors);

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -1146,4 +1146,19 @@ describe('<Formik>', () => {
       users: [{ firstName: 'required', lastName: 'required' }],
     });
   });
+
+  it('should not eat an error thrown by the validationSchema', async () => {
+    const validationSchema = function() {
+      throw new Error('broken validations');
+    };
+
+    const { getProps } = renderFormik({
+      initialValues: { users: [{ firstName: '', lastName: '' }] },
+      validationSchema,
+    });
+
+    expect(() => {
+      getProps().validateForm();
+    }).toThrow('broken validations');
+  });
 });


### PR DESCRIPTION
I had a setup like the following, where the logic inside of `is` was throwing an error.  In the browser, it just appeared that validations were not being run at all.  The actual error did not bubble up to the developer console.  It took me quite a while to figure out what was going wrong.

This PR just moves some code outside of `new Promise()` so that it will be run synchronously and errors in validations will bubble up.

```
const validationSchema = Yup.object().shape({
    prop: Yup.string().when('event_type', {
        is: val => throw new Error('Error in validation'),
        then: Yup.string().required(),
        otherwise: Yup.string().nullable()
})
```