### PR TITLE
added: ability to pass submit context to onSubmit handler

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -130,9 +130,9 @@ Set the error message of a field imperatively. `field` should match the key of
 Set the touched state of a field imperatively. `field` should match the key of
 `touched` you wish to update. Useful for creating custom input blur handlers. Calling this method will trigger validation to run if `validateOnBlur` is set to `true` (which it is by default). `isTouched` defaults to `true` if not specified. You can also explicitly prevent/skip validation by passing a third argument as `false`.
 
-#### `submitForm: () => Promise`
+#### `submitForm: (submitContext?: any) => Promise`
 
-Trigger a form submission. The promise will be rejected if form is invalid.
+Trigger a form submission. The promise will be rejected if form is invalid. Value of `submitContext` will be passed to `onSubmit` handler.
 
 #### `submitCount: number`
 
@@ -325,13 +325,15 @@ Note: `initialValues` not available to the higher-order component, use
 Your optional form reset handler. It is passed your forms `values` and the
 "FormikBag".
 
-### `onSubmit: (values: Values, formikBag: FormikBag) => void | Promise<any>`
+### `onSubmit: (values: Values, formikBag: FormikBag, submitContext?: any) => void | Promise<any>`
 
-Your form submission handler. It is passed your forms `values` and the
-"FormikBag", which includes an object containing a subset of the
+Your form submission handler. It is passed your:
+ - Forms `values`
+ - The "FormikBag", which includes an object containing a subset of the
 [injected props and methods](#formik-render-methods-and-props) (i.e. all the methods
 with names that start with `set<Thing>` + `resetForm`) and any props that were
 passed to the wrapped component.
+ - `submitContext` which was passed to `submitForm` method
 
 Note: `errors`, `touched`, `status` and all event handlers are NOT
 included in the `FormikBag`.

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -334,6 +334,45 @@ Your form submission handler. It is passed your:
 with names that start with `set<Thing>` + `resetForm`) and any props that were
 passed to the wrapped component.
  - `submitContext` which was passed to `submitForm` method
+    (will contain event object if form submission was invoked via `handleSubmit` method), e.g.:
+    
+    ```js
+      <Formik
+        onSubmit={(values, actions, context) => {
+          if (context instanceof SubmitEvent) {
+            if (context.submitter) {
+                console.log('Form is submitted using native HTML submit button')
+            }
+            else {
+                console.log('Form is submitted using HTMLForm.submit()')
+            }
+          }
+          else if (context instanceof MouseEvent) {
+               console.log(`User clicked on ${context.target.name} button`)
+          }
+          else {
+            console.log(`Submit was invoked programmatically. Current context is: ${context}`)
+          }
+        }}
+      >
+        {props => (
+          <form id="htmlform" onSubmit={props.handleSubmit}>
+            <button name="submit_using_click_handler" onClick={props.handleSubmit}>
+              Submit using click handler
+            </button>
+            <button onClick={() => props.submitForm('My test submit context')}>
+              Submit using formik.submitForm()
+            </button>
+            <button onClick={() => document.getElementById('htmlform').submit()}>
+              Submit using native HTMLForm submit method
+            </button>
+            <button type="submit">
+              Submit using native html submit button
+            </button>
+          </form>
+        )}
+      </Formik>
+    ```
 
 Note: `errors`, `touched`, `status` and all event handlers are NOT
 included in the `FormikBag`.

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -737,7 +737,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     dispatch({ type: 'SET_ISSUBMITTING', payload: isSubmitting });
   }, []);
 
-  const submitForm = useEventCallback(() => {
+  const submitForm = useEventCallback((submitContext?: any) => {
     dispatch({ type: 'SUBMIT_ATTEMPT' });
     return validateFormWithHighPriority().then(
       (combinedErrors: FormikErrors<Values>) => {
@@ -764,7 +764,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
           // cleanup of isSubmitting on behalf of the consumer.
           let promiseOrUndefined;
           try {
-            promiseOrUndefined = executeSubmit();
+            promiseOrUndefined = executeSubmit(submitContext);
             // Bail if it's sync, consumer is responsible for cleaning up
             // via setSubmitting(false)
             if (promiseOrUndefined === undefined) {
@@ -856,8 +856,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     submitForm,
   };
 
-  const executeSubmit = useEventCallback(() => {
-    return onSubmit(state.values, imperativeMethods);
+  const executeSubmit = useEventCallback((submitContext?: any) => {
+    return onSubmit(state.values, imperativeMethods, submitContext);
   });
 
   const handleReset = useEventCallback(e => {

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -830,7 +830,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         }
       }
 
-      submitForm().catch(reason => {
+      submitForm(e).catch(reason => {
         console.warn(
           `Warning: An unhandled error was caught from submitForm()`,
           reason

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -102,7 +102,7 @@ export interface FormikHelpers<Values> {
   /** Reset form */
   resetForm(nextState?: Partial<FormikState<Values>>): void;
   /** Submit the form imperatively */
-  submitForm(): Promise<void>;
+  submitForm(submitContext?: any): Promise<void>;
   /** Set Formik state, careful! */
   setFormikState(
     f:
@@ -204,7 +204,8 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    */
   onSubmit: (
     values: Values,
-    formikHelpers: FormikHelpers<Values>
+    formikHelpers: FormikHelpers<Values>,
+    submitContext?: any
   ) => void | Promise<any>;
   /**
    * A Yup Schema or a function that returns a Yup schema
@@ -230,7 +231,7 @@ export type FormikProps<Values> = FormikSharedConfig &
   FormikHelpers<Values> &
   FormikHandlers &
   FormikComputedProps<Values> &
-  FormikRegistration & { submitForm: () => Promise<any> };
+  FormikRegistration & { submitForm: (submitContext?: any) => Promise<any> };
 
 /** Internal Formik registration methods that get passed down as props */
 export interface FormikRegistration {


### PR DESCRIPTION
This closes #214, closes #1792

-----
[View rendered docs/api/formik.md](https://github.com/avasuro/formik/blob/feat/add-submit-context/docs/api/formik.md)