### PR TITLE
Fix runtime error in useFormikContext example

### DIFF
--- a/docs/api/useFormikContext.md
+++ b/docs/api/useFormikContext.md
@@ -33,7 +33,7 @@ const TwoFactorVerificationForm = () => (
     <Formik
       initialValues={{ token: '' }}
       validate={values => {
-        let errors;
+        const errors = {};
         if (values.token.length < 5) {
           errors.token = 'Invalid code. Too short.'
         }


### PR DESCRIPTION
Previous implementation would have caused an `Uncaught TypeError: Cannot read property 'token' of undefined`

-----
[View rendered docs/api/useFormikContext.md](https://github.com/karl-run/formik/blob/patch-3/docs/api/useFormikContext.md)