### PR TITLE
Updated setError signature to string

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -289,7 +289,7 @@ export interface FieldHelperProps<Value> {
   /** Set the field's touched value */
   setTouched(value: boolean): void;
   /** Set the field's error value */
-  setError(value: Value): void;
+  setError(value: string): void;
 }
 
 /** Field input value, name, and event handlers */


### PR DESCRIPTION
As per comments on [here](https://github.com/jaredpalmer/formik/commit/e696e57c97a297b332be66515cbddfc8f4176321#r36783717), updated the signature of setError to take string instead of Value as param.