### PR TITLE
Improve documentation of setSubmitting

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -151,7 +151,7 @@ use it to pass API responses back into your component in `handleSubmit`.
 
 #### `setSubmitting: (isSubmitting: boolean) => void`
 
-Set `isSubmitting` imperatively.
+Set `isSubmitting` imperatively. You would call it with `setSubmitting(false)` in your `onSubmit` handler to finish the cycle. To learn more about the submission process, see [Form Submission](guides/form-submission.md).
 
 #### `setTouched: (fields: { [field: string]: boolean }) => void`
 


### PR DESCRIPTION
Fixes https://github.com/jaredpalmer/formik/issues/1855

This adds a link to the **[Form Submission](https://jaredpalmer.com/formik/docs/guides/form-submission#submission)** page on the documentation of [setSubmitting](https://jaredpalmer.com/formik/docs/api/formik#setsubmitting-issubmitting-boolean-void), making it easier to explore more information about the form submission process.

-----
[View rendered docs/api/formik.md](https://github.com/fmoliveira/formik/blob/docs/improve-set-submitting/docs/api/formik.md)