### PR TITLE
docs: mention that ref prop currently doesn't work

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -10,7 +10,7 @@ title: Migrating from v1.x to v2.x
 - Since Formik 2 is built on top of React Hooks, you must be on React 16.8.x or higher
 - Since Formik 2 uses the `unknown` type, you must be on TypeScript 3.0 or higher (if you use TypeScript)
 
-**There are only two tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
+**There are only three tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
 
 ### `resetForm`
 
@@ -19,6 +19,10 @@ Because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, 
 ### `validate`
 
 As you may know, you can return a Promise of a validation error from `validate`. In 1.x, it didn't matter if this promise is resolved or rejected as in both cases the payload of the promise was interpreted as the validation error. In 2.x, rejection will be interpreted as an actual exception and it won't update the form error state. Any validation function that returns a rejected promise of errors needs to be adjusted to return a resolved promise of errors instead.
+
+### `ref`
+
+Currently, you can't attach a ref to Formik using the `ref` prop. However, you still can get around this issue using the prop `innerRef`. We have some WIP [#2208](https://github.com/jaredpalmer/formik/issues/2208) to instead use `React.forwardRef`.
 
 **v1**
 


### PR DESCRIPTION
Resolves #2234 

-----
[View rendered docs/migrating-v2.md](https://github.com/brunohkbx/formik/blob/docs/mention-ref-breaking-change/docs/migrating-v2.md)