### PR TITLE
add validationSchema to FormikContext

### DIFF
--- a/src/Formik.tsx
+++ b/src/Formik.tsx
@@ -564,8 +564,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         if ((eventOrTextValue as React.ChangeEvent<any>).persist) {
           (eventOrTextValue as React.ChangeEvent<any>).persist();
         }
-        const target = eventOrTextValue.target ? (eventOrTextValue as React.ChangeEvent<any>).target : (eventOrTextValue as React.ChangeEvent<any>).currentTarget;
-        
+        const target = eventOrTextValue.target
+          ? (eventOrTextValue as React.ChangeEvent<any>).target
+          : (eventOrTextValue as React.ChangeEvent<any>).currentTarget;
+
         const {
           type,
           name,
@@ -914,7 +916,7 @@ export function Formik<
   ExtraProps = {}
 >(props: FormikConfig<Values> & ExtraProps) {
   const formikbag = useFormik<Values>(props);
-  const { component, children, render } = props;
+  const { component, children, render, validationSchema } = props;
   React.useEffect(() => {
     if (__DEV__) {
       invariant(
@@ -925,7 +927,12 @@ export function Formik<
     // eslint-disable-next-line
   }, []);
   return (
-    <FormikProvider value={formikbag}>
+    <FormikProvider
+      value={{
+        ...formikbag,
+        validationSchema,
+      }}
+    >
       {component
         ? React.createElement(component as any, formikbag)
         : render

--- a/test/FormikContext.test.tsx
+++ b/test/FormikContext.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { Formik } from '../src/Formik';
+import { useFormikContext } from '../src/FormikContext';
+
+describe('FormikContext', () => {
+  describe('useFormikContext', () => {
+    it('should return validationContext if set', () => {
+      const validationSchema = 'validationSchema';
+
+      const AComponenent: React.FC = () => {
+        const formikContext = useFormikContext();
+        expect(formikContext.validationSchema).toBe(validationSchema);
+        return null;
+      };
+
+      render(
+        <Formik
+          initialValues={{ test: '' }}
+          validationSchema={validationSchema}
+          onSubmit={() => {}}
+        >
+          <AComponenent />
+        </Formik>
+      );
+    });
+  });
+});


### PR DESCRIPTION
```useFormikContext``` doesn't return ```validationSchema,``` although the type says it should do and the ```connect```in v1 did.
This PR fixes the problem and adds a specific test for this case.