### PR TITLE
[Formik Website] Remove typescript badge image to prevent broken links on the page

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -3,8 +3,6 @@ id: typescript
 title: TypeScript
 ---
 
-[![TypeScript Types](https://img.shields.io/npm/types/formik.svg)](https://npm.im/formik)
-
 The Formik source code is written in TypeScript, so you can rest easy that Formik's
 types will always be up-to-date. As a mental model, Formik's type signatures are very
 similar to React Router 4's `<Route>`.


### PR DESCRIPTION
## Screenshot of the issue
<img width="1624" alt="Screen Shot 2021-12-15 at 10 08 23 PM" src="https://user-images.githubusercontent.com/981993/146301068-7cf33fd6-35a7-4b91-af2c-ff97de4bba09.png">

It seems that the badge at the top of [this page](https://formik.org/docs/guides/typescript) is getting rendered as a page-wide link that covers the rest of the links. 

## Proposed Fix
- I'm not sure if it's necessary, but remove the badge (which currently links to Formik's NPM page) seemed to work. 

If the badge needs to remain, please let me know - I can try to dig into it from a different angle. Cheers to the Formik team!