### PR TITLE
Fix unnecessary let usage

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -348,7 +348,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -370,7 +370,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/docs/api/withFormik.md
+++ b/docs/api/withFormik.md
@@ -161,7 +161,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values, props) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -183,7 +183,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -27,7 +27,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -45,7 +45,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -116,7 +116,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -187,7 +187,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (

--- a/examples/AsyncValidation.js
+++ b/examples/AsyncValidation.js
@@ -7,7 +7,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values) => {
   return sleep(300).then(() => {
-    let errors = {};
+    const errors = {};
 
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';

--- a/examples/SyncValidation.js
+++ b/examples/SyncValidation.js
@@ -3,7 +3,7 @@ import { Formik, Field, Form, ErrorMessage } from 'formik';
 import { Debug } from './Debug';
 
 const validate = values => {
-  let errors = {};
+  const errors = {};
   if (!values.email) {
     errors.email = 'Required';
   } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {

--- a/website/versioned_docs/version-1.2.0/api/formik.md
+++ b/website/versioned_docs/version-1.2.0/api/formik.md
@@ -327,7 +327,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -349,7 +349,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.2.0/api/withFormik.md
+++ b/website/versioned_docs/version-1.2.0/api/withFormik.md
@@ -142,7 +142,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values, props) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -164,7 +164,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.2.0/guides/validation.md
+++ b/website/versioned_docs/version-1.2.0/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.2.0/overview.md
+++ b/website/versioned_docs/version-1.2.0/overview.md
@@ -107,7 +107,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -178,7 +178,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (

--- a/website/versioned_docs/version-1.3.0/overview.md
+++ b/website/versioned_docs/version-1.3.0/overview.md
@@ -113,7 +113,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -184,7 +184,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (

--- a/website/versioned_docs/version-1.3.1/guides/validation.md
+++ b/website/versioned_docs/version-1.3.1/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.3.2/api/formik.md
+++ b/website/versioned_docs/version-1.3.2/api/formik.md
@@ -327,7 +327,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -349,7 +349,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.3.2/guides/validation.md
+++ b/website/versioned_docs/version-1.3.2/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.0/api/formik.md
+++ b/website/versioned_docs/version-1.4.0/api/formik.md
@@ -327,7 +327,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -349,7 +349,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.0/guides/validation.md
+++ b/website/versioned_docs/version-1.4.0/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.2/api/formik.md
+++ b/website/versioned_docs/version-1.4.2/api/formik.md
@@ -327,7 +327,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -349,7 +349,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.2/guides/validation.md
+++ b/website/versioned_docs/version-1.4.2/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.3/guides/validation.md
+++ b/website/versioned_docs/version-1.4.3/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.4.3/overview.md
+++ b/website/versioned_docs/version-1.4.3/overview.md
@@ -115,7 +115,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -186,7 +186,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (

--- a/website/versioned_docs/version-1.5.0/api/formik.md
+++ b/website/versioned_docs/version-1.5.0/api/formik.md
@@ -334,7 +334,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -356,7 +356,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.5.0/api/withFormik.md
+++ b/website/versioned_docs/version-1.5.0/api/withFormik.md
@@ -148,7 +148,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values, props) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -170,7 +170,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.5.1/guides/validation.md
+++ b/website/versioned_docs/version-1.5.1/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.5.2/api/formik.md
+++ b/website/versioned_docs/version-1.5.2/api/formik.md
@@ -330,7 +330,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -352,7 +352,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.5.3/api/formik.md
+++ b/website/versioned_docs/version-1.5.3/api/formik.md
@@ -330,7 +330,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -352,7 +352,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-1.5.3/overview.md
+++ b/website/versioned_docs/version-1.5.3/overview.md
@@ -115,7 +115,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -186,7 +186,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (

--- a/website/versioned_docs/version-1.5.5/api/formik.md
+++ b/website/versioned_docs/version-1.5.5/api/formik.md
@@ -330,7 +330,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -352,7 +352,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-2.0.3/api/formik.md
+++ b/website/versioned_docs/version-2.0.3/api/formik.md
@@ -349,7 +349,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = values => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -371,7 +371,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = values => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-2.0.3/api/withFormik.md
+++ b/website/versioned_docs/version-2.0.3/api/withFormik.md
@@ -162,7 +162,7 @@ Validate the form's `values` with function. This function can either be:
 ```js
 // Synchronous validation
 const validate = (values, props) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -184,7 +184,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-2.0.3/guides/validation.md
+++ b/website/versioned_docs/version-2.0.3/guides/validation.md
@@ -28,7 +28,7 @@ There are 2 ways to do form-level validation with Formik:
 ```js
 // Synchronous validation
 const validate = (values, props /* only available when using withFormik */) => {
-  let errors = {};
+  const errors = {};
 
   if (!values.email) {
     errors.email = 'Required';
@@ -46,7 +46,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const validate = (values, props /* only available when using withFormik */) => {
   return sleep(2000).then(() => {
-    let errors = {};
+    const errors = {};
     if (['admin', 'null', 'god'].includes(values.username)) {
       errors.username = 'Nice try';
     }

--- a/website/versioned_docs/version-2.0.3/overview.md
+++ b/website/versioned_docs/version-2.0.3/overview.md
@@ -117,7 +117,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (
@@ -188,7 +188,7 @@ const Basic = () => (
     <Formik
       initialValues={{ email: '', password: '' }}
       validate={values => {
-        let errors = {};
+        const errors = {};
         if (!values.email) {
           errors.email = 'Required';
         } else if (


### PR DESCRIPTION
When only properties are updated on the error object it should be `const` not `let`.

-----
[View rendered docs/guides/validation.md](https://github.com/karl-run/formik/blob/patch-2/docs/guides/validation.md)