### PR TITLE
Split out getFieldMeta into its own fn

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -72,7 +72,12 @@ export function useField<Val = any>(
   propsOrFieldName: string | FieldAttributes<Val>
 ) {
   const formik = useFormikContext();
-  const { getFieldProps, registerField, unregisterField } = formik;
+  const {
+    getFieldProps,
+    getFieldMeta,
+    registerField,
+    unregisterField,
+  } = formik;
   const isAnObject = isObject(propsOrFieldName);
   const fieldName = isAnObject
     ? (propsOrFieldName as FieldAttributes<Val>).name
@@ -100,16 +105,21 @@ export function useField<Val = any>(
   }
 
   if (isObject(propsOrFieldName)) {
-    if (__DEV__) {
-      invariant(
-        (propsOrFieldName as FieldAttributes<Val>).name,
-        'Invalid field name. Either pass `useField` a string or an object containing a `name` key.'
-      );
-    }
-    return getFieldProps(propsOrFieldName);
+    invariant(
+      (propsOrFieldName as FieldAttributes<Val>).name,
+      'Invalid field name. Either pass `useField` a string or an object containing a `name` key.'
+    );
+
+    return [
+      getFieldProps(propsOrFieldName),
+      getFieldMeta((propsOrFieldName as FieldAttributes<Val>).name),
+    ];
   }
 
-  return getFieldProps({ name: propsOrFieldName });
+  return [
+    getFieldProps({ name: propsOrFieldName }),
+    getFieldMeta(propsOrFieldName),
+  ];
 }
 
 export function Field({
@@ -163,7 +173,8 @@ export function Field({
       unregisterField(name);
     };
   }, [registerField, unregisterField, name, validate]);
-  const [field, meta] = formik.getFieldProps({ name, ...props });
+  const field = formik.getFieldProps({ name, ...props });
+  const meta = formik.getFieldMeta(name);
   const legacyBag = { field, form: formik };
 
   if (render) {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -137,9 +137,8 @@ export interface FormikHandlers {
     ? void
     : ((e: string | React.ChangeEvent<any>) => void);
 
-  getFieldProps<Value = any>(
-    props: any
-  ): [FieldInputProps<Value>, FieldMetaProps<Value>];
+  getFieldProps<Value = any>(props: any): FieldInputProps<Value>;
+  getFieldMeta<Value>(name: string): FieldMetaProps<Value>;
 }
 
 /**

--- a/test/withFormik.test.tsx
+++ b/test/withFormik.test.tsx
@@ -90,6 +90,7 @@ describe('withFormik()', () => {
       isValid: true,
       isValidating: false,
       getFieldProps: expect.any(Function),
+      getFieldMeta: expect.any(Function),
       registerField: expect.any(Function),
       resetForm: expect.any(Function),
       setErrors: expect.any(Function),


### PR DESCRIPTION
Splits out getFieldMeta into its own fn. This allows getFieldProps to be more useful for folks not using Context.