### PR TITLE
Mention FormikActions renamed to FormikHelpers in migration guide

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -26,6 +26,21 @@ resetForm(nextValues);
 resetForm({ values: nextValues /* errors, touched, etc ... */ });
 ```
 
+### Typescript changes
+**`FormikActions` has been renamed to `FormikHelpers`** It should be a straightforward change to import or alias the type
+
+**v1**
+
+```tsx
+import { FormikActions } from 'formik';
+```
+
+**v2**
+
+```tsx
+import { FormikHelpers as FormikActions } from 'formik';
+```
+
 ## What's New?
 
 ### Checkboxes and Select multiple


### PR DESCRIPTION
Was just updating to V2 and noticed that the name had been changed, figured it could be good to mention it in the migration guide

-----
[View rendered docs/migrating-v2.md](https://github.com/qw-in/formik/blob/patch-3/docs/migrating-v2.md)