### PR TITLE
Fix for Object-like data without hasOwnProperty

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1071,7 +1071,7 @@ export function prepareDataForValidation<T extends FormikValues>(
 ): FormikValues {
   let data: FormikValues = {};
   for (let k in values) {
-    if (values.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(values, k)) {
       const key = String(k);
       if (Array.isArray(values[key]) === true) {
         data[key] = values[key].map((value: any) => {


### PR DESCRIPTION
Closes #2138

From time to time, Formik may be passed Object-like
data that does not inherit from the Object prototype.
In these cases, hasOwnProperty is not defined, and
prepareDataForValidation will throw.

The fix is to use Object.prototype to call
hasOwnProperty on the data.

See FormidableLabs/urql#343