### PR TITLE
Fixing 60sec broken link

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,7 +7,7 @@ title: Tutorial
 
 Welcome to the Formik tutorial. This will teach you everything you need to know to build simple and complex forms in React.
 
-If you're impatient and just want to start hacking on your machine locally, checkout [the 60-second quickstart](/formik/docs/overview#installation).
+If you're impatient and just want to start hacking on your machine locally, checkout [the 60-second quickstart](/docs/overview.md#installation).
 
 ### What are we building?
 


### PR DESCRIPTION
Fixing broken link from:

`/formik/docs/overview#installation`

to:

`/docs/overview.md#installation`

-----
[View rendered docs/tutorial.md](https://github.com/yuritoledo/formik/blob/patch-1/docs/tutorial.md)