### PR TITLE
Fix broken formatting on useField docs

### DIFF
--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -150,6 +150,6 @@ An object that contains relevant computed metadata about a field. More specifica
 
 An object that contains helper functions which you can use to imperatively change the value, error value or touched status for the field in question. This is useful for components which need to change a field's status directly, without triggering change or blur events.
 
-`setValue(value: any): void` - A function to change the field's value
-`setTouched(value: boolean): void` - A function to change the field's touched status
-`setError(value: any): void` - A function to change the field's error value
+- `setValue(value: any): void` - A function to change the field's value
+- `setTouched(value: boolean): void` - A function to change the field's touched status
+- `setError(value: any): void` - A function to change the field's error value


### PR DESCRIPTION
This makes the `FieldHelperProps` section consistent with the rest of this doc, allowing for each method to be more readable as a separate bullet point

-----
[View rendered docs/api/useField.md](https://github.com/zingerj/formik/blob/patch-1/docs/api/useField.md)