### PR TITLE
package.json: remove unused lodash-es dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "deepmerge": "^2.1.1",
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.14",
-    "lodash-es": "^4.17.14",
     "react-fast-compare": "^2.0.1",
     "scheduler": "^0.17.0",
     "tiny-warning": "^1.0.2",


### PR DESCRIPTION
I was using `yarn why` on my project, and I noticed that lodash-es seems to be a spurious dependency. (Formik only ever imports from `'lodash'`.)