### PR TITLE
Note about lack of file support

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -8,6 +8,8 @@ custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/fiel
 attribute to match up with Formik state. `<Field />` will default to an HTML
 `<input />` element.
 
+*Note* - Formik doesn't currently support `type="file"`. Please refer to [this issue](https://github.com/jaredpalmer/formik/issues/45) for various solutions as to uploading a file while using Formik. 
+
 ## Rendering
 
 There are 2 ways to render things with `<Field>`.


### PR DESCRIPTION
It was my assumption (like many others as per the issue I referenced above) that this library would handle file uploads. Based on this assumption I thought I was using the library wrong when the file wouldn't upload correctly. It would've saved me a lot of time and effort if there was a note somewhere in the docs clearly stating that it cannot handle file uploads. So, this is that note.

This seemed the most obvious place to put it. Let me know if y'all would rather it elsewhere.