### PR TITLE
Use FormikHelpers instead of FormikActions in the example

### DIFF
--- a/examples/Basic.tsx
+++ b/examples/Basic.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Formik, Field, Form, FormikActions } from 'formik';
+import { Formik, Field, Form, FormikHelpers } from 'formik';
 
 interface Values {
   firstName: string;
@@ -16,7 +16,7 @@ const Basic: React.SFC<{}> = () => (
         lastName: '',
         email: '',
       }}
-      onSubmit={(values: Values, { setSubmitting }: FormikActions<Values>) => {
+      onSubmit={(values: Values, { setSubmitting }: FormikHelpers<Values>) => {
         setTimeout(() => {
           alert(JSON.stringify(values, null, 2));
           setSubmitting(false);

--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -27,7 +27,6 @@ import { FormikProvider } from './FormikContext';
 import invariant from 'tiny-warning';
 import { LowPriority, unstable_runWithPriority } from 'scheduler';
 
-// We already used FormikActions. So we'll go all Elm-y, and use Message.
 type FormikMessage<Values> =
   | { type: 'SUBMIT_ATTEMPT' }
   | { type: 'SUBMIT_FAILURE' }

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -582,7 +582,7 @@ describe('<Formik>', () => {
       });
     });
 
-    describe('FormikActions', () => {
+    describe('FormikHelpers', () => {
       it('setValues sets values', () => {
         const { getProps } = renderFormik<Values>();
 


### PR DESCRIPTION
As discussed in #1947 - the example still mentions `FormikActions`, which has been renamed to `FormikHelpers`.