### PR TITLE
`as` prop: added info about pass through props

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -17,7 +17,7 @@ There are 2 ways to render things with `<Field>`.
 - ~~`<Field render>`~~ _deprecated in 2.x. Using these will log warning_
 - `<Field component>`
 
-`as` can either be a React component or the name of an HTML element to render. Formik will automagically inject `onChange`, `onBlur`, `name`, and `value` props of the field designated by the `name` prop to the (custom) component.
+`as` can either be a React component or the name of an HTML element to render. Formik will automagically inject `onChange`, `onBlur`, `name`, and `value` props of the field designated by the `name` prop to the (custom) component. All additional props will be passed through.
 
 `children` can either be an array of elements (e.g. `<option>` in the case of `<Field as="select">`) or a callback function (a.k.a render prop). The render props are an object containing:
 


### PR DESCRIPTION
It was not clear if only `component` prop does pass through or `as` also

From the code it looks like it does pass through 
https://github.com/jaredpalmer/formik/blob/4b6731f88dde05b0771097213f04d70acf6a57c2/packages/formik/src/Field.tsx#L222

-----
[View rendered docs/api/field.md](https://github.com/oleg-brizy/formik/blob/patch-1/docs/api/field.md)