### PR TITLE
Fix grammar and typos

### DIFF
--- a/docs/api/useFormik.md
+++ b/docs/api/useFormik.md
@@ -4,7 +4,9 @@ title: useFormik()
 custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/useFormik.md
 ---
 
-`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite it's name, it is not meant for the majority of usecases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext](useFormikContext). Only use this hook if you are NOT using `<Formik>` or `withFormik`. \*\*Be aware that `<Field>`, `<FastField>`, `<ErrorMessage>`, `connect()`, and `<FieldArray>` will NOT work with `useFormik()` as they all require React Context.
+`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite its name, it is not meant for the majority of use cases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext](useFormikContext). Only use this hook if you are NOT using `<Formik>` or `withFormik`.
+
+\*\* Be aware that `<Field>`, `<FastField>`, `<ErrorMessage>`, `connect()`, and `<FieldArray>` will NOT work with `useFormik()` as they all require React Context.
 
 ## Use cases for `useFormik()`
 

--- a/docs/api/useFormik.md
+++ b/docs/api/useFormik.md
@@ -4,7 +4,7 @@ title: useFormik()
 custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/useFormik.md
 ---
 
-`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite it's name, it is not meant for the majority of usecases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext]. Only use this hook if you are NOT using `<Formik>` or `withFormik`. \*\*Be aware that `<Field>`, `<FastField>`, `<ErrorMessage>`, `connect()`, and `<FieldArray>` will NOT work with `useFormik()` as they all require React Context.
+`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite it's name, it is not meant for the majority of usecases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext](useFormikContext). Only use this hook if you are NOT using `<Formik>` or `withFormik`. \*\*Be aware that `<Field>`, `<FastField>`, `<ErrorMessage>`, `connect()`, and `<FieldArray>` will NOT work with `useFormik()` as they all require React Context.
 
 ## Use cases for `useFormik()`
 


### PR DESCRIPTION
The diff isn't too clear on what changed, so here you go:
- Despite it's name -> Despite its name
- usecases -> use cases
- Turned `[useFormikContext]` into a link.
- Added line between text and warning.

Not sure if the `**` was meant to make the text bold or not?

-----
[View rendered docs/api/useFormik.md](https://github.com/stephan281094/formik/blob/patch-1/docs/api/useFormik.md)