### PR TITLE
Fix prepareDataForValidation work with instances

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import isEqual from 'react-fast-compare';
 import deepmerge from 'deepmerge';
+import isPlainObject from 'lodash/isPlainObject';
 import {
   FormikConfig,
   FormikErrors,
@@ -986,7 +987,7 @@ export function validateYupSchema<T extends FormikValues>(
 /**
  * Recursively prepare values.
  */
-function prepareDataForValidation<T extends FormikValues>(
+export function prepareDataForValidation<T extends FormikValues>(
   values: T
 ): FormikValues {
   let data: FormikValues = {};
@@ -1001,7 +1002,7 @@ function prepareDataForValidation<T extends FormikValues>(
             return value !== '' ? value : undefined;
           }
         });
-      } else if (typeof values[key] === 'object' && values[key] !== null) {
+      } else if (isPlainObject(values[key])) {
         data[key] = prepareDataForValidation(values[key]);
       } else {
         data[key] = values[key] !== '' ? values[key] : undefined;

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { render, fireEvent, wait } from 'react-testing-library';
 import * as Yup from 'yup';
 
-import { Formik, FormikProps, FormikConfig } from '../src';
+import {
+  Formik,
+  prepareDataForValidation,
+  FormikProps,
+  FormikConfig,
+} from '../src';
 import { noop } from './testHelpers';
 
 jest.spyOn(global.console, 'warn');
@@ -873,6 +878,36 @@ describe('<Formik>', () => {
 
       getProps().handleReset();
       expect(getProps().submitCount).toEqual(0);
+    });
+  });
+
+  describe('prepareDataForValidation', () => {
+    it('should works correctly with instances', () => {
+      class SomeClass {}
+      const expected = {
+        string: 'string',
+        date: new Date(),
+        someInstance: new SomeClass(),
+      };
+
+      const dataForValidation = prepareDataForValidation(expected);
+      expect(dataForValidation).toEqual(expected);
+    });
+
+    it('should works correctly with mixed deta', () => {
+      const date = new Date();
+      const dataForValidation = prepareDataForValidation({
+        string: 'string',
+        empty: '',
+        arr: [],
+        date,
+      });
+      expect(dataForValidation).toEqual({
+        string: 'string',
+        empty: undefined,
+        arr: [],
+        date,
+      });
     });
   });
 


### PR DESCRIPTION
This pull request fix same problem as [1940](https://github.com/jaredpalmer/formik/pull/1940), but I used lodash `isPlainObject` methods and writed tests for `prepareDataForValidation`. Unfortunately I exported this function, because for this case it was hard to test whole Formik component