### PR TITLE
Update contributing guidelines start step

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. Fork this repository to your own GitHub account and then clone it to your local device.
 2. Install the dependencies: `yarn install`
 3. Run `yarn link` to link the local repo to NPM
-4. Run `yarn start` to build and watch for code changes
+4. Run `cd packages/formik && yarn start` to build and watch for code changes
 5. Run `yarn test` to start Jest
 7. Then npm link this repo inside any other project on your local dev with `yarn link formik`
 8. Then you can use your local version of Formik within your project


### PR DESCRIPTION
The `yarn start` step in the contributing guidelines is not reflecting the recently introduced package structure.

The `package.json` file at the root of the project doesn't provide a `start` script, therefore running `yarn start` from there causes the following error:
```sh
error Command "start" not found.
```

-----
[View rendered .github/CONTRIBUTING.md](https://github.com/eliamaino-fp/formik/blob/patch-1/.github/CONTRIBUTING.md)