### PR TITLE
Fix hasOwnProperty problem

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1071,7 +1071,7 @@ export function prepareDataForValidation<T extends FormikValues>(
 ): FormikValues {
   let data: FormikValues = {};
   for (let k in values) {
-    if (values.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(values, k)) {
       const key = String(k);
       if (Array.isArray(values[key]) === true) {
         data[key] = values[key].map((value: any) => {


### PR DESCRIPTION
Closes #2138

This should fix the problem with `hasOwnProperty` sometimes throwing an error.

The fix was suggested by @emrosenf and is based on [this issue](https://github.com/FormidableLabs/urql/pull/343)