### PR TITLE
Deprecate <Formik render>

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -54,13 +54,13 @@ const BasicExample = () => (
 
 ### Formik render methods and props
 
-There are three ways to render things with `<Formik />`
+There are 2 ways to render things with `<Formik />`
 
 - `<Formik component>`
-- `<Formik render>`
 - `<Formik children>`
+- ~~`<Formik render>`~~ Deprecated in 2.x
 
-All three render methods will be passed the same props:
+Each render methods will be passed the same props:
 
 #### `dirty: boolean`
 
@@ -218,6 +218,8 @@ const ContactForm = ({
 don’t use both in the same `<Formik>`.
 
 ### `render: (props: FormikProps<Values>) => ReactNode`
+
+**Deprecated in 2.x**
 
 ```jsx
 <Formik render={props => <ContactForm {...props} />} />

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -24,7 +24,8 @@ const BasicExample = () => (
           actions.setSubmitting(false);
         }, 1000);
       }}
-      render={props => (
+    >
+      {props => (
         <form onSubmit={props.handleSubmit}>
           <input
             type="text"
@@ -37,7 +38,7 @@ const BasicExample = () => (
           <button type="submit">Submit</button>
         </form>
       )}
-    />
+    </Formik>
   </div>
 );
 ```

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -148,10 +148,11 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     if (__DEV__) {
       invariant(
         typeof isInitialValid === 'undefined',
-        'isInitialValid has been deprecated and will be removed in future versions of Formik. Please use initialErrors instead.'
+        'isInitialValid has been deprecated and will be removed in future versions of Formik. Please use initialErrors or validateOnMount instead.'
       );
     }
-  }, [isInitialValid]);
+    // eslint-disable-next-line
+  }, []);
 
   React.useEffect(() => {
     isMounted.current = true;
@@ -897,6 +898,15 @@ export function Formik<
 >(props: FormikConfig<Values> & ExtraProps) {
   const formikbag = useFormik<Values>(props);
   const { component, children, render } = props;
+  React.useEffect(() => {
+    if (__DEV__) {
+      invariant(
+        !props.render,
+        `<Formik render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Formik render={(props) => ...} /> with <Formik>{(props) => ...}</Formik>`
+      );
+    }
+    // eslint-disable-next-line
+  }, []);
   return (
     <FormikProvider value={formikbag}>
       {component

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -169,6 +169,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
 
   /**
    * Render prop (works like React router's <Route render={props =>} />)
+   * @deprecated
    */
   render?: (props: FormikProps<Values>) => React.ReactNode;
 

--- a/src/withFormik.tsx
+++ b/src/withFormik.tsx
@@ -175,7 +175,7 @@ export function withFormik<
               config.mapPropsToTouched && config.mapPropsToTouched(this.props)
             }
             onSubmit={this.handleSubmit as any}
-            render={this.renderFormComponent}
+            children={this.renderFormComponent}
           />
         );
       }

--- a/test/FieldArray.test.tsx
+++ b/test/FieldArray.test.tsx
@@ -39,8 +39,8 @@ describe('<FieldArray />', () => {
 
   it('renders with render callback with array helpers as props', () => {
     ReactDOM.render(
-      <TestForm
-        render={() => (
+      <TestForm>
+        {() => (
           <FieldArray
             name="friends"
             render={arrayProps => {
@@ -49,15 +49,15 @@ describe('<FieldArray />', () => {
             }}
           />
         )}
-      />,
+      </TestForm>,
       node
     );
   });
 
   it('renders with "children as a function" with array helpers as props', () => {
     ReactDOM.render(
-      <TestForm
-        render={() => (
+      <TestForm>
+        {() => (
           <FieldArray name="friends">
             {arrayProps => {
               expect(isFunction(arrayProps.push)).toBeTruthy();
@@ -65,15 +65,15 @@ describe('<FieldArray />', () => {
             }}
           </FieldArray>
         )}
-      />,
+      </TestForm>,
       node
     );
   });
 
   it('renders with name as props', () => {
     ReactDOM.render(
-      <TestForm
-        render={() => (
+      <TestForm>
+        {() => (
           <FieldArray
             name="friends"
             render={arrayProps => {
@@ -82,7 +82,7 @@ describe('<FieldArray />', () => {
             }}
           />
         )}
-      />,
+      </TestForm>,
       node
     );
   });
@@ -92,8 +92,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -105,7 +105,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -131,12 +131,12 @@ describe('<FieldArray />', () => {
       };
 
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return <FieldArray name="friends" render={AddFriendsButton} />;
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -158,9 +158,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          initialValues={{ people: [] }}
-          render={(props: any) => {
+        <TestForm initialValues={{ people: [] }}>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -172,7 +171,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -191,8 +190,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -204,7 +203,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -220,8 +219,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -233,7 +232,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -248,8 +247,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -261,7 +260,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -276,8 +275,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -289,7 +288,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -304,8 +303,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -317,7 +316,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 
@@ -333,8 +332,8 @@ describe('<FieldArray />', () => {
       let formikBag: any;
       let arrayHelpers: any;
       ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
               <FieldArray
@@ -346,7 +345,7 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        />,
+        </TestForm>,
         node
       );
 


### PR DESCRIPTION
- Deprecate `<Formik render>` via warning (people should use `children` instead.

-----
[View rendered docs/api/formik.md](https://github.com/jaredpalmer/formik/blob/feat/deprecate-formik-render/docs/api/formik.md)