### PR TITLE
Fix preconnect link to target search cluster

### DIFF
--- a/website/src/components/Search.tsx
+++ b/website/src/components/Search.tsx
@@ -30,7 +30,7 @@ const options = {
 
 let DocSearchModal: any = null;
 
-export const Search: React.FC<SearchProps> = ({ appId }) => {
+export const Search: React.FC<SearchProps> = () => {
   const searchButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [isShowing, setIsShowing] = React.useState(false);
   const [initialQuery, setInitialQuery] = React.useState<string | null>(null);
@@ -95,7 +95,7 @@ export const Search: React.FC<SearchProps> = ({ appId }) => {
       <Head>
         <link
           rel="preconnect"
-          href={`https://${appId}-dsn.algolia.net`}
+          href={`https://${options.appId}-dsn.algolia.net`}
           crossOrigin="true"
         />
       </Head>


### PR DESCRIPTION
_Same as reactjs/reactjs.org#3980_

The `appId` was retrieved from props but the `<Search>` component is never instantiated with props. So the preconnect link targeted an unknown search cluster:

```html
<link rel="preconnect" href="https://undefined-dsn.algolia.net" crossorigin="true">
```

This fixes the preconnect link by getting the `appId` from the website config.