### PR TITLE
fix/feature: useField respects the checked property

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -907,6 +907,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     (nameOrOptions): FieldInputProps<any> => {
       const isAnObject = isObject(nameOrOptions);
       const name = isAnObject ? nameOrOptions.name : nameOrOptions;
+      const checked = isAnObject ? nameOrOptions.checked : false;
       const valueState = getIn(state.values, name);
 
       const field: FieldInputProps<any> = {
@@ -924,7 +925,9 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         } = nameOrOptions;
 
         if (type === 'checkbox') {
-          if (valueProp === undefined) {
+          if (checked) {
+            field.checked = checked;
+          } else if (valueProp === undefined) {
             field.checked = !!valueState;
           } else {
             field.checked = !!(

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -976,7 +976,7 @@ describe('<Formik>', () => {
           ['a1', 'a2'],
           ['b1', 'b2'],
         ]
-      }
+      };
 
       const dataForValidation = prepareDataForValidation(expected);
       expect(dataForValidation).toEqual(expected);

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -195,14 +195,14 @@ describe('withFormik()', () => {
     expect(getProps().my).toEqual('prop');
   });
 
-  it('should return checked true if getFieldProps is passed checked', () => {
+  it('should return checked.field equal to true if checked is passed to getFieldProps', () => {
     const { getProps } = renderWithFormik();
     const props = getProps();
     const field = props.getFieldProps({name: 'test box', type: 'checkbox', checked: true});
     expect(field.checked).toEqual(true);
   });
 
-  it('should return checked false if getFieldProps is not passed checked', () => {
+  it('should return checked.field equal to false if is not is passed to getFieldProps', () => {
     const { getProps } = renderWithFormik();
     const props = getProps();
     const field = props.getFieldProps({name: 'test box', type: 'checkbox',});

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -195,14 +195,14 @@ describe('withFormik()', () => {
     expect(getProps().my).toEqual('prop');
   });
 
-  it('should return checked.field equal to true if checked is passed to getFieldProps', () => {
+  it('should set checked.field to true if checked is passed to getFieldProps', () => {
     const { getProps } = renderWithFormik();
     const props = getProps();
     const field = props.getFieldProps({name: 'test box', type: 'checkbox', checked: true});
     expect(field.checked).toEqual(true);
   });
 
-  it('should return checked.field equal to false if is not is passed to getFieldProps', () => {
+  it('should set checked.field to false if it is falsy', () => {
     const { getProps } = renderWithFormik();
     const props = getProps();
     const field = props.getFieldProps({name: 'test box', type: 'checkbox',});

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -206,7 +206,7 @@ describe('withFormik()', () => {
     const { getProps } = renderWithFormik();
     const props = getProps();
     const field = props.getFieldProps({name: 'test box', type: 'checkbox',});
-    expect(field.checked).toEqual(false);
+    expect(field.checked).toBeFalsy();
   })
 
   // no ref, WONTFIX?

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -195,6 +195,20 @@ describe('withFormik()', () => {
     expect(getProps().my).toEqual('prop');
   });
 
+  it('should return checked true if getFieldProps is passed checked', () => {
+    const { getProps } = renderWithFormik();
+    const props = getProps();
+    const field = props.getFieldProps({name: 'test box', type: 'checkbox', checked: true});
+    expect(field.checked).toEqual(true);
+  });
+
+  it('should return checked false if getFieldProps is not passed checked', () => {
+    const { getProps } = renderWithFormik();
+    const props = getProps();
+    const field = props.getFieldProps({name: 'test box', type: 'checkbox',});
+    expect(field.checked).toEqual(false);
+  })
+
   // no ref, WONTFIX?
   // it('should correctly set displayName', () => {
   //   const tree = mount(<BasicForm user={{ name: 'jared' }} />);


### PR DESCRIPTION
This PR addresses an issue around checkboxes values not being set with the `useField` hook. `useField` doesn't respect the `checked` property of the `Options` object. Specifically, the `getFieldProps` hook. Now, when calling `useField`, if the `name`, `type: 'checkbox'`, and `checked` are passed in, the `field.checked` property will be `true`. 

Tests were added.
