### PR TITLE
Fix typo in migration docs

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -12,7 +12,7 @@ title: Migrating from v1.x to v2.x
 
 ### `resetForm`
 
-**There is only one tiny breaking change in Formik 2.x.** Luckily, it probably won't impact verry many people. Long story short, because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
+**There is only one tiny breaking change in Formik 2.x.** Luckily, it probably won't impact very many people. Long story short, because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
 
 **v1**
 


### PR DESCRIPTION
There was a tiny typo in the migrating to v2 docs.

-----
[View rendered docs/migrating-v2.md](https://github.com/jozsi/formik/blob/patch-2/docs/migrating-v2.md)