### PR TITLE
Formik 2 - 2FA Documentation Typo Fix

### DIFF
--- a/docs/api/useFormikContext.md
+++ b/docs/api/useFormikContext.md
@@ -19,8 +19,8 @@ const AutoSubmitToken = () => {
   const { values, submitForm } = useFormikContext();
   React.useEffect(() => {
     // Submit the form imperatively as an effect as soon as form values.token are 6 digits long
-    if (formik.values.token.length === 6) {
-      formik.submitForm();
+    if (values.token.length === 6) {
+      submitForm();
     }
   }, [values, submitForm]);
   return null;


### PR DESCRIPTION
In the example, the dependency argument refers to the destructured values, but inside the hook it refers to `formik` which isn't in scope. This removes formik so that the arguments in use match the dependency arguments.

-----
[View rendered docs/api/useFormikContext.md](https://github.com/ericchernuka/formik/blob/patch-1/docs/api/useFormikContext.md)