### PR TITLE
Fix nav search box on big screens

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -344,4 +344,7 @@ pre[class*="language-"] {
   .reactNavSearchWrapper {
     top: auto;
   }
+  .reactNavSearchWrapper input#search_input_react {
+    line-height: 18px;
+  }
 }


### PR DESCRIPTION
Search box is broken on the website (desktop version), it's overflowing out of the navbar