### PR TITLE
Load Snack code from external source so it stays up to date

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -95,8 +95,8 @@ Once you've added this you will have access to the `window.Formik.<Insert_Compon
 
 You can play with Formik in your web browser with these live online playgrounds.
 
-- CodeSandbox (ReactDOM) https://codesandbox.io/s/zKrK5YLDZ
-- Expo Snack (React Native) https://snack.expo.io/@jaredpalmer/basic-formik-x-react-native-example
+- [CodeSandbox (ReactDOM)](https://codesandbox.io/s/zKrK5YLDZ)
+- [Snack (React Native)](https://snack.expo.io/?dependencies=yup%2Cformik%2Creact-native-paper%2Cexpo-constants&sourceUrl=https%3A%2F%2Fgist.githubusercontent.com%2Fbrentvatne%2F700e1dbf9c3e88a11aef8e557627ce3f%2Fraw%2Feeee57721c9890c1212ac34a4c37707f6354f469%2FApp.js)
 
 ## The Gist
 

--- a/website/versioned_docs/version-2.0.3/overview.md
+++ b/website/versioned_docs/version-2.0.3/overview.md
@@ -96,8 +96,8 @@ Once you've added this you will have access to the `window.Formik.<Insert_Compon
 
 You can play with Formik in your web browser with these live online playgrounds.
 
-- CodeSandbox (ReactDOM) https://codesandbox.io/s/zKrK5YLDZ
-- Expo Snack (React Native) https://snack.expo.io/@jaredpalmer/basic-formik-x-react-native-example
+- [CodeSandbox (ReactDOM)](https://codesandbox.io/s/zKrK5YLDZ)
+- [Snack (React Native)](https://snack.expo.io/?dependencies=yup%2Cformik%2Creact-native-paper%2Cexpo-constants&sourceUrl=https%3A%2F%2Fgist.githubusercontent.com%2Fbrentvatne%2F700e1dbf9c3e88a11aef8e557627ce3f%2Fraw%2Feeee57721c9890c1212ac34a4c37707f6354f469%2FApp.js)
 
 ## The Gist
 


### PR DESCRIPTION
You probably want to change it to to a gist on your account @jaredpalmer but yeah this will fix a current issue with the Snack not working and make it less likely to have annoying warnings about SDK versions in the future.

I'm going to follow up on looking into an easier general way for people to include Snack links in their documentation and not have to update them often. We have some stuff for this on https://reactnavigation.org/ but I need to generalize it.

-----
[View rendered docs/overview.md](https://github.com/brentvatne/formik/blob/@brent/fix-snack-link/docs/overview.md)
[View rendered website/versioned_docs/version-2.0.3/overview.md](https://github.com/brentvatne/formik/blob/@brent/fix-snack-link/website/versioned_docs/version-2.0.3/overview.md)