### PR TITLE
added: ability to pass submit context to onSubmit handler

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -130,9 +130,9 @@ Set the error message of a field imperatively. `field` should match the key of
 Set the touched state of a field imperatively. `field` should match the key of
 `touched` you wish to update. Useful for creating custom input blur handlers. Calling this method will trigger validation to run if `validateOnBlur` is set to `true` (which it is by default). `isTouched` defaults to `true` if not specified. You can also explicitly prevent/skip validation by passing a third argument as `false`.
 
-#### `submitForm: () => Promise`
+#### `submitForm: (submitContext?: any) => Promise`
 
-Trigger a form submission. The promise will be rejected if form is invalid.
+Trigger a form submission. The promise will be rejected if form is invalid. Value of `submitContext` will be passed to `onSubmit` handler.
 
 #### `submitCount: number`
 
@@ -325,13 +325,15 @@ Note: `initialValues` not available to the higher-order component, use
 Your optional form reset handler. It is passed your forms `values` and the
 "FormikBag".
 
-### `onSubmit: (values: Values, formikBag: FormikBag) => void | Promise<any>`
+### `onSubmit: (values: Values, formikBag: FormikBag, submitContext?: any) => void | Promise<any>`
 
-Your form submission handler. It is passed your forms `values` and the
-"FormikBag", which includes an object containing a subset of the
+Your form submission handler. It is passed your:
+ - Forms `values`
+ - The "FormikBag", which includes an object containing a subset of the
 [injected props and methods](#formik-render-methods-and-props) (i.e. all the methods
 with names that start with `set<Thing>` + `resetForm`) and any props that were
 passed to the wrapped component.
+ - `submitContext` which was passed to `submitForm` method
 
 Note: `errors`, `touched`, `status` and all event handlers are NOT
 included in the `FormikBag`.

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -737,7 +737,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     dispatch({ type: 'SET_ISSUBMITTING', payload: isSubmitting });
   }, []);
 
-  const submitForm = useEventCallback(() => {
+  const submitForm = useEventCallback((submitContext?: any) => {
     dispatch({ type: 'SUBMIT_ATTEMPT' });
     return validateFormWithHighPriority().then(
       (combinedErrors: FormikErrors<Values>) => {
@@ -764,7 +764,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
           // cleanup of isSubmitting on behalf of the consumer.
           let promiseOrUndefined;
           try {
-            promiseOrUndefined = executeSubmit();
+            promiseOrUndefined = executeSubmit(submitContext);
             // Bail if it's sync, consumer is responsible for cleaning up
             // via setSubmitting(false)
             if (promiseOrUndefined === undefined) {
@@ -856,8 +856,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     submitForm,
   };
 
-  const executeSubmit = useEventCallback(() => {
-    return onSubmit(state.values, imperativeMethods);
+  const executeSubmit = useEventCallback((submitContext?: any) => {
+    return onSubmit(state.values, imperativeMethods, submitContext);
   });
 
   const handleReset = useEventCallback(e => {

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -102,7 +102,7 @@ export interface FormikHelpers<Values> {
   /** Reset form */
   resetForm(nextState?: Partial<FormikState<Values>>): void;
   /** Submit the form imperatively */
-  submitForm(): Promise<void>;
+  submitForm(submitContext?: any): Promise<void>;
   /** Set Formik state, careful! */
   setFormikState(
     f:
@@ -204,7 +204,8 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    */
   onSubmit: (
     values: Values,
-    formikHelpers: FormikHelpers<Values>
+    formikHelpers: FormikHelpers<Values>,
+    submitContext?: any
   ) => void | Promise<any>;
   /**
    * A Yup Schema or a function that returns a Yup schema
@@ -230,7 +231,7 @@ export type FormikProps<Values> = FormikSharedConfig &
   FormikHelpers<Values> &
   FormikHandlers &
   FormikComputedProps<Values> &
-  FormikRegistration & { submitForm: () => Promise<any> };
+  FormikRegistration & { submitForm: (submitContext?: any) => Promise<any> };
 
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {


### PR DESCRIPTION
This closes #214, closes #1792

-----
[View rendered docs/api/formik.md](https://github.com/avasuro/formik/blob/feat/add-submit-context/docs/api/formik.md)