### PR TITLE
Add 'validate' and 'validationSchema' props to useFormikContext object

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -980,6 +980,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     validateOnBlur,
     validateOnChange,
     validateOnMount,
+    validate: props.validate,
+    validationSchema: props.validationSchema,
   };
 
   return ctx;


### PR DESCRIPTION
This PR is to resolve issue #2092 to include the `validate` and `validationSchema` props in the `useFomrikContext` object as specified by the documentation.