### PR TITLE
Update field.md

### DIFF
--- a/docs/api/field.md
+++ b/docs/api/field.md
@@ -10,7 +10,7 @@ attribute to match up with Formik state. `<Field />` will default to an HTML
 
 ## Rendering
 
-There are 2 ways to render things with `<Field>`.
+There are different ways to render with `<Field>`:
 
 - `<Field as>`
 - `<Field children>`


### PR DESCRIPTION
minor docs fix.

*Question*: the quotation section on line 30 says that "`component` ... props could also be used for rendering.".  But we are actually saying that <Field component> is valid.  This seems ... confusing.  Is it that `render` is now deprecated but `component` is not, or is the use of `component` here different than `<Field component>` ?

-----
[View rendered docs/api/field.md](https://github.com/gregfenton/formik/blob/patch-1/docs/api/field.md)