### PR TITLE
feat: add method get to ArrayHelpers

### DIFF
--- a/docs/api/fieldarray.md
+++ b/docs/api/fieldarray.md
@@ -184,6 +184,7 @@ The following methods are made available via render props.
 - `remove<T>(index: number): T | undefined`: Remove an element at an index of an array and return it
 - `pop<T>(): T | undefined`: Remove and return value from the end of the array
 - `replace: (index: number, value: any) => void`: Replace a value at the given index into the array
+- `get<T>(index: number): T | undefined`: Get an element at the given index of an array
 
 ## FieldArray render methods
 

--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -60,6 +60,8 @@ export interface ArrayHelpers {
   remove<T>(index: number): T | undefined;
   /** Imperatively remove and return value from the end of the array */
   pop<T>(): T | undefined;
+  /** Imperatively get an element at the given index of an array */
+  get<T>(index: number): T | undefined;
 }
 
 /**
@@ -132,6 +134,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
     // @todo Fix TS 3.2.1
     this.remove = this.remove.bind(this) as any;
     this.pop = this.pop.bind(this) as any;
+    this.get = this.get.bind(this) as any;
   }
 
   componentDidUpdate(
@@ -319,6 +322,17 @@ class FieldArrayInner<Values = {}> extends React.Component<
 
   handlePop = () => () => this.pop<any>();
 
+  get<T>(index: number): T {
+    const {
+      name,
+      formik: { values },
+    } = this.props;
+
+    let result: any = getIn(values, name)[index];
+
+    return result as T;
+  }
+
   render() {
     const arrayHelpers: ArrayHelpers = {
       push: this.push,
@@ -329,6 +343,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
       replace: this.replace,
       unshift: this.unshift,
       remove: this.remove,
+      get: this.get,
       handlePush: this.handlePush,
       handlePop: this.handlePop,
       handleSwap: this.handleSwap,

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -375,6 +375,35 @@ describe('<FieldArray />', () => {
     });
   });
 
+  describe('props.get()', () => {
+    let arrayHelpers: any;
+
+    beforeEach(() => {
+      ReactDOM.render(
+        <TestForm>
+          {() => {
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        </TestForm>,
+        node
+      );
+    });
+
+    it('should return the value at the given index', () => {
+      const el = arrayHelpers.get(0);
+
+      expect(el).toEqual('jared');
+    });
+  });
+
   describe('given array-like object representing errors', () => {
     it('should run arrayHelpers successfully', () => {
       let formikBag: any;

--- a/website/versioned_docs/version-2.0.3/api/fieldarray.md
+++ b/website/versioned_docs/version-2.0.3/api/fieldarray.md
@@ -185,6 +185,7 @@ The following methods are made available via render props.
 - `remove<T>(index: number): T | undefined`: Remove an element at an index of an array and return it
 - `pop<T>(): T | undefined`: Remove and return value from the end of the array
 - `replace: (index: number, value: any) => void`: Replace a value at the given index into the array
+- `get<T>(index: number): T | undefined`: Get an element at the given index of an array
 
 ## FieldArray render methods
 


### PR DESCRIPTION
It would be nice to be able to imperative inspect a value in the array rather than accessing formik state directly when working with refs.

-----
[View rendered docs/api/fieldarray.md](https://github.com/brunohkbx/formik/blob/feat/add-method-get-to-array-helpers/docs/api/fieldarray.md)
[View rendered website/versioned_docs/version-2.0.3/api/fieldarray.md](https://github.com/brunohkbx/formik/blob/feat/add-method-get-to-array-helpers/website/versioned_docs/version-2.0.3/api/fieldarray.md)