### PR TITLE
Fix prepareDataForValidation when the object is an instance.

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -1001,7 +1001,11 @@ function prepareDataForValidation<T extends FormikValues>(
             return value !== '' ? value : undefined;
           }
         });
-      } else if (typeof values[key] === 'object' && values[key] !== null) {
+      } else if (
+        typeof values[key] === 'object' &&
+        values[key] !== null &&
+        Object.getPrototypeOf(values[key]).constructor.name === Object.name
+      ) {
         data[key] = prepareDataForValidation(values[key]);
       } else {
         data[key] = values[key] !== '' ? values[key] : undefined;


### PR DESCRIPTION
The prepareDataForValidation function, call recursively when the value is an object but it is possible that the value is an instance, like a Moment. With this change (Inline 1007) we're checking that the value is one javascript object, if not... don't touch.