### PR TITLE
Avoid unnecessary re-renders by comparing errors to previous errors

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -60,6 +60,10 @@ function formikReducer<Values>(
     case 'SET_TOUCHED':
       return { ...state, touched: msg.payload };
     case 'SET_ERRORS':
+      if (isEqual(state.errors, msg.payload)) {
+        return state;
+      }
+
       return { ...state, errors: msg.payload };
     case 'SET_STATUS':
       return { ...state, status: msg.payload };


### PR DESCRIPTION
This addresses part of #1974

Each time any field is touched (onChange, onBlur) the errors on the context changed, causing all fields to re-render once more than needed (2 renders per change)

This fix will compare the new errors object being assigned to the existing one, and only change the state if they are different.

FastField is still fundamentally broken, because it will re-render on each change to the context. Should be fixed in #2070