### PR TITLE
Bring back FastField using contextType

### DIFF
--- a/src/ErrorMessage.tsx
+++ b/src/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormikContext } from './types';
+import { FormikContextType } from './types';
 import { getIn, isFunction } from './utils';
 import { connect } from './connect';
 
@@ -12,10 +12,10 @@ export interface ErrorMessageProps {
 }
 
 class ErrorMessageImpl extends React.Component<
-  ErrorMessageProps & { formik: FormikContext<any> }
+  ErrorMessageProps & { formik: FormikContextType<any> }
 > {
   shouldComponentUpdate(
-    props: ErrorMessageProps & { formik: FormikContext<any> }
+    props: ErrorMessageProps & { formik: FormikContextType<any> }
   ) {
     if (
       getIn(this.props.formik.errors, this.props.name) !==
@@ -54,5 +54,5 @@ class ErrorMessageImpl extends React.Component<
 
 export const ErrorMessage = connect<
   ErrorMessageProps,
-  ErrorMessageProps & { formik: FormikContext<any> }
+  ErrorMessageProps & { formik: FormikContextType<any> }
 >(ErrorMessageImpl);

--- a/src/FastField.tsx
+++ b/src/FastField.tsx
@@ -1,0 +1,242 @@
+import * as React from 'react';
+
+import {
+  FormikProps,
+  GenericFieldHTMLAttributes,
+  FormikContextType,
+} from './types';
+import invariant from 'tiny-warning';
+import { getIn, isEmptyChildren, isFunction } from './utils';
+import { FormikContext } from './FormikContext';
+
+type $FixMe = any;
+
+export interface FastFieldProps<V = any> {
+  field: {
+    /** Classic React change handler, keyed by input name */
+    onChange: (e: React.ChangeEvent<any>) => void;
+    /** Mark input as touched */
+    onBlur: (e: any) => void;
+    /** Value of the input */
+    value: any;
+    /* name of the input */
+    name: string;
+  };
+  form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
+}
+
+export interface FastFieldConfig<T> {
+  /**
+   * Field component to render. Can either be a string like 'select' or a component.
+   */
+  as?: string | React.ComponentType<FastFieldProps<any>> | React.ComponentType;
+  /**
+   * Field component to render. Can either be a string like 'select' or a component.
+   */
+  component?:
+    | string
+    | React.ComponentType<FastFieldProps<any>>
+    | React.ComponentType;
+
+  /**
+   * Render prop (works like React router's <Route render={props =>} />)
+   */
+  render?: (props: FastFieldProps<any>) => React.ReactNode;
+
+  /**
+   * Children render function <Field name>{props => ...}</Field>)
+   */
+  children?:
+    | ((props: FastFieldProps<any>) => React.ReactNode)
+    | React.ReactNode;
+
+  /**
+   * Validate a single field value independently
+   */
+  validate?: (value: any) => string | Promise<void> | undefined;
+
+  /** Override FastField's default shouldComponentUpdate */
+  shouldUpdate?: (
+    nextProps: T & GenericFieldHTMLAttributes,
+    props: {}
+  ) => boolean;
+
+  /**
+   * Field name
+   */
+  name: string;
+
+  /** HTML class */
+  className?: string;
+
+  /** HTML input type */
+  type?: string;
+
+  /** Field value */
+  value?: any;
+
+  /** Inner ref */
+  innerRef?: (instance: any) => void;
+}
+
+export type FastFieldAttributes<T> = GenericFieldHTMLAttributes &
+  FastFieldConfig<T> &
+  T;
+
+/**
+ * Custom Field component for quickly hooking into Formik
+ * context and wiring up forms.
+ */
+class FastFieldInner<Values = {}, Props = {}> extends React.Component<
+  FastFieldAttributes<Props>,
+  {}
+> {
+  static contextType = FormikContext;
+  constructor(props: FastFieldAttributes<Props>) {
+    super(props);
+    const { render, children, component, as: is, name } = props;
+    invariant(
+      !render,
+      `<FastField render> has been deprecated. Please use a child callback function instead: <FastField name={${name}}>{props => ...}</FastField> instead.`
+    );
+    invariant(
+      !(component && render),
+      'You should not use <FastField component> and <FastField render> in the same <FastField> component; <FastField component> will be ignored'
+    );
+
+    invariant(
+      !(is && children && isFunction(children)),
+      'You should not use <FastField as> and <FastField children> as a function in the same <FastField> component; <FastField as> will be ignored.'
+    );
+
+    invariant(
+      !(component && children && isFunction(children)),
+      'You should not use <FastField component> and <FastField children> as a function in the same <FastField> component; <FastField component> will be ignored.'
+    );
+
+    invariant(
+      !(render && children && !isEmptyChildren(children)),
+      'You should not use <FastField render> and <FastField children> in the same <FastField> component; <FastField children> will be ignored'
+    );
+  }
+
+  shouldComponentUpdate(
+    props: FastFieldAttributes<Props>,
+    _state: {},
+    context: FormikContextType<Values>
+  ) {
+    if (this.props.shouldUpdate) {
+      return this.props.shouldUpdate(props, this.props);
+    } else if (
+      getIn(this.context.values, this.props.name) !==
+        getIn(context.values, this.props.name) ||
+      getIn(this.context.errors, this.props.name) !==
+        getIn(context.errors, this.props.name) ||
+      getIn(this.context.touched, this.props.name) !==
+        getIn(context.touched, this.props.name) ||
+      Object.keys(this.props).length !== Object.keys(props).length ||
+      this.context.isSubmitting !== context.isSubmitting
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  componentDidMount() {
+    // Register the Field with the parent Formik. Parent will cycle through
+    // registered Field's validate fns right prior to submit
+    this.context.registerField(this.props.name, this);
+  }
+
+  componentDidUpdate(prevProps: FastFieldAttributes<Props>) {
+    if (this.props.name !== prevProps.name) {
+      this.context.unregisterField(prevProps.name);
+      this.context.registerField(this.props.name, this);
+    }
+
+    if (this.props.validate !== prevProps.validate) {
+      this.context.registerField(this.props.name, this);
+    }
+  }
+
+  componentWillUnmount() {
+    this.context.unregisterField(this.props.name);
+  }
+
+  render() {
+    const {
+      validate,
+      name,
+      render,
+      as: is,
+      children,
+      component,
+      shouldUpdate,
+      ...props
+    } = this.props as FastFieldAttributes<Props>;
+
+    const formik = this.context;
+    const {
+      validate: _validate,
+      validationSchema: _validationSchema,
+      ...restOfFormik
+    } = formik;
+    const field = {
+      value:
+        props.type === 'radio' || props.type === 'checkbox'
+          ? props.value // React uses checked={} for these inputs
+          : getIn(formik.values, name),
+      name,
+      onChange: formik.handleChange,
+      onBlur: formik.handleBlur,
+    };
+    const bag = { field, form: restOfFormik };
+
+    if (render) {
+      return (render as any)(bag);
+    }
+
+    if (isFunction(children)) {
+      return (children as (props: FastFieldProps<any>) => React.ReactNode)(bag);
+    }
+
+    if (component) {
+      // This behavior is backwards compat with earlier Formik 0.9 to 1.x
+      if (typeof component === 'string') {
+        const { innerRef, ...rest } = props;
+        return React.createElement(
+          component,
+          { ref: innerRef, ...field, ...(rest as $FixMe) },
+          children
+        );
+      }
+      // We don't pass `meta` for backwards compat
+      return React.createElement(
+        component as React.ComponentClass<$FixMe>,
+        { field, form: formik, ...props },
+        children
+      );
+    }
+
+    // default to input here so we can check for both `as` and `children` above
+    const asElement = is || 'input';
+
+    if (typeof asElement === 'string') {
+      const { innerRef, ...rest } = props;
+      return React.createElement(
+        asElement,
+        { ref: innerRef, ...field, ...(rest as $FixMe) },
+        children
+      );
+    }
+
+    return React.createElement(
+      asElement as React.ComponentClass,
+      { ...field, ...props },
+      children
+    );
+  }
+}
+
+export const FastField = FastFieldInner;

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -21,7 +21,7 @@ export interface FieldConfig {
    * Field component to render. Can either be a string like 'select' or a component.
    */
   component?:
-    | string
+    | keyof JSX.IntrinsicElements
     | React.ComponentType<FieldProps<any>>
     | React.ComponentType;
 
@@ -167,7 +167,7 @@ export function Field({
   const legacyBag = { field, form: formik };
 
   if (render) {
-    return render(legacyBag);
+    return render({ ...legacyBag, meta });
   }
 
   if (isFunction(children)) {

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -212,4 +212,3 @@ export function Field({
 
   return React.createElement(asElement, { ...field, ...props }, children);
 }
-export const FastField = Field;

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { connect } from './connect';
 import {
-  FormikContext,
+  FormikContextType,
   FormikState,
   SharedRenderProps,
   FormikProps,
@@ -86,14 +86,14 @@ export const replace = (array: any[], index: number, value: any) => {
   return copy;
 };
 class FieldArrayInner<Values = {}> extends React.Component<
-  FieldArrayConfig & { formik: FormikContext<Values> },
+  FieldArrayConfig & { formik: FormikContextType<Values> },
   {}
 > {
   static defaultProps = {
     validateOnChange: true,
   };
 
-  constructor(props: FieldArrayConfig & { formik: FormikContext<Values> }) {
+  constructor(props: FieldArrayConfig & { formik: FormikContextType<Values> }) {
     super(props);
     // We need TypeScript generics on these, so we'll bind them in the constructor
     // @todo Fix TS 3.2.1

--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { FormikContext } from './types';
+import { FormikContext as FormikContextType } from './types';
 import invariant from 'tiny-warning';
 
-const PrivateFormikContext = React.createContext<FormikContext<any>>(
+export const FormikContext = React.createContext<FormikContextType<any>>(
   undefined as any
 );
-export const FormikProvider = PrivateFormikContext.Provider;
-export const FormikConsumer = PrivateFormikContext.Consumer;
+export const FormikProvider = FormikContext.Provider;
+export const FormikConsumer = FormikContext.Consumer;
 
 export function useFormikContext<Values>() {
-  const formik = React.useContext<FormikContext<Values>>(PrivateFormikContext);
+  const formik = React.useContext<FormikContextType<Values>>(FormikContext);
 
   invariant(
     !!formik,

--- a/src/FormikContext.tsx
+++ b/src/FormikContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormikContext as FormikContextType } from './types';
+import { FormikContextType } from './types';
 import invariant from 'tiny-warning';
 
 export const FormikContext = React.createContext<FormikContextType<any>>(

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
-import { FormikContext } from './types';
+import { FormikContextType } from './types';
 import { FormikConsumer } from './FormikContext';
 import invariant from 'tiny-warning';
 
@@ -10,7 +10,7 @@ import invariant from 'tiny-warning';
  * @param Comp React Component
  */
 export function connect<OuterProps, Values = {}>(
-  Comp: React.ComponentType<OuterProps & { formik: FormikContext<Values> }>
+  Comp: React.ComponentType<OuterProps & { formik: FormikContextType<Values> }>
 ) {
   const C: React.SFC<OuterProps> = (props: OuterProps) => (
     <FormikConsumer>
@@ -39,6 +39,8 @@ export function connect<OuterProps, Values = {}>(
 
   return hoistNonReactStatics(
     C,
-    Comp as React.ComponentClass<OuterProps & { formik: FormikContext<Values> }> // cast type to ComponentClass (even if SFC)
+    Comp as React.ComponentClass<
+      OuterProps & { formik: FormikContextType<Values> }
+    > // cast type to ComponentClass (even if SFC)
   ) as React.ComponentType<OuterProps>;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,3 +8,4 @@ export * from './types';
 export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
+export * from './FastField';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -236,7 +236,7 @@ export interface FormikRegistration {
 /**
  * State, handlers, and helpers made available to Formik's primitive components through context.
  */
-export type FormikContext<Values> = FormikProps<Values> &
+export type FormikContextType<Values> = FormikProps<Values> &
   Pick<FormikConfig<Values>, 'validate' | 'validationSchema'>;
 
 export interface SharedRenderProps<T> {

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -128,7 +128,7 @@ describe('Field / FastField', () => {
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
-        if (idx === 0) {
+        if (idx === 2) {
           expect(props.meta.value).toBe('jared');
           expect(props.meta.error).toBeUndefined();
           expect(props.meta.touched).toBe(false);
@@ -161,28 +161,23 @@ describe('Field / FastField', () => {
         <>
           <FastField name="name" children={Component} />
           <FastField name="name" render={Component} />
-          <FastField name="name" component={Component} />
+          {/* @todo fix the types here?? #shipit *}
+          {/* <FastField name="name" component={Component} /> */}
           <FastField name="name" as={AsComponent} />
         </>
       );
 
       const { handleBlur, handleChange } = getFormProps();
-      injected.forEach((props, idx) => {
+      injected.forEach(props => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
-        if (idx === 0) {
-          expect(props.meta.value).toBe('jared');
-          expect(props.meta.error).toBeUndefined();
-          expect(props.meta.touched).toBe(false);
-          expect(props.meta.initialValue).toEqual('jared');
-        } else {
-          // Ensure that we do not pass through `meta` to
-          // <Field component> or <Field render>
-          expect(props.meta).toBeUndefined();
-        }
+        expect(props.meta.value).toBe('jared');
+        expect(props.meta.error).toBeUndefined();
+        expect(props.meta.touched).toBe(false);
+        expect(props.meta.initialValue).toEqual('jared');
       });
 
       expect(asInjectedProps.name).toBe('name');

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -184,7 +184,7 @@ describe('Field / FastField', () => {
       expect(asInjectedProps.value).toBe('jared');
       expect(asInjectedProps.onChange).toBe(handleChange);
       expect(asInjectedProps.onBlur).toBe(handleBlur);
-      expect(queryAllByText(TEXT)).toHaveLength(4);
+      expect(queryAllByText(TEXT)).toHaveLength(3);
     });
   });
 

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -192,7 +192,7 @@ describe('Field / FastField', () => {
       expect(asInjectedProps.value).toBe('jared');
       expect(asInjectedProps.onChange).toBe(handleChange);
       expect(asInjectedProps.onBlur).toBe(handleBlur);
-      expect(queryAllByText(TEXT)).toHaveLength(3);
+      expect(queryAllByText(TEXT)).toHaveLength(4);
     });
   });
 

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -16,6 +16,8 @@ const initialValues = { name: 'jared', email: 'hello@reason.nyc' };
 type Values = typeof initialValues;
 type FastFieldConfig = FieldConfig;
 
+type $FixMe = any;
+
 function renderForm(
   ui?: React.ReactNode,
   props?: Partial<FormikConfig<Values>>
@@ -128,7 +130,7 @@ describe('Field / FastField', () => {
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
-        if (idx === 2) {
+        if (idx !== 2) {
           expect(props.meta.value).toBe('jared');
           expect(props.meta.error).toBeUndefined();
           expect(props.meta.touched).toBe(false);
@@ -161,23 +163,29 @@ describe('Field / FastField', () => {
         <>
           <FastField name="name" children={Component} />
           <FastField name="name" render={Component} />
-          {/* @todo fix the types here?? #shipit *}
-          {/* <FastField name="name" component={Component} /> */}
+          {/* @todo fix the types here?? #shipit */}
+          <FastField name="name" component={Component as $FixMe} />
           <FastField name="name" as={AsComponent} />
         </>
       );
 
       const { handleBlur, handleChange } = getFormProps();
-      injected.forEach(props => {
+      injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
         expect(props.field.onChange).toBe(handleChange);
         expect(props.field.onBlur).toBe(handleBlur);
         expect(props.form).toEqual(getFormProps());
-        expect(props.meta.value).toBe('jared');
-        expect(props.meta.error).toBeUndefined();
-        expect(props.meta.touched).toBe(false);
-        expect(props.meta.initialValue).toEqual('jared');
+        if (idx !== 2) {
+          expect(props.meta.value).toBe('jared');
+          expect(props.meta.error).toBeUndefined();
+          expect(props.meta.touched).toBe(false);
+          expect(props.meta.initialValue).toEqual('jared');
+        } else {
+          // Ensure that we do not pass through `meta` to
+          // <Field component> or <Field render>
+          expect(props.meta).toBeUndefined();
+        }
       });
 
       expect(asInjectedProps.name).toBe('name');


### PR DESCRIPTION
- Add back FastField from v1.
- Get rid of `connect` and just use `contextType`