### PR TITLE
Add FieldProps change to v2 migration guide

### DIFF
--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -42,6 +42,8 @@ resetForm({ values: nextValues /* errors, touched, etc ... */ });
 
 ### Typescript changes
 
+#### `FormikActions`
+
 **`FormikActions` has been renamed to `FormikHelpers`** It should be a straightforward change to import or alias the type
 
 **v1**
@@ -54,6 +56,22 @@ import { FormikActions } from 'formik';
 
 ```tsx
 import { FormikHelpers as FormikActions } from 'formik';
+```
+
+#### `FieldProps`
+
+**`FieldProps` now accepts two generic type parameters.** Both are optional but `FormValues` needs to be passed as the second parameter.
+
+**v1**
+
+```tsx
+type Props = FieldProps<FormValues>;
+```
+
+**v2**
+
+```tsx
+type Props = FieldProps<FieldValue, FormValues>;
 ```
 
 ## What's New?

--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -60,7 +60,7 @@ import { FormikHelpers as FormikActions } from 'formik';
 
 #### `FieldProps`
 
-**`FieldProps` now accepts two generic type parameters.** Both are optional but `FormValues` needs to be passed as the second parameter.
+**`FieldProps` now accepts two generic type parameters.** Both parameters are optional, but `FormValues` has been moved from the first to the second parameter.
 
 **v1**
 

--- a/packages/formik/MIGRATING-v2.md
+++ b/packages/formik/MIGRATING-v2.md
@@ -55,7 +55,7 @@ import { FormikHelpers as FormikActions } from 'formik';
 
 #### `FieldProps`
 
-**`FieldProps` now accepts two generic type parameters.** Both are optional but `FormValues` needs to be passed as the second parameter.
+**`FieldProps` now accepts two generic type parameters.** Both parameters are optional, but `FormValues` has been moved from the first to the second parameter.
 
 **v1**
 

--- a/packages/formik/MIGRATING-v2.md
+++ b/packages/formik/MIGRATING-v2.md
@@ -37,6 +37,8 @@ resetForm({ values: nextValues /* errors, touched, etc ... */ });
 
 ### Typescript changes
 
+#### `FormikActions`
+
 **`FormikActions` has been renamed to `FormikHelpers`** It should be a straightforward change to import or alias the type
 
 **v1**
@@ -49,6 +51,22 @@ import { FormikActions } from 'formik';
 
 ```tsx
 import { FormikHelpers as FormikActions } from 'formik';
+```
+
+#### `FieldProps`
+
+**`FieldProps` now accepts two generic type parameters.** Both are optional but `FormValues` needs to be passed as the second parameter.
+
+**v1**
+
+```tsx
+type Props = FieldProps<FormValues>;
+```
+
+**v2**
+
+```tsx
+type Props = FieldProps<FieldValue, FormValues>;
 ```
 
 ## What's New?


### PR DESCRIPTION
`FieldProps` had an undocumented breaking change introduced in v2. For users that relied on the previously unary type generic, the `FormValues` parameter ended up as the type on `field.value`.

This PR adds documentation for this change in the v1 to v2 migration guide. This fixes #2350 

## [`FieldProps` in v1.6.8](https://github.com/jaredpalmer/formik/blob/v1.5.8/src/Field.tsx#L32):

```ts
export interface FieldProps<V = any> {
  field: {
    /** Classic React change handler, keyed by input name */
    onChange: FormikHandlers['handleChange'];
    /** Mark input as touched */
    onBlur: FormikHandlers['handleBlur'];
    /** Value of the input */
    value: any;
    /* name of the input */
    name: string;
  };
  form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
}
```
## [`FieldProps` in v2.1.4](https://github.com/jaredpalmer/formik/blob/v2.1.4/packages/formik/src/Field.tsx#L14):

```ts
export interface FieldProps<V = any, FormValues = any> {
  field: FieldInputProps<V>;
  form: FormikProps<FormValues>; // if ppl want to restrict this for a given form, let them.
  meta: FieldMetaProps<V>;
}
```
-----
[View rendered docs/migrating-v2.md](https://github.com/mhelmer/formik/blob/fieldprops-type-migration/docs/migrating-v2.md)