### PR TITLE
Use placeholder (lowercase) consistently in documentation

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -168,7 +168,7 @@ A hook that is equivalent to `connect()`.
 - `initialErrors`, `initialTouched`, `initialStatus` have been added
 
 ```jsx
-// <input className="form-input" placeHolder="Jane"  />
+// <input className="form-input" placeholder="Jane"  />
 <Field name="firstName" className="form-input" placeholder="Jane" />
 
 // <textarea className="form-textarea"/></textarea>
@@ -189,11 +189,11 @@ const MyStyledInput = styled.input`
 `
 const MyStyledTextarea = MyStyledInput.withComponent('textarea');
 
-// <input className="czx_123" placeHolder="google.com"  />
-<Field name="website" as={MyStyledInput} placeHolder="google.com"/>
+// <input className="czx_123" placeholder="google.com"  />
+<Field name="website" as={MyStyledInput} placeholder="google.com"/>
 
-// <textarea  placeHolder="Post a message..." rows={5}></textarea>
-<Field name="message" as={MyStyledTextArea} placeHolder="Post a message.." rows={4}/>
+// <textarea placeholder="Post a message..." rows={5}></textarea>
+<Field name="message" as={MyStyledTextArea} placeholder="Post a message.." rows={4}/>
 ```
 
 ### `getFieldProps(nameOrProps)`


### PR DESCRIPTION
In the documentation for the Migration to v2, there are a few occurrences of `placeHolder` (camel-case) instead of `placeholder` (lower-case).

This change should make the naming of the prop consistently use the lowercase variant.

-----
[View rendered docs/migrating-v2.md](https://github.com/Narigo/formik/blob/patch-2/docs/migrating-v2.md)