### PR TITLE
fix: Update innerRef type signature

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -218,7 +218,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   validate?: (values: Values) => void | object | Promise<FormikErrors<Values>>;
 
   /** Inner ref */
-  innerRef?: (instance: any) => void;
+  innerRef?: React.Ref<FormikProps<Values>>;
 }
 
 /**


### PR DESCRIPTION
Change of the `innerRef` prop type signature as discussed in https://github.com/jaredpalmer/formik/issues/2290

Used the type definition from @johnrom PR https://github.com/jaredpalmer/formik/pull/2222