### PR TITLE
Change `isSubmitting` behaviour to mimic v1

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -8,7 +8,7 @@ export type FormikFormProps = Pick<
     'onReset' | 'onSubmit'
   >
 >;
-    
+
 type FormProps = React.ComponentPropsWithoutRef<'form'>;
 
 // @todo tests

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -710,7 +710,12 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       (combinedErrors: FormikErrors<Values>) => {
         const isActuallyValid = Object.keys(combinedErrors).length === 0;
         if (isActuallyValid) {
-          return Promise.resolve(executeSubmit())
+          const promiseOrUndefined = executeSubmit();
+          if (promiseOrUndefined === undefined) {
+            return;
+          }
+
+          return Promise.resolve(promiseOrUndefined)
             .then(() => {
               if (!!isMounted.current) {
                 dispatch({ type: 'SUBMIT_SUCCESS' });

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -203,7 +203,10 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Submission handler
    */
-  onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void;
+  onSubmit: (
+    values: Values,
+    formikHelpers: FormikHelpers<Values>
+  ) => void | Promise<void>;
   /**
    * A Yup Schema or a function that returns a Yup schema
    */

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -1144,7 +1144,7 @@ describe('<Formik>', () => {
     expect(getProps().submitCount).toEqual(1);
   });
 
-  it('isSubmitting is fired when submit is attempted', async () => {
+  it('isSubmitting is fired when submit is attempted (v1)', async () => {
     const onSubmit = jest.fn();
     const validate = jest.fn(() => Promise.resolve({}));
 
@@ -1164,6 +1164,34 @@ describe('<Formik>', () => {
     // do it again async
     await validatePromise;
     // done validating and submitting
+    expect(getProps().isSubmitting).toBe(true);
+    expect(getProps().isValidating).toBe(false);
+    expect(validate).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+    expect(getProps().submitCount).toEqual(1);
+  });
+
+  it('isSubmitting is fired when submit is attempted (v2, promise)', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const validate = jest.fn(() => Promise.resolve({}));
+
+    const { getProps } = renderFormik({
+      onSubmit,
+      validate,
+    });
+
+    expect(getProps().submitCount).toEqual(0);
+    expect(getProps().isSubmitting).toBe(false);
+    expect(getProps().isValidating).toBe(false);
+    // we call set isValidating synchronously
+    const validatePromise = getProps().submitForm();
+    // so it should change
+    expect(getProps().isSubmitting).toBe(true);
+    expect(getProps().isValidating).toBe(true);
+    // do it again async
+    await validatePromise;
+    // done validating and submitting
+    expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);
     expect(validate).toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalled();


### PR DESCRIPTION
In version 2 the behaviour of `isSubmitting` was changed from having the
user handle its state after submitting to always resetting it to false
after the `onSubmit` handler had returned (or it's promise). This reverts
it back to the version 1 behaviour of not touching the `isSubmitting`
state after the `onSubmit` handler has been called.

Solves: #1957