### PR TITLE
Fix FormikHelpers types

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -86,16 +86,12 @@ export interface FormikHelpers<Values> {
   /** Manually set values object  */
   setValues(values: Values): void;
   /** Set value of form field directly */
-  setFieldValue(
-    field: keyof Values & string,
-    value: any,
-    shouldValidate?: boolean
-  ): void;
+  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
   /** Set error message of a form field directly */
-  setFieldError(field: keyof Values & string, message: string): void;
+  setFieldError(field: string, message: string): void;
   /** Set whether field has been touched directly */
   setFieldTouched(
-    field: keyof Values & string,
+    field: string,
     isTouched?: boolean,
     shouldValidate?: boolean
   ): void;


### PR DESCRIPTION
This is a fix for issue https://github.com/jaredpalmer/formik/issues/2065
The root cause is that https://github.com/jaredpalmer/formik/blob/master/src/types.tsx#L90 and the other similar type definition don't do what was the intention to do.
As string literal types are subtypes of the type ```string```, ```keyof Values & string``` is equivalent to just ```keyof Values ```, as ```keyof Values | string``` is equivalent to just ```string```. This can . be easily seen in vscode hovering over the function, and seeing that the shown type has the relative part eresed.
Unfortunately this means that for TS users not just nested fields cannot be used without a cast to ```any```, but even common idioms like ```form.setFieldValue(field.name)```, required with many components library with a non standard onChange, require a cast to any.
The funny thing is that this mistake is not new. It's in the code base since more than 1 year. This can be seen in version 1.5.8 https://github.com/jaredpalmer/formik/blob/v1.5.8/src/types.tsx#L86 , where the code is the same.
But it had no effect as in https://github.com/jaredpalmer/formik/blob/v1.5.8/src/types.tsx#L119, possibly after an unintended merge conflict, the same type was overridden with the right one.
Unfortunately the same override is not possible, AFAIK, with types in external libraries used as part of type alias, as it happens in v2.