### PR TITLE
Fix 2.1.4 regression with initialValues updating

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -437,12 +437,6 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   React.useEffect(() => {
-    if (!enableReinitialize) {
-      initialValues.current = props.initialValues;
-    }
-  }, [enableReinitialize, props.initialValues]);
-
-  React.useEffect(() => {
     if (
       enableReinitialize &&
       isMounted.current === true &&


### PR DESCRIPTION
This PR remove code introduced in #2205 as described in this issue #2292 

To reiterate, as of v2.1.4, initialValues cannot be counted on to not change during the duration of a page load. [This code](https://github.com/jaredpalmer/formik/blob/c85d85a3b6236a30034e73f8b821a280de8856b0/packages/formik/src/Formik.tsx#L439-L443) which was introduced in v2.1.4, updates initialValues anytime the `initialValues` passed into `<Formik>` changes. Therefore if I have an application and the initialValues I pass in happen to change then Formik will update that in its internal state and therefore when doing things like determining if a form is dirty it can report unexpected results.

This by proxy would then force https://github.com/jaredpalmer/formik/issues/2034 to be investigated/fixed again.

