### PR TITLE
add shouldUpdate + shouldComponentUpdate to fieldArray, fixes #1895

### DIFF
--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -26,6 +26,8 @@ export type FieldArrayConfig = {
   name: string;
   /** Should field array validate the form AFTER array updates/changes? */
   validateOnChange?: boolean;
+  /** Override FieldArray's default shouldComponentUpdate */
+  shouldUpdate?: (nextProps: {}, props: {}) => boolean;
 } & SharedRenderProps<FieldArrayRenderProps>;
 export interface ArrayHelpers {
   /** Imperatively add a value to the end of an array */
@@ -132,6 +134,26 @@ class FieldArrayInner<Values = {}> extends React.Component<
     // @todo Fix TS 3.2.1
     this.remove = this.remove.bind(this) as any;
     this.pop = this.pop.bind(this) as any;
+  }
+
+  shouldComponentUpdate(props: any) {
+    if (this.props.shouldUpdate) {
+      return this.props.shouldUpdate(props, this.props);
+    } else if (
+      props.name !== this.props.name ||
+      getIn(props.formik.values, this.props.name) !==
+        getIn(this.props.formik.values, this.props.name) ||
+      getIn(props.formik.errors, this.props.name) !==
+        getIn(this.props.formik.errors, this.props.name) ||
+      getIn(props.formik.touched, this.props.name) !==
+        getIn(this.props.formik.touched, this.props.name) ||
+      Object.keys(this.props).length !== Object.keys(props).length ||
+      props.formik.isSubmitting !== this.props.formik.isSubmitting
+    ) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   componentDidUpdate(


### PR DESCRIPTION
FieldArray experiences an issue where it re-renders constantly when changing the values inside. This has been affecting user experience.

After looking at the problem the only solution available to was to offer something similar to `FastField` where a `shouldUpdate` method can be provided and the user can choose when re-rendering occurs.  (for e.g only re-render when there's new fields but not on changed input)

I needed to set line 147 to `any` as i couldn't get the types to behave so any help there would be nice.

Fixes https://github.com/formium/formik/issues/1895