### PR TITLE
Ensure dirty is reevaluated when form is reset

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -855,7 +855,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   const dirty = React.useMemo(
     () => !isEqual(initialValues.current, state.values),
-    [state.values]
+    [initialValues.current, state.values]
   );
 
   const isValid = React.useMemo(


### PR DESCRIPTION
I was seeing an issue where calling `resetForm` wasn't resetting the
`dirty` state. `dirty` is memoized, but the cache was only set to bust
on one of it's dependencies - `state.values`. Now, it also depends on
`initialValues.current`, which is updated when you call `resetForm`.

Interestingly, it looks like the `initialValues.current` dependency used
to exist, but was removed [here](https://github.com/jaredpalmer/formik/commit/2a08d5eb3b0c964c7ec3e1aeb59a3743f7cd7941#diff-18d1f112a814aca08509a74bded25fbfL696).
It's a large commit, and there isn't much context, so I'm wondering if
it may have been an accident.