### PR TITLE
Abort submit if instance of real Error

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,14 +12,13 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node: ['10.x', '12.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
 
-    name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
+    name: Test on node ${{ matrix.node }}
 
     steps:
       - uses: actions/checkout@v1

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -721,7 +721,14 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         // If we don't do that, calling `Object.keys(new Error())` yields an
         // empty array, which causes the validation to pass and the form
         // to be submitted.
-        const isInstanceOfError = combinedErrors instanceof Error;
+        if (combinedErrors instanceof Error) {
+          if (!!isMounted.current) {
+            // ^^^ Make sure Formik is still mounted before calling setState
+            dispatch({ type: 'SUBMIT_FAILURE' });
+          }
+          throw combinedErrors;
+        }
+
         const isActuallyValid = Object.keys(combinedErrors).length === 0;
         if (isActuallyValid) {
           // Proceed with submit
@@ -746,12 +753,6 @@ export function useFormik<Values extends FormikValues = FormikValues>({
                 throw _errors;
               }
             });
-        } else if (!!isMounted.current) {
-          // ^^^ Make sure Formik is still mounted before calling setState
-          dispatch({ type: 'SUBMIT_FAILURE' });
-          if (isInstanceOfError) {
-            throw combinedErrors;
-          }
         }
         return;
       }

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1132,7 +1132,9 @@ describe('<Formik>', () => {
 
   it('isValidating is fired when submit is attempted', async () => {
     const onSubmit = jest.fn();
-    const validate = jest.fn(() => ({ name: 'no' }));
+    const validate = jest.fn(() => ({
+      name: 'no',
+    }));
 
     const { getProps } = renderFormik({
       onSubmit,


### PR DESCRIPTION
Because of the new behavior in 2.0.7, we actually need to change our validity check in submitForm to deal with what happens if there is an error thrown in validate somehow. 2.0.7 exacerbated this bug by logging it to the console. With this change, Formik will only throw the error if it is an instance of error

Fix #1198 