### PR TITLE
Added v2 migration note on `FormikActions` rename to `FormikHelpers`

### DIFF
--- a/MIGRATING-v2.md
+++ b/MIGRATING-v2.md
@@ -235,6 +235,7 @@ export interface FieldMetaProps<Value> {
 - `FormikContext` is now exported
 - `validateOnMount?: boolean = false`
 - `initialErrors`, `initialTouched`, `initialStatus` have been added
+- `FormikActions` type has been renamed to `FormikHelpers`
 
 ## Deprecation Warnings
 


### PR DESCRIPTION


-----
[View rendered MIGRATING-v2.md](https://github.com/fabb/formik/blob/patch-2/MIGRATING-v2.md)