### PR TITLE
Properly handle nested array data in `prepareDataForValidation`.

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1095,7 +1095,7 @@ export function validateYupSchema<T extends FormikValues>(
 export function prepareDataForValidation<T extends FormikValues>(
   values: T
 ): FormikValues {
-  let data: FormikValues = {};
+  let data: FormikValues = Array.isArray(values) ? [] : {};
   for (let k in values) {
     if (Object.prototype.hasOwnProperty.call(values, k)) {
       const key = String(k);

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -969,6 +969,18 @@ describe('<Formik>', () => {
         date,
       });
     });
+
+    it('should work correctly for nested arrays', () => {
+      const expected = {
+        content: [
+          ['a1', 'a2'],
+          ['b1', 'b2'],
+        ]
+      }
+
+      const dataForValidation = prepareDataForValidation(expected);
+      expect(dataForValidation).toEqual(expected);
+    });
   });
 
   // describe('componentDidUpdate', () => {


### PR DESCRIPTION
Previously, we would always return an object even if `values` was an array. Now, we test to see if `values` is an array and set `data` accordingly.

I've included a test for this scenario.

Fixes #2213.