### PR TITLE
Fix checkbox with null value

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -922,7 +922,7 @@ export function Formik<
         ? render(formikbag)
         : children // children come last, always called
         ? isFunction(children)
-          ? (children as ((bag: FormikProps<Values>) => React.ReactNode))(
+          ? (children as (bag: FormikProps<Values>) => React.ReactNode)(
               formikbag as FormikProps<Values>
             )
           : !isEmptyChildren(children)
@@ -1053,13 +1053,13 @@ function getValueForCheckbox(
     return !!checked;
   }
 
-  if (checked) {
+  if (checked && valueProp) {
     return Array.isArray(currentValue)
       ? currentValue.concat(valueProp)
       : [valueProp];
   }
   if (!Array.isArray(currentValue)) {
-    return !!currentValue;
+    return !currentValue;
   }
   const index = currentValue.indexOf(valueProp);
   if (index < 0) {


### PR DESCRIPTION
Fixes #2002 

A checkbox initialized with a `null` value could not be unchecked.

CodeSandbox of the issue: https://codesandbox.io/s/formik-example-lej56