### PR TITLE
Fix typo in api docs

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -187,7 +187,7 @@ Imperatively call your `validate` or `validateSchema` depending on what was spec
 
 #### `validateField: (field: string) => void`
 
-Imperatively call field's `validate` function if specified for given field or run schema validation using [Yup's `schema.validteAt`](https://github.com/jquense/yup#mixedvalidateatpath-string-value-any-options-object-promiseany-validationerror) and the provided top-level `validationSchema` prop. Formik will use the current field value.
+Imperatively call field's `validate` function if specified for given field or run schema validation using [Yup's `schema.validateAt`](https://github.com/jquense/yup#mixedvalidateatpath-string-value-any-options-object-promiseany-validationerror) and the provided top-level `validationSchema` prop. Formik will use the current field value.
 
 ### `component?: React.ComponentType<FormikProps<Values>>`
 


### PR DESCRIPTION
Just a small typo in [Formik component api docs](https://jaredpalmer.com/formik/docs/api/formik)

-----
[View rendered docs/api/formik.md](https://github.com/mstanielewicz/formik/blob/patch-2/docs/api/formik.md)