### PR TITLE
Fix for checkboxes with an initial value of undefined

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1134,6 +1134,8 @@ function getValueForCheckbox(
 
   // If the currentValue was not a boolean we want to return an array
   let currentArrayOfValues = []
+  let isValueInArray = false
+  let index = -1
 
   if (!Array.isArray(currentValue)) {
     // eslint-disable-next-line eqeqeq
@@ -1143,10 +1145,10 @@ function getValueForCheckbox(
   } else {
     // If the current value is already an array, use it
     currentArrayOfValues = currentValue
+    index = currentValue.indexOf(valueProp);
+    isValueInArray = index >= 0;
   }
 
-  const index = currentValue.indexOf(valueProp);
-  const isValueInArray = index >= 0;
 
   // If the checkbox was checked and the value is not already present in the aray we want to add the new value to the array of values
   if (checked && valueProp && !isValueInArray) {


### PR DESCRIPTION
[v2.1.1 introduced a bug](https://github.com/jaredpalmer/formik/pull/2159) with checkboxes where they require an initial value in order to work. This is reproducible and is fixed by back-pinning to v2.1.0. Please view this codesandbox:

[![Edit solitary-smoke-qp6kx](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/solitary-smoke-qp6kx?fontsize=14&hidenavigation=1&theme=dark)

The `getValueForCheckbox` function in `Formik.tsx` was updated to handle checkbox values better, but it introduced a situation where a checkbox with an undefined value would throw an error, since `getValueForCheckbox` was assuming it was an array.

Stack Trace:

```javascript
Uncaught TypeError: Cannot read property 'indexOf' of undefined
    at getValueForCheckbox (formik.cjs.development.js:1216)
    at eval (formik.cjs.development.js:735)
    at eval (formik.cjs.development.js:750)
	...
```

Here is the line where it breaks:
https://github.com/jaredpalmer/formik/blob/fee503ebae0f77068a6097bd2f9be43cd5c5aaa3/packages/formik/src/Formik.tsx#L1148

The changes in this PR just shuffle the logic a tiny bit to guarantee this check does not occur unless `currentValue` is an array.

resolves #2184 

