### PR TITLE
Add shouldValidate params to setValue, setTouched

### DIFF
--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -51,10 +51,10 @@ const Example = () => (
     >
       {(props: FormikProps<Values>) => (
         <Form>
-          <MyTextField name="firstName" type="text" label="First Name" />
-          <MyTextField name="lastName" type="text" label="Last Name" />
-          <MyTextField name="email" type="email" label="Email" />
-          <button type="submit">Submit</button>
+          <MyTextField name='firstName' type='text' label='First Name' />
+          <MyTextField name='lastName' type='text' label='Last Name' />
+          <MyTextField name='email' type='email' label='Email' />
+          <button type='submit'>Submit</button>
         </Form>
       )}
     </Formik>
@@ -150,6 +150,6 @@ An object that contains relevant computed metadata about a field. More specifica
 
 An object that contains helper functions which you can use to imperatively change the value, error value or touched status for the field in question. This is useful for components which need to change a field's status directly, without triggering change or blur events.
 
-- `setValue(value: any): void` - A function to change the field's value
-- `setTouched(value: boolean): void` - A function to change the field's touched status
+- `setValue(value: any, shouldValidate?: boolean): void` - A function to change the field's value
+- `setTouched(value: boolean, shouldValidate?: boolean): void` - A function to change the field's touched status
 - `setError(value: any): void` - A function to change the field's error value

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -889,8 +889,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   const getFieldHelpers = React.useCallback(
     (name: string): FieldHelperProps<any> => {
       return {
-        setValue: (value: any) => setFieldValue(name, value),
-        setTouched: (value: boolean) => setFieldTouched(name, value),
+        setValue: (value: any, shouldValidate?: boolean) =>
+          setFieldValue(name, value, shouldValidate),
+        setTouched: (value: boolean, shouldValidate?: boolean) =>
+          setFieldTouched(name, value, shouldValidate),
         setError: (value: any) => setFieldError(name, value),
       };
     },

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -285,9 +285,9 @@ export interface FieldMetaProps<Value> {
 /** Imperative handles to change a field's value, error and touched */
 export interface FieldHelperProps<Value> {
   /** Set the field's value */
-  setValue(value: Value): void;
+  setValue(value: Value, shouldValidate?: boolean): void;
   /** Set the field's touched value */
-  setTouched(value: boolean): void;
+  setTouched(value: boolean, shouldValidate?: boolean): void;
   /** Set the field's error value */
   setError(value: Value): void;
 }


### PR DESCRIPTION
Exposes the shouldValidate parameter from setFieldValue and setFieldTouched to useField's helpers object.

-----
[View rendered docs/api/useField.md](https://github.com/drivasperez/formik/blob/addparams/docs/api/useField.md)