### PR TITLE
(ts): fix use field typing

### DIFF
--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -12,8 +12,14 @@ custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/usef
 import React from 'react';
 import { useField, Formik } from 'formik';
 
+type FormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+};
+
 const MyTextField = ({ label, ...props }) => {
-  const [field, meta] = useField(props);
+  const [field, meta] = useField<string>(props);
   return (
     <>
       <label>
@@ -57,7 +63,7 @@ const Example = () => (
 
 ## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>]`
 
-A custom React Hook that returns a tuple (2 element array) containing `FieldProps` and `FieldMetaProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should identical to the props that you would pass to `<Field>` and the returned helpers will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
+A custom React Hook that returns a tuple (2 element array) containing `FieldInputProps` and `FieldMetaProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should be identical to the props that you would pass to `<Field>` and the returned helpers will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 
 ```jsx
 import React from 'react';
@@ -65,7 +71,7 @@ import { useField } from 'formik';
 
 function MyTextField(props) {
   // this will return field props for an <input />
-  const [field, meta] = useField(props.name);
+  const [field, meta] = useField<string>(props.name);
   return (
     <>
       <input {...field} {...props} />
@@ -86,7 +92,7 @@ function MyInput(props) {
 }
 ```
 
-### `FieldInputProps`
+### `FieldInputProps<Value>`
 
 An object that contains:
 
@@ -94,16 +100,16 @@ An object that contains:
 - `checked?: boolean` - Whether or not the input is checked, this is _only_ defined if `useField` is passed an object with a `name`, `type: "checkbox"` or `type: radio`.
 - `onBlur: () => void;` - A blur event handler
 - `onChange: (e: React.ChangeEvent<any>) => void` - A change event handler
-- `value: any` - The field's value (plucked out of `values`) or, if it is a checkbox or radio input, then potentially the `value` passed into `useField`.
+- `value: Value` - The field's value (plucked out of `values`) or, if it is a checkbox or radio input, then potentially the `value` passed into `useField`.
 - `multiple?: boolean` - Whether or not the multiple values can be selected. This is only ever defined when `useField` is passed an object with `multiple: true`
 
-### `FieldMetaProps`
+### `FieldMetaProps<Value>`
 
 An object that contains relevant computed metadata about a field. More specifically,
 
 - `error?: string` - The field's error message (plucked out of `errors`)
 - `initialError?: string` - The field's initial error if the field is present in `initialErrors` (plucked out of `initialErrors`)
 - `initialTouched: boolean` - The field's initial value if the field is present in `initialTouched` (plucked out of `initialTouched`)
-- `initialValue?: any` - The field's initial value if the field is given a value in `initialValues` (plucked out of `initialValues`)
+- `initialValue?: Value` - The field's initial value if the field is given a value in `initialValues` (plucked out of `initialValues`)
 - `touched: boolean` - Whether the field has been visited (plucked out of `touched`)
-- `value: any` - The field's value (plucked out of `values`)
+- `value: Value` - The field's value (plucked out of `values`)

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -80,13 +80,16 @@ export function useField<Val = any>(
     registerField,
     unregisterField,
   } = formik;
+
   const isAnObject = isObject(propsOrFieldName);
-  const fieldName = isAnObject
-    ? (propsOrFieldName as FieldHookConfig<Val>).name
-    : (propsOrFieldName as string);
-  const validateFn = isAnObject
-    ? (propsOrFieldName as FieldHookConfig<Val>).validate
-    : undefined;
+
+  // Normalize propsOrFieldName to FieldHookConfig<Val>
+  const props: FieldHookConfig<Val> = isAnObject
+    ? (propsOrFieldName as FieldHookConfig<Val>)
+    : { name: propsOrFieldName as string };
+
+  const { name: fieldName, validate: validateFn } = props;
+
   React.useEffect(() => {
     if (fieldName) {
       registerField(fieldName, {
@@ -99,6 +102,7 @@ export function useField<Val = any>(
       }
     };
   }, [registerField, unregisterField, fieldName, validateFn]);
+
   if (__DEV__) {
     invariant(
       formik,
@@ -106,22 +110,12 @@ export function useField<Val = any>(
     );
   }
 
-  if (isObject(propsOrFieldName)) {
-    invariant(
-      (propsOrFieldName as FieldAttributes<Val>).name,
-      'Invalid field name. Either pass `useField` a string or an object containing a `name` key.'
-    );
+  invariant(
+    fieldName,
+    'Invalid field name. Either pass `useField` a string or an object containing a `name` key.'
+  );
 
-    return [
-      getFieldProps(propsOrFieldName),
-      getFieldMeta((propsOrFieldName as FieldAttributes<Val>).name),
-    ];
-  }
-
-  return [
-    getFieldProps({ name: propsOrFieldName }),
-    getFieldMeta(propsOrFieldName),
-  ];
+  return [getFieldProps(props), getFieldMeta(fieldName)];
 }
 
 export function Field({

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -10,9 +10,9 @@ import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren, isObject } from './utils';
 import invariant from 'tiny-warning';
 
-export interface FieldProps<V = any> {
+export interface FieldProps<V = any, FormValues = any> {
   field: FieldInputProps<V>;
-  form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
+  form: FormikProps<FormValues>; // if ppl want to restrict this for a given form, let them.
   meta: FieldMetaProps<V>;
 }
 

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -16,20 +16,20 @@ export interface FieldProps<V = any> {
   meta: FieldMetaProps<V>;
 }
 
-export interface FieldConfig {
+export interface FieldConfig<V = any> {
   /**
    * Field component to render. Can either be a string like 'select' or a component.
    */
   component?:
     | keyof JSX.IntrinsicElements
-    | React.ComponentType<FieldProps<any>>
+    | React.ComponentType<FieldProps<V>>
     | React.ComponentType;
 
   /**
    * Component to render. Can either be a string e.g. 'select', 'input', or 'textarea', or a component.
    */
   as?:
-    | React.ComponentType<FieldProps<any>['field']>
+    | React.ComponentType<FieldProps<V>['field']>
     | keyof JSX.IntrinsicElements
     | React.ComponentType;
 
@@ -37,12 +37,12 @@ export interface FieldConfig {
    * Render prop (works like React router's <Route render={props =>} />)
    * @deprecated
    */
-  render?: (props: FieldProps<any>) => React.ReactNode;
+  render?: (props: FieldProps<V>) => React.ReactNode;
 
   /**
    * Children render function <Field name>{props => ...}</Field>)
    */
-  children?: ((props: FieldProps<any>) => React.ReactNode) | React.ReactNode;
+  children?: ((props: FieldProps<V>) => React.ReactNode) | React.ReactNode;
 
   /**
    * Validate a single field value independently
@@ -65,11 +65,13 @@ export interface FieldConfig {
 }
 
 export type FieldAttributes<T> = GenericFieldHTMLAttributes &
-  FieldConfig &
+  FieldConfig<T> &
   T & { name: string };
 
+export type FieldHookConfig<T> = GenericFieldHTMLAttributes & FieldConfig<T>;
+
 export function useField<Val = any>(
-  propsOrFieldName: string | FieldAttributes<Val>
+  propsOrFieldName: string | FieldHookConfig<Val>
 ): [FieldInputProps<Val>, FieldMetaProps<Val>] {
   const formik = useFormikContext();
   const {
@@ -80,10 +82,10 @@ export function useField<Val = any>(
   } = formik;
   const isAnObject = isObject(propsOrFieldName);
   const fieldName = isAnObject
-    ? (propsOrFieldName as FieldAttributes<Val>).name
+    ? (propsOrFieldName as FieldHookConfig<Val>).name
     : (propsOrFieldName as string);
   const validateFn = isAnObject
-    ? (propsOrFieldName as FieldAttributes<Val>).validate
+    ? (propsOrFieldName as FieldHookConfig<Val>).validate
     : undefined;
   React.useEffect(() => {
     if (fieldName) {


### PR DESCRIPTION
This PR fixes #1961 by correcting the parameter type of useField when field type is specified and a props object is passed.

useField was taking FieldAttributes<Val> as argument. If Val is of type string or other primitive type, FieldAttributes<Val> will be invalid because primitive type can't be intersected with other type.  In other words, the following type is invalid.

```typescript
GenericFieldHTMLAttributes & FieldConfig & string & { name: string }
```

This results in a type error. When the default type for Val is any. It broadens the above type to 'any' and hence the default behavior of useField works when you don't explicitly specify the field's type.

-----
[View rendered docs/api/useField.md](https://github.com/lightwave/formik/blob/hotfix/fix-useField-typing/docs/api/useField.md)