### PR TITLE
Fix peer dependency version

### DIFF
--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=16.8.0"
   },
   "scripts": {
     "test": "tsdx test --env=jsdom",


### PR DESCRIPTION
Migration guide mentions that React >= 16.8 is required: https://github.com/jaredpalmer/formik/blob/master/docs/migrating-v2.md#minimum-requirements

Peer dependencies should reflect this requirement