### PR TITLE
Update setFieldValue return type in documentation for issue #3465

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -191,7 +191,7 @@ Trigger a form submission. The promise will be rejected if form is invalid.
 Number of times user tried to submit the form. Increases when [`handleSubmit`](#handlesubmit-e-reactformevent-htmlformelement-void) is called, resets after calling
 [`handleReset`](#handlereset-void). `submitCount` is readonly computed property and should not be mutated directly.
 
-#### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
+#### `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => Promise<FormikErrors<Values>> | Promise<void>`
 
 Set the value of a field imperatively. `field` should match the key of
 `values` you wish to update. Useful for creating custom input change handlers. Calling this will trigger validation to run if `validateOnChange` is set to `true` (which it is by default). You can also explicitly prevent/skip validation by passing a third argument as `false`.


### PR DESCRIPTION
Updated `setFieldValue` return type in documentation as it returns a `Promise` which either resolves with void or formik error object once the validation completes