### PR TITLE
Update 3rd-party-bindings.md

### DIFF
--- a/docs/3rd-party-bindings.md
+++ b/docs/3rd-party-bindings.md
@@ -11,6 +11,6 @@ A few popular frameworks have open source wrappers readily available:
 - [Ant Design](https://github.com/jannikbuschke/formik-antd)
 - [Fabric](https://github.com/kmees/formik-office-ui-fabric-react)
 - [Material UI](https://github.com/stackworx/formik-material-ui)
-- [Reactstrap](https://github.com/shoaibkhan94/reactstrap-formik)
+- [Reactstrap](https://github.com/LaplancheMaxime/reactstrap-formik-adapter)
 - [Semantic UI 2.0](https://github.com/JT501/formik-semantic-ui-react)
 - [Semantic UI](https://github.com/turner-industries/formik-semantic-ui)


### PR DESCRIPTION
The reactstrap-formik is out to date. I propose you my library, updated : reactstrap-formik-adapter.
https://www.npmjs.com/package/reactstrap-formik-adapter
 * Boostrap v5.1.3
 * formik v2.2.9
 * prop-types v15.7.2
 * reactstrap v9.0.1