### PR TITLE
Add optional typing for errors and fields

### DIFF
--- a/src/DefineFormik.ts
+++ b/src/DefineFormik.ts
@@ -1,0 +1,22 @@
+import { Formik } from './Formik';
+import { useFormikContext } from './FormikContext';
+import { Field, FieldAttributes, useField } from './Field';
+import { FormikConfig, FormikValues } from './types';
+
+export const defineFormik = <
+  TValues extends FormikValues,
+  TError = string
+>() => ({
+  Formik: <ExtraProps = {}>(
+    props: FormikConfig<TValues, TError> & ExtraProps
+  ) => Formik(props),
+  useFormikContext: () => useFormikContext<TValues, TError>(),
+  Field: <TFieldName extends keyof TValues & string, TAttributes = any>(
+    props: FieldAttributes<TAttributes, TFieldName, TValues, TError>
+  ) => Field(props),
+  useField: <TFieldName extends keyof TValues & string, TAttributes = any>(
+    propsOrFieldName:
+      | TFieldName
+      | FieldAttributes<TAttributes, TFieldName, TValues, TError>
+  ) => useField(propsOrFieldName),
+});

--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -2,14 +2,16 @@ import * as React from 'react';
 import { FormikContext } from './types';
 import invariant from 'tiny-warning';
 
-const PrivateFormikContext = React.createContext<FormikContext<any>>(
+const PrivateFormikContext = React.createContext<FormikContext<any, any>>(
   undefined as any
 );
 export const FormikProvider = PrivateFormikContext.Provider;
 export const FormikConsumer = PrivateFormikContext.Consumer;
 
-export function useFormikContext<Values>() {
-  const formik = React.useContext<FormikContext<Values>>(PrivateFormikContext);
+export function useFormikContext<TValues, TError = string>() {
+  const formik = React.useContext<FormikContext<TValues, TError>>(
+    PrivateFormikContext
+  );
 
   invariant(
     !!formik,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,3 +8,4 @@ export * from './types';
 export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
+export * from './defineFormik';


### PR DESCRIPTION
Created defineFormik utility to create a cohesive typesafe form

Fixes:
  * Issue 1489: Why limit error to just a string?
  * Issue 1334: Strongly Typed Fields

Using `defineFormik` allows users to define structure of the form in one spot and then use the typesafe formik components in their code.

```javascript
import React from 'react';
import { defineFormik } from './DefineFormik';

interface Test {
  a: number;
}
const { Formik, Field } = defineFormik<Test>();

export const Component = () => {
  return (
    <Formik initialValues={{ a: 1 }} onSubmit={() => {}}>
      <Field
        name="a"
        // This throws a ts error
        validate={value => (value.indexOf('a') > -1 ? 'error' : undefined)}
      ></Field>
    </Formik>
  );
};
```