### PR TITLE
Add customization for error shape of useField FieldMetaProps

### DIFF
--- a/docs/api/useField.md
+++ b/docs/api/useField.md
@@ -27,7 +27,7 @@ const MyTextField = ({ label, ...props }) => {
         <input {...field} {...props} />
       </label>
       {meta.touched && meta.error ? (
-        <div className='error'>{meta.error}</div>
+        <div className="error">{meta.error}</div>
       ) : null}
     </>
   );
@@ -66,7 +66,7 @@ const Example = () => (
 
 # Reference
 
-## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>, FieldHelperProps]`
+## `useField<Value = any, Error extends {} = string>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value, Error>, FieldHelperProps]`
 
 A custom React Hook that returns a 3-tuple (an array with three elements) containing `FieldProps`, `FieldMetaProps` and `FieldHelperProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should be identical to the props that you would pass to `<Field>` and the values and functions in `FieldProps` will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 
@@ -109,7 +109,7 @@ function MyOtherComponent(props) {
   const isSelected = v => (v === value ? 'selected' : '');
 
   return (
-    <div className='itemsPerPage'>
+    <div className="itemsPerPage">
       <button onClick={() => setValue(5)} className={isSelected(5)}>
         5
       </button>

--- a/docs/migrating-v2.md
+++ b/docs/migrating-v2.md
@@ -270,11 +270,11 @@ export interface FieldInputProps<Value> {
 Given a name it will return an object:
 
 ```tsx
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/packages/formik/MIGRATING-v2.md
+++ b/packages/formik/MIGRATING-v2.md
@@ -265,11 +265,11 @@ export interface FieldInputProps<Value> {
 Given a name it will return an object:
 
 ```tsx
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/packages/formik/src/FastField.tsx
+++ b/packages/formik/src/FastField.tsx
@@ -14,9 +14,9 @@ import { connect } from './connect';
 
 type $FixMe = any;
 
-export interface FastFieldProps<V = any> {
+export interface FastFieldProps<V = any, E extends {} = string> {
   field: FieldInputProps<V>;
-  meta: FieldMetaProps<V>;
+  meta: FieldMetaProps<V, E>;
   form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
 }
 

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -11,10 +11,10 @@ import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren, isObject } from './utils';
 import invariant from 'tiny-warning';
 
-export interface FieldProps<V = any, FormValues = any> {
+export interface FieldProps<V = any, FormValues = any, E extends {} = string> {
   field: FieldInputProps<V>;
   form: FormikProps<FormValues>; // if ppl want to restrict this for a given form, let them.
-  meta: FieldMetaProps<V>;
+  meta: FieldMetaProps<V, E>;
 }
 
 export interface FieldConfig<V = any> {
@@ -73,9 +73,9 @@ export type FieldAttributes<T> = GenericFieldHTMLAttributes &
 
 export type FieldHookConfig<T> = GenericFieldHTMLAttributes & FieldConfig<T>;
 
-export function useField<Val = any>(
+export function useField<Val = any, Err extends {} = string>(
   propsOrFieldName: string | FieldHookConfig<Val>
-): [FieldInputProps<Val>, FieldMetaProps<Val>, FieldHelperProps<Val>] {
+): [FieldInputProps<Val>, FieldMetaProps<Val, Err>, FieldHelperProps<Val>] {
   const formik = useFormikContext();
   const {
     getFieldProps,

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -873,7 +873,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   });
 
   const getFieldMeta = React.useCallback(
-    (name: string): FieldMetaProps<any> => {
+    (name: string): FieldMetaProps<any, any> => {
       return {
         value: getIn(state.values, name),
         error: getIn(state.errors, name),

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -136,7 +136,9 @@ export interface FormikHandlers {
     : (e: string | React.ChangeEvent<any>) => void;
 
   getFieldProps<Value = any>(props: any): FieldInputProps<Value>;
-  getFieldMeta<Value>(name: string): FieldMetaProps<Value>;
+  getFieldMeta<Value, Error extends {} = string>(
+    name: string
+  ): FieldMetaProps<Value, Error>;
   getFieldHelpers<Value = any>(name: string): FieldHelperProps<Value>;
 }
 
@@ -267,11 +269,11 @@ export type GenericFieldHTMLAttributes =
   | JSX.IntrinsicElements['textarea'];
 
 /** Field metadata */
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/website/versioned_docs/version-2.0.3/api/useField.md
+++ b/website/versioned_docs/version-2.0.3/api/useField.md
@@ -56,7 +56,7 @@ const Example = () => (
 
 # Reference
 
-## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>]`
+## `useField<Value = any, Error extends {} = string>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value, Error>]`
 
 A custom React Hook that returns a tuple (2 element array) containing `FieldProps` and `FieldMetaProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should identical to the props that you would pass to `<Field>` and the returned helpers will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 

--- a/website/versioned_docs/version-2.0.3/migrating-v2.md
+++ b/website/versioned_docs/version-2.0.3/migrating-v2.md
@@ -227,11 +227,11 @@ export interface FieldInputProps<Value> {
 Given a name it will return an object:
 
 ```tsx
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/website/versioned_docs/version-2.0.4/api/useField.md
+++ b/website/versioned_docs/version-2.0.4/api/useField.md
@@ -56,7 +56,7 @@ const Example = () => (
 
 # Reference
 
-## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>]`
+## `useField<Value = any, Error extends {} = string>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value, Error>]`
 
 A custom React Hook that returns a tuple (2 element array) containing `FieldProps` and `FieldMetaProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should identical to the props that you would pass to `<Field>` and the returned helpers will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 

--- a/website/versioned_docs/version-2.0.4/migrating-v2.md
+++ b/website/versioned_docs/version-2.0.4/migrating-v2.md
@@ -242,11 +242,11 @@ export interface FieldInputProps<Value> {
 Given a name it will return an object:
 
 ```tsx
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */

--- a/website/versioned_docs/version-2.1.0/api/useField.md
+++ b/website/versioned_docs/version-2.1.0/api/useField.md
@@ -67,7 +67,7 @@ const Example = () => (
 
 # Reference
 
-## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>, FieldHelperProps]`
+## `useField<Value = any, Error extends {} = string>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value, Error>, FieldHelperProps]`
 
 A custom React Hook that returns a 3-tuple (an array with three elements) containing `FieldProps`, `FieldMetaProps` and `FieldHelperProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should be identical to the props that you would pass to `<Field>` and the values and functions in `FieldProps` will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 

--- a/website/versioned_docs/version-2.1.2/api/useField.md
+++ b/website/versioned_docs/version-2.1.2/api/useField.md
@@ -67,7 +67,7 @@ const Example = () => (
 
 # Reference
 
-## `useField<Value = any>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value>, FieldHelperProps]`
+## `useField<Value = any, Error extends {} = string>(name: string | FieldAttributes<Val>): [FieldInputProps<Value>, FieldMetaProps<Value, Error>, FieldHelperProps]`
 
 A custom React Hook that returns a 3-tuple (an array with three elements) containing `FieldProps`, `FieldMetaProps` and `FieldHelperProps`. It accepts either a string of a field name or an object as an argument. The object must at least contain a `name` key. This object should be identical to the props that you would pass to `<Field>` and the values and functions in `FieldProps` will mimic the behavior of `<Field>` exactly. This is useful, and generally preferred, since it allows you to take advantage of formik's checkbox, radio, and multiple select behavior when the object contains the relevant key/values (e.g. `type: 'checkbox'`, `multiple: true`, etc.).
 

--- a/website/versioned_docs/version-2.1.2/migrating-v2.md
+++ b/website/versioned_docs/version-2.1.2/migrating-v2.md
@@ -248,11 +248,11 @@ export interface FieldInputProps<Value> {
 Given a name it will return an object:
 
 ```tsx
-export interface FieldMetaProps<Value> {
+export interface FieldMetaProps<Value, Error> {
   /** Value of the field */
   value: Value;
   /** Error message of the field */
-  error?: string;
+  error?: Error;
   /** Has the field been visited? */
   touched: boolean;
   /** Initial value of the field */


### PR DESCRIPTION
This is improvement for `FieldMetaProps` error typing by providing second optional `Generic` type, default is still `string` so if you are not intended to change it - no actions needed 
minimal reproducing example is [here](https://codesandbox.io/s/little-brook-4obzc?file=/src/form.tsx)
I understand that it could be solved in other way(like separating these fields) but in some cases it may be comfortable to have such feature
I was also trying to update related `.md` files, hope that cover them all

-----
[View rendered docs/api/useField.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/docs/api/useField.md)
[View rendered docs/migrating-v2.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/docs/migrating-v2.md)
[View rendered packages/formik/MIGRATING-v2.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/packages/formik/MIGRATING-v2.md)
[View rendered website/versioned_docs/version-2.0.3/api/useField.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.0.3/api/useField.md)
[View rendered website/versioned_docs/version-2.0.3/migrating-v2.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.0.3/migrating-v2.md)
[View rendered website/versioned_docs/version-2.0.4/api/useField.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.0.4/api/useField.md)
[View rendered website/versioned_docs/version-2.0.4/migrating-v2.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.0.4/migrating-v2.md)
[View rendered website/versioned_docs/version-2.1.0/api/useField.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.1.0/api/useField.md)
[View rendered website/versioned_docs/version-2.1.2/api/useField.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.1.2/api/useField.md)
[View rendered website/versioned_docs/version-2.1.2/migrating-v2.md](https://github.com/gitpash/formik/blob/feat/meta-field-error-type/website/versioned_docs/version-2.1.2/migrating-v2.md)