### PR TITLE
cleanup arrays if the last value, which is not undefined, gets removed from it

### DIFF
--- a/.changeset/fair-students-fix.md
+++ b/.changeset/fair-students-fix.md
@@ -1,0 +1,6 @@
+---
+'formik': patch
+'formik-native': patch
+---
+
+Fixes array fields not beeing cleanup up properly if the get deleted

--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -288,7 +288,12 @@ class FieldArrayInner<Values = {}> extends React.Component<
         if (isFunction(copy.splice)) {
           copy.splice(index, 1);
         }
-        return copy;
+        // if the array only includes undefined values we have to return an empty array
+        return isFunction(copy.every)
+          ? copy.every(v => v === undefined)
+            ? []
+            : copy
+          : copy;
       },
       true,
       true

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -382,6 +382,14 @@ describe('<FieldArray />', () => {
       expect(formikBag.errors.friends).toEqual(undefined);
       expect(formikBag.touched.friends).toEqual(undefined);
     });
+    it('should clean up errors', () => {
+      act(() => {
+        formikBag.setFieldError('friends.1', 'Field error');
+        arrayHelpers.remove(1);
+      });
+
+      expect(formikBag.errors.friends).toEqual(undefined);
+    });
   });
 
   describe('given array-like object representing errors', () => {


### PR DESCRIPTION
This fixes an error where you can get to an invalid error state if you remove an array field which has a corresponding error.

Here is a basic example of the original problem: https://codesandbox.io/s/formik-example-forked-gi0kc?file=/index.js

If the empty field gets removed the form will not turn valid because the array is not "empty" and therefore gets not removed from the parent object.

An other way to to fix this might be to rewrite the `isEmptyArray` assertion to also consider arrays with only `undefined` values as empty.

