### PR TITLE
Allow initialValues to be an optional prop

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -180,7 +180,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Initial values of the form
    */
-  initialValues: Values;
+  initialValues?: Values;
 
   /**
    * Initial status


### PR DESCRIPTION
`initialValues` should be an optional prop. All fields need to be initialized with a value, but that can be done at the `Field` level, as shown here:

https://github.com/jaredpalmer/formik/issues/321#issuecomment-506963902

```js-jsx
<Field name={name}
  render={({field}) => (
    <Input
        {...field} 
        value={field.value || ''}  
     />
    )}
/>
```

Since `initialValues` is currently required, that forces us to pass in an empty object for no reason:

```js-jsx
<Formik initialValues={{}} onSubmit={handleSubmit}>
  <Form>
    <CustomInput name="firstName" />
  </Form>
</Formik>
```

This reduces the boilerplate code required to set up a form. Additionally, this DRYs up the form more, as you don't have to specify `firstName` on the input and inside the `initialValues`