### PR TITLE
Fix form.touched types for array fields

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -26,8 +26,8 @@ export type FormikErrors<Values> = {
 export type FormikTouched<Values> = {
   [K in keyof Values]?: Values[K] extends any[]
     ? Values[K][number] extends object // [number] is the special sauce to get the type of array's element. More here https://github.com/Microsoft/TypeScript/pull/21316
-      ? FormikTouched<Values[K][number]>[]
-      : boolean
+      ? FormikTouched<Values[K][number]>[] | boolean | boolean[]
+      : boolean | boolean[]
     : Values[K] extends object
     ? FormikTouched<Values[K]>
     : boolean;


### PR DESCRIPTION
In Typescript `touched` was showing up as `boolean`, which did not accommodate array fields. Copied from the type of error field