### PR TITLE
Formik wrapper component library documentation

### DIFF
--- a/website/versioned_docs/version-2.0.3/3rd-party-bindings.md
+++ b/website/versioned_docs/version-2.0.3/3rd-party-bindings.md
@@ -1,0 +1,15 @@
+---
+id: version-2.0.3-3rd-party-bindings
+title: 3rd Party Bindings
+original_id: 3rd-party-bindings
+---
+
+If you would like to use Formik with a UI framework, you'll probably want to create a wrapper component that binds Formik's props and callbacks.
+
+A few popular frameworks have open source wrappers readily available:
+
+- [Ant Design](https://github.com/jannikbuschke/formik-antd)
+- [Fabric](https://github.com/kmees/formik-office-ui-fabric-react)
+- [Material UI](https://github.com/stackworx/formik-material-ui)
+- [Reactstrap](https://github.com/shoaibkhan94/reactstrap-formik)
+- [Semantic UI](https://github.com/turner-industries/formik-semantic-ui)

--- a/website/versioned_sidebars/version-2.0.3-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.3-sidebars.json
@@ -3,6 +3,7 @@
     "Getting Started": [
       "version-2.0.3-overview",
       "version-2.0.3-tutorial",
+      "version-2.0.3-3rd-party-bindings",
       "version-2.0.3-migrating-v2",
       "version-2.0.3-resources"
     ],


### PR DESCRIPTION
Per #1117, I've created a new page under the "Getting Started" section of the Formik v2 docs that lists out several wrapper libraries.

A future improvement could include a new section under "Guides" where we walk someone through creating a wrapper for their home-grown UI framework.

-----
[View rendered website/versioned_docs/version-2.0.3/3rd-party-bindings.md](https://github.com/jcolbyfisher/formik/blob/create-3rd-party-wrapper-doc/website/versioned_docs/version-2.0.3/3rd-party-bindings.md)