### PR TITLE
tutorial: use children in MySelect code example

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -854,7 +854,7 @@ const MySelect = ({ label, ...props }) => {
   return (
     <div>
       <label htmlFor={props.id || props.name}>{label}</label>
-      <select {...field} {...props} />
+      <select {...field} {...props}>{children}</select>
       {meta.touched && meta.error ? (
         <div className="error">{meta.error}</div>
       ) : null}


### PR DESCRIPTION
Hello! I was following the tutorial and noticed the custom component `<MySelect>` didn't work as expected.

I changed the code example in the tutorial to make it work by rendering its children (which would be `<option>` elements, as shown below in the example when `<MySelect>` is being used).

If I may, I would suggest some other "clean ups" to this section (I can add them to this PR if you think they're worth it):
- changing `<MyCheckbox>` to not render any children (maybe this and MySelect got switched?)
- making the wrapper in `<MyTextInput>` a `div` instead of a fragment, to make it consistent with the other components in the example
- changing the `<label>` in `<MyCheckbox>` to use `htmlFor` instead of wrapping the input, again for consistency.

I didn't add these changes because I wasn't sure if those differences were intended (maybe as a way of showing versatility?)

Anyway, thanks for reviewing and for making Formik!