### PR TITLE
Fix typo in 'Field' docs

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -254,7 +254,7 @@ A function that returns one or more JSX elements.
 You can run independent field-level validations by passing a function to the
 `validate` prop. The function will respect the `validateOnBlur` and
 `validateOnChange` config/props specified in the `<Field>'s` parent `<Formik>`
-/ `withFormik`. This function can be either be synchronous or asynchronous:
+/ `withFormik`. This function can either be synchronous or asynchronous:
 
 - Sync: if invalid, return a `string` containing the error message or
   return `undefined`.


### PR DESCRIPTION
Minor typo fix in the 'Field' part of Formik docs.

-----
[View rendered docs/api/field.md](https://github.com/aloeugene/formik/blob/fix-typo-in-field-docs/docs/api/field.md)