### PR TITLE
Make formik helpers types stricter

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -92,19 +92,19 @@ export interface FormikHelpers<Values> {
     shouldValidate?: boolean
   ) => void;
   /** Set value of form field directly */
-  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+  setFieldValue: (field: keyof Values, value: any, shouldValidate?: boolean) => void;
   /** Set error message of a form field directly */
-  setFieldError: (field: string, message: string | undefined) => void;
+  setFieldError: (field: keyof Values, message: string | undefined) => void;
   /** Set whether field has been touched directly */
   setFieldTouched: (
-    field: string,
+    field: keyof Values,
     isTouched?: boolean,
     shouldValidate?: boolean
   ) => void;
   /** Validate form values */
   validateForm: (values?: any) => Promise<FormikErrors<Values>>;
   /** Validate field value */
-  validateField: (field: string) => void;
+  validateField: (field: keyof Values) => void;
   /** Reset form */
   resetForm: (nextState?: Partial<FormikState<Values>>) => void;
   /** Submit the form imperatively */


### PR DESCRIPTION
This PR updates the types of the helpers such as `setFieldValues` to make sure that only field names that exist in the FormValues type are allowed. Provides better completion as well as error detection.