### PR TITLE
hotfix: Revert throwing combined errors

### DIFF
--- a/packages/formik-native/test/blah.test.ts
+++ b/packages/formik-native/test/blah.test.ts
@@ -1,7 +1,5 @@
-import { sum } from '../src';
-
 describe('blah', () => {
   it('works', () => {
-    expect(sum(1, 1)).toEqual(2);
+    expect(1).toEqual(1);
   });
 });

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -564,8 +564,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         if ((eventOrTextValue as React.ChangeEvent<any>).persist) {
           (eventOrTextValue as React.ChangeEvent<any>).persist();
         }
-        const target = eventOrTextValue.target ? (eventOrTextValue as React.ChangeEvent<any>).target : (eventOrTextValue as React.ChangeEvent<any>).currentTarget;
-        
+        const target = eventOrTextValue.target
+          ? (eventOrTextValue as React.ChangeEvent<any>).target
+          : (eventOrTextValue as React.ChangeEvent<any>).currentTarget;
+
         const {
           type,
           name,
@@ -715,7 +717,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       (combinedErrors: FormikErrors<Values>) => {
         const isActuallyValid = Object.keys(combinedErrors).length === 0;
         if (isActuallyValid) {
+          // Proceed with submit
           const promiseOrUndefined = executeSubmit();
+          // Bail if it's sync, consumer is responsible for cleaning up
+          // via setSubmitting(false)
           if (promiseOrUndefined === undefined) {
             return;
           }
@@ -729,13 +734,14 @@ export function useFormik<Values extends FormikValues = FormikValues>({
             .catch(_errors => {
               if (!!isMounted.current) {
                 dispatch({ type: 'SUBMIT_FAILURE' });
+                // This is a legit error rejected by the onSubmit fn
+                // so we don't want to break the promise chain
                 throw _errors;
               }
             });
         } else if (!!isMounted.current) {
           // ^^^ Make sure Formik is still mounted before calling setState
           dispatch({ type: 'SUBMIT_FAILURE' });
-          throw combinedErrors;
         }
         return;
       }

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -580,18 +580,6 @@ describe('<Formik>', () => {
         fireEvent.submit(getByTestId('form'));
         expect(validate).toHaveBeenCalled();
       });
-
-      it('should not submit the form if validate function rejects with an error', async () => {
-        const onSubmit = jest.fn();
-        const validationSchema = Yup.object().shape({
-          field: Yup.string().required('required'),
-        });
-
-        const { getProps } = renderFormik({ onSubmit, validationSchema });
-        await expect(getProps().submitForm()).rejects.toEqual({
-          field: 'required',
-        });
-      });
     });
 
     describe('FormikHelpers', () => {


### PR DESCRIPTION
I confused myself this morning with 2.0.7. The change to submission is making formik unusable outside of react native. 

Revert changes in #1843 