### PR TITLE
Bugfix for <Field /> Ignoring the "as" Attribute

### DIFF
--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -131,7 +131,7 @@ export function Field({
   name,
   render,
   children,
-  as: is, // `as` is reserved in typescript lol
+  is: as, // `as` is reserved in typescript lol
   component,
   ...props
 }: FieldAttributes<any>) {


### PR DESCRIPTION
I encountered a bug today where "as" had no effect on a Field. It looks like line 134 is *supposed* to take the value of the attribute "as" passed in and assign it to an internal property named "is" which is used later in the code. As written, it instead looks for an input named "is" (which doesn't exist in the docs) and tries to assign it to a property named "as" (which is a reserved word in TS).