### PR TITLE
Call validateFormWithLowPriority with correct values

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -516,7 +516,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   const setValues = useEventCallback((values: Values) => {
     dispatch({ type: 'SET_VALUES', payload: values });
     return validateOnChange
-      ? validateFormWithLowPriority(state.values)
+      ? validateFormWithLowPriority(values)
       : Promise.resolve();
   });
 
@@ -922,7 +922,7 @@ export function Formik<
         ? render(formikbag)
         : children // children come last, always called
         ? isFunction(children)
-          ? (children as ((bag: FormikProps<Values>) => React.ReactNode))(
+          ? (children as (bag: FormikProps<Values>) => React.ReactNode)(
               formikbag as FormikProps<Values>
             )
           : !isEmptyChildren(children)

--- a/test/Formik.test.tsx
+++ b/test/Formik.test.tsx
@@ -591,13 +591,15 @@ describe('<Formik>', () => {
       });
 
       it('setValues should run validations when validateOnChange is true (default)', async () => {
-        const validate = jest.fn(() => ({}));
-        const { getProps, rerender } = renderFormik({ validate });
+        const newValue: Values = { name: 'ian' };
+        const validate = jest.fn(_values => ({}));
+        // const { getProps, rerender } = renderFormik({ validate });
+        const { getProps } = renderFormik({ validate });
 
-        getProps().setValues({ name: 'ian' });
-        rerender();
+        getProps().setValues(newValue);
+        // rerender();
         await wait(() => {
-          expect(validate).toHaveBeenCalled();
+          expect(validate).toHaveBeenCalledWith(newValue, undefined);
         });
       });
       it('setValues should NOT run validations when validateOnChange is false', async () => {


### PR DESCRIPTION
Fixes #1977 

- When using `setValues` `dispatch` is called with type: SET_VALUES and
payload: values. However the state update happens asynchronously so when
`validateFormWithLowPriority` is called, `state.values` still hasn't
been updated.
- This fix improves the assertion for the `setValues`
validation to test to confirm that the expected value is given to
Formik's validate function.
- The fix itself is to call `validateFormWithLowPriority` with the
`values` parameter given to `setValues` itself, instead of waiting for
the `useReducer` to update the state. Currently it does not seem to be
possible to wait for `dispatch` to have completed.