### PR TITLE
Fix no target error

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -561,6 +561,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         if ((eventOrTextValue as React.ChangeEvent<any>).persist) {
           (eventOrTextValue as React.ChangeEvent<any>).persist();
         }
+        const target = eventOrTextValue.target ? (eventOrTextValue as React.ChangeEvent<any>).target : (eventOrTextValue as React.ChangeEvent<any>).currentTarget;
+        
         const {
           type,
           name,
@@ -570,7 +572,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
           outerHTML,
           options,
           multiple,
-        } = (eventOrTextValue as React.ChangeEvent<any>).target;
+        } = target;
 
         field = maybePath ? maybePath : name ? name : id;
         if (!field && __DEV__) {


### PR DESCRIPTION
I've updated from 1.5.1 to 2.0.3

Since then, I've suffered from no target error while using checkbox.

Please look at My implementation.

```tsx
public render() {
    ...
    return (
      <div style={style} className={className} {...restProps}>
        <Container inline={inline}>
          {checked ? (
            <CheckboxOn fillColor={disabled ? gray300 : undefined} size={size} />
          ) : (
            <CheckboxOff size={size} fillColor={disabled ? gray300 : undefined} />
          )}
          <HiddenCheckboxInput
            onChange={this.handleChange}
            checked={checked}
            style={inputStyle}
            disabled={disabled}
            {...inputAttributes}
            type="checkbox"
          />
          <ChildText color={disabled ? gray300 : undefined}>{children}</ChildText>
        </Container>
      ...
      </div>
    );
  }

  private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    if (this.props.onChange !== undefined) {
      let event = e;
      event.target = e.currentTarget;
      console.log(e.currentTarget.type, event);
      this.props.onChange(e);
    }
  };
```

to use this custom checkbox
```tsx
return (
      <Field
        name={name}
        validate={validate}
        render={({ field: { value, onChange, onBlur }, form }: FieldProps<boolean>) => {
          const error = get(form.errors, name);
          const touched = get(form.touched, name);

          return (
            <Checkbox
              className={className}
              checked={value}
              onChange={onChange}
              inline={inline}
              style={containerStyle}
              inputStyle={style}
              inputAttributes={{ name, onBlur }}
              {...props}
              errorMessage={touched ? error : undefined}
            >
              {children}
            </Checkbox>
          );
        }}
      />
    );
```