### PR TITLE
Typo in formik.md : "that's resolves"

### DIFF
--- a/website/versioned_docs/version-2.1.4/api/formik.md
+++ b/website/versioned_docs/version-2.1.4/api/formik.md
@@ -365,7 +365,7 @@ const validate = values => {
 };
 ```
 
-- Asynchronous and return a Promise that's resolves to an object containing `errors`
+- Asynchronous and return a Promise that resolves to an object containing `errors`
 
 ```js
 // Async Validation


### PR DESCRIPTION
"that's resolves" => "that resolves"

-----
[View rendered website/versioned_docs/version-2.1.4/api/formik.md](https://github.com/ElRatonDeFuego/formik/blob/patch-1/website/versioned_docs/version-2.1.4/api/formik.md)