### PR TITLE
Changed from .min() to max() method 

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -501,10 +501,10 @@ const SignupForm = () => {
     },
     validationSchema: Yup.object({
       firstName: Yup.string()
-        .min(15, 'Must be 15 characters or less')
+        .max(15, 'Must be 15 characters or less')
         .required('Required'),
       lastName: Yup.string()
-        .min(20, 'Must be 20 characters or less')
+        .max(20, 'Must be 20 characters or less')
         .required('Required'),
       email: Yup.string()
         .email('Invalid email addresss`')


### PR DESCRIPTION
Changed from `.min()` method to `max()` to match the use case:
This part of the Tutorial uses validationSchema to limit the input to 15 or less characters, and uses `min()` instead of `max()` method to make the Yup schema validation.

-----
[View rendered docs/tutorial.md](https://github.com/martincomito/formik/blob/patch-2/docs/tutorial.md)