### PR TITLE
handle an empty array value argument to setIn

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,10 @@ import * as React from 'react';
 
 // Assertions
 
+/** @private is the value an empty array? */
+export const isEmptyArray = (value?: any) =>
+  Array.isArray(value) && value.length === 0;
+
 /** @private is the given object a Function? */
 export const isFunction = (obj: any): obj is Function =>
   typeof obj === 'function';
@@ -123,7 +127,7 @@ export function setIn(obj: any, path: string, value: any): any {
     return obj;
   }
 
-  if (value === undefined) {
+  if (value === undefined || isEmptyArray(value)) {
     delete resVal[pathArray[i]];
   } else {
     resVal[pathArray[i]] = value;
@@ -131,7 +135,7 @@ export function setIn(obj: any, path: string, value: any): any {
 
   // If the path array has a single element, the loop did not run.
   // Deleting on `resVal` had no effect in this scenario, so we delete on the result instead.
-  if (i === 0 && value === undefined) {
+  if ((i === 0 && value === undefined) || isEmptyArray(value)) {
     delete res[pathArray[i]];
   }
 

--- a/test/utils.test.tsx
+++ b/test/utils.test.tsx
@@ -1,4 +1,5 @@
 import {
+  isEmptyArray,
   setIn,
   setNestedObjectValues,
   isPromise,
@@ -7,6 +8,20 @@ import {
 } from '../src/utils';
 
 describe('utils', () => {
+  describe('isEmptyArray', () => {
+    it('returns true when an empty array is passed in', () => {
+      expect(isEmptyArray([])).toBe(true);
+    });
+    it('returns false when anything other than empty array is passed in', () => {
+      expect(isEmptyArray()).toBe(false);
+      expect(isEmptyArray(null)).toBe(false);
+      expect(isEmptyArray(123)).toBe(false);
+      expect(isEmptyArray('abc')).toBe(false);
+      expect(isEmptyArray({})).toBe(false);
+      expect(isEmptyArray({ a: 1 })).toBe(false);
+      expect(isEmptyArray(['abc'])).toBe(false);
+    });
+  });
   describe('setNestedObjectValues', () => {
     it('sets value flat object', () => {
       const obj = { x: 'y' };


### PR DESCRIPTION
setIn checks for an undefined value argument but does not check for empty array. This is causing the bug described in:

https://github.com/jaredpalmer/formik/issues/2050

This change resolves the bug by treating a value of empty array like an undefined value for purposes of removing arrays.