### PR TITLE
Fix dirty flag when calling resetForm with current values

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -847,7 +847,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   const dirty = React.useMemo(
     () => !isEqual(initialValues.current, state.values),
-    [state.values]
+    [initialValues.current, state.values]
   );
 
   const isValid = React.useMemo(

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -881,6 +881,19 @@ describe('<Formik>', () => {
     });
   });
 
+  describe('resetForm', () => {
+    it('should reset dirty when reseting to same values', () => {
+      const { getProps } = renderFormik();
+      expect(getProps().dirty).toBe(false);
+
+      getProps().setFieldValue('name', 'jared-next');
+      expect(getProps().dirty).toBe(true);
+
+      getProps().resetForm({ values: getProps().values });
+      expect(getProps().dirty).toBe(false);
+    });
+  });
+
   describe('prepareDataForValidation', () => {
     it('should works correctly with instances', () => {
       class SomeClass {}


### PR DESCRIPTION
When you are resetting the form using `resetForm` and specify current
formik values as the next state the dirty hook won't be run since the
current values didn't change. This adds `intialValues.current` as a
dependency so the hook will run again if either of these changes.

This fixes the dirty part of issue #1976.