### PR TITLE
Fix conditional type in FormikTouched typings

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -24,13 +24,16 @@ export type FormikErrors<Values> = {
  * An object containing touched state of the form whose keys correspond to FormikValues.
  */
 export type FormikTouched<Values> = {
-  [K in keyof Values]?: Values[K] extends any[]
-    ? Values[K][number] extends object // [number] is the special sauce to get the type of array's element. More here https://github.com/Microsoft/TypeScript/pull/21316
-      ? FormikTouched<Values[K][number]>[]
-      : boolean
-    : Values[K] extends object
-    ? FormikTouched<Values[K]>
-    : boolean;
+  [K in keyof Values]?:
+    Values[K] extends infer P ? // makes sure the conditional works as expected. More here https://github.com/microsoft/TypeScript/issues/33669#issuecomment-536493169
+      P extends any[]
+      ? P[number] extends object // [number] is the special sauce to get the type of array's element. More here https://github.com/Microsoft/TypeScript/pull/21316
+        ? FormikTouched<P[number]>[]
+        : boolean
+      : P extends object
+        ? FormikTouched<P>
+        : boolean
+    : never;
 };
 
 /**


### PR DESCRIPTION
I was running into an issue where `FormikTouched` did not produce the expected typings. Here is an example:

```ts
type Lesson = {
  name: string;
  instructors?: Array<{ id: string }> | null;
}

type Result = FormikTouched<Lesson>;
```

I would have expected that `Result` is typed like this:
```ts
type Result = {
    name?: boolean;
    instructors?: Array<{ id: boolean } | boolean;
}
```

but the actual `Result` looks like this:
```ts
type Result = {
    name?: boolean;
    instructors?: boolean;
}
```

The problem is, that [conditional types fail to distribute in properties of mapped types](https://github.com/microsoft/TypeScript/issues/33669). This can be fixed in two ways: 
1. Introduce an auxiliary type
2. [Infer the value before using it](https://github.com/microsoft/TypeScript/issues/33669#issuecomment-536493169)

For this PR I have decided to go with the second solution to avoid adding an auxiliary type.