### PR TITLE
Add setError to v2 breaking changes doc

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -16,6 +16,10 @@ title: Migrating from v1.x to v2.x
 
 Because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
 
+### `setError`
+
+Please use Formik's `setStatus(status)` instead. It works identically.
+
 ### `validate`
 
 As you may know, you can return a Promise of a validation error from `validate`. In 1.x, it didn't matter if this promise is resolved or rejected as in both cases the payload of the promise was interpreted as the validation error. In 2.x, rejection will be interpreted as an actual exception and it won't update the form error state. Any validation function that returns a rejected promise of errors needs to be adjusted to return a resolved promise of errors instead.

--- a/packages/formik/MIGRATING-v2.md
+++ b/packages/formik/MIGRATING-v2.md
@@ -7,11 +7,15 @@
 - Since Formik 2 is built on top of React Hooks, you must be on React 16.8.x or higher
 - Since Formik 2 uses the `unknown` type, you must be on TypeScript 3.0 or higher (if you use TypeScript)
 
-**There are only two tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
+**There are only three tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
 
 #### `resetForm`
 
 Because we introduced the new `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed since there is more stuff to _reset_. It now accepts the next initial state of Formik (instead of just the next initial values).
+
+### `setError`
+
+Please use Formik's `setStatus(status)` instead. It works identically.
 
 ### `validate`
 

--- a/website/versioned_docs/version-2.0.3/migrating-v2.md
+++ b/website/versioned_docs/version-2.0.3/migrating-v2.md
@@ -15,6 +15,10 @@ original_id: migrating-v2
 
 **There is only one tiny breaking change in Formik 2.x.** Luckily, it probably won't impact very many people. Long story short, because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
 
+### `setError`
+
+Please use Formik's `setStatus(status)` instead. It works identically.
+
 **v1**
 
 ```tsx

--- a/website/versioned_docs/version-2.0.4/migrating-v2.md
+++ b/website/versioned_docs/version-2.0.4/migrating-v2.md
@@ -15,6 +15,10 @@ original_id: migrating-v2
 
 **There is only one tiny breaking change in Formik 2.x.** Luckily, it probably won't impact very many people. Long story short, because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
 
+### `setError`
+
+Please use Formik's `setStatus(status)` instead. It works identically.
+
 **v1**
 
 ```tsx

--- a/website/versioned_docs/version-2.1.2/migrating-v2.md
+++ b/website/versioned_docs/version-2.1.2/migrating-v2.md
@@ -11,11 +11,15 @@ original_id: migrating-v2
 - Since Formik 2 is built on top of React Hooks, you must be on React 16.8.x or higher
 - Since Formik 2 uses the `unknown` type, you must be on TypeScript 3.0 or higher (if you use TypeScript)
 
-**There are only two tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
+**There are only three tiny breaking changes in Formik 2.x.** Luckily, these probably won't impact many people:
 
 ### `resetForm`
 
 Because we introduced `initialErrors`, `initialTouched`, `initialStatus` props, `resetForm`'s signature has changed. It now accepts the next initial state of Formik (instead of just the next initial values).
+
+### `setError`
+
+Please use Formik's `setStatus(status)` instead. It works identically.
 
 ### `validate`
 


### PR DESCRIPTION
Per #2190, the "Migrating from v1.x to v2.x" doc does not include the removal of `setError`.

I've added the field along with a snippet from the deprecation notice found in 1.5.8 (https://github.com/jaredpalmer/formik/blob/version-1.5.8/src/Formik.tsx#L149) to provide awareness.


-----
[View rendered docs/migrating-v2.md](https://github.com/jcolbyfisher/formik/blob/add-formik-setError-migration-notice/docs/migrating-v2.md)
[View rendered packages/formik/MIGRATING-v2.md](https://github.com/jcolbyfisher/formik/blob/add-formik-setError-migration-notice/packages/formik/MIGRATING-v2.md)
[View rendered website/versioned_docs/version-2.0.3/migrating-v2.md](https://github.com/jcolbyfisher/formik/blob/add-formik-setError-migration-notice/website/versioned_docs/version-2.0.3/migrating-v2.md)
[View rendered website/versioned_docs/version-2.0.4/migrating-v2.md](https://github.com/jcolbyfisher/formik/blob/add-formik-setError-migration-notice/website/versioned_docs/version-2.0.4/migrating-v2.md)
[View rendered website/versioned_docs/version-2.1.2/migrating-v2.md](https://github.com/jcolbyfisher/formik/blob/add-formik-setError-migration-notice/website/versioned_docs/version-2.1.2/migrating-v2.md)