### PR TITLE
Change return type of setFieldValue to Promise

### DIFF
--- a/docs/src/pages/docs/api/formik.md
+++ b/docs/src/pages/docs/api/formik.md
@@ -137,7 +137,7 @@ Trigger a form submission. The promise will be rejected if form is invalid.
 Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-e-reactformevent-htmlformevent-void) is called, resets after calling
 [`handleReset`](#handlereset-void). `submitCount` is readonly computed property and should not be mutated directly.
 
-#### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
+#### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => Promise<void>`
 
 Set the value of a field imperatively. `field` should match the key of
 `values` you wish to update. Useful for creating custom input change handlers. Calling this will trigger validation to run if `validateOnChange` is set to `true` (which it is by default). You can also explicitly prevent/skip validation by passing a third argument as `false`.


### PR DESCRIPTION
Corrects setFieldValue return type as reported in #2568. 