### PR TITLE
Update docs describing validateForm method

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -235,7 +235,7 @@ component.
 
 #### `validateForm: (values?: any) => Promise<FormikErrors<Values>>`
 
-Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
+Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against, otherwise this will use the current `values` of the form.
 
 #### `validateField: (field: string) => void`
 


### PR DESCRIPTION
Passing values to validateForm doesn't seem to update the form values. Maybe it did at one point?