### PR TITLE
Fixes broken typing in Formik 2.0.1

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -113,13 +113,13 @@ export function useField<Val = any>(
     return [
       getFieldProps(propsOrFieldName),
       getFieldMeta((propsOrFieldName as FieldAttributes<Val>).name),
-    ];
+    ] as const;
   }
 
   return [
     getFieldProps({ name: propsOrFieldName }),
     getFieldMeta(propsOrFieldName),
-  ];
+  ] as const;
 }
 
 export function Field({


### PR DESCRIPTION
Formik returns an array. In TypeScript 3.6.2 (and probably lower), this array is interpreted as being an array of union types (`(FieldProps | FieldMeta)[]`) rather than a tuple (`[FieldProps, FieldMeta]`). `as const` forces the compiler to interpret the array as it is in the literal. This could also be `[FieldProps, FieldMeta]` depending on which version of TS you target.

The return type of `useField` being interpreted as an array of union types is a significant barrier to adoption:

<img width="590" alt="image" src="https://user-images.githubusercontent.com/2939173/67617414-cd408680-f7da-11e9-843d-7af55a1fa0ca.png">


Resolves #1924



