### PR TITLE
feat: validateAfterSubmit prop

### DIFF
--- a/.changeset/pink-falcons-shake.md
+++ b/.changeset/pink-falcons-shake.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Added `validateAfterSubmit` prop to prevent form validation until the first submission attempt.

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -451,6 +451,11 @@ events and `change`-related methods. More specifically, when either
 Default is `false`. Use this option to tell Formik to run validations when the `<Formik />` component mounts
 and/or `initialValues` change.
 
+### `validateAfterSubmit?: boolean`
+
+Default is `false`. Use this option to tell Formik to not run validations before the first attempt to submit the `<Form />`.
+After submission, validation logic will follow the rules set by `validateOnBlur` and `validateOnChange`.
+
 ### `validationSchema?: Schema | (() => Schema)`
 
 [A Yup schema](https://github.com/jquense/yup) or a function that returns a Yup

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -252,7 +252,7 @@ export const FieldLevelValidationExample = () => (
 
 ## When Does Validation Run?
 
-You can control when Formik runs validation by changing the values of `<Formik validateOnChange>` and/or `<Formik validateOnBlur>` props depending on your needs. By default, Formik will run validation methods as follows:
+You can control when Formik runs validation by changing the values of `<Formik validateOnChange>`, `<Formik validateOnBlur>`, and/or `<Formik validateAfterSubmit>` props depending on your needs. By default, Formik will run validation methods as follows:
 
 **After "change" events/methods** (things that update`values`)
 

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -133,6 +133,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   validateOnChange = true,
   validateOnBlur = true,
   validateOnMount = false,
+  validateAfterSubmit = false,
   isInitialValid,
   enableReinitialize = false,
   onSubmit,
@@ -142,6 +143,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     validateOnChange,
     validateOnBlur,
     validateOnMount,
+    validateAfterSubmit,
     onSubmit,
     ...rest,
   };
@@ -536,7 +538,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     (touched: FormikTouched<Values>, shouldValidate?: boolean) => {
       dispatch({ type: 'SET_TOUCHED', payload: touched });
       const willValidate =
-        shouldValidate === undefined ? validateOnBlur : shouldValidate;
+          shouldValidate ?? (validateAfterSubmit && !state.submitCount ? false : validateOnBlur);
       return willValidate
         ? validateFormWithHighPriority(state.values)
         : Promise.resolve();
@@ -553,7 +555,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
       dispatch({ type: 'SET_VALUES', payload: resolvedValues });
       const willValidate =
-        shouldValidate === undefined ? validateOnChange : shouldValidate;
+          shouldValidate ?? (validateAfterSubmit && !state.submitCount ? false : validateOnChange);
       return willValidate
         ? validateFormWithHighPriority(resolvedValues)
         : Promise.resolve();
@@ -580,7 +582,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         },
       });
       const willValidate =
-        shouldValidate === undefined ? validateOnChange : shouldValidate;
+          shouldValidate ?? (validateAfterSubmit && !state.submitCount ? false : validateOnChange);
       return willValidate
         ? validateFormWithHighPriority(setIn(state.values, field, value))
         : Promise.resolve();
@@ -665,7 +667,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
         },
       });
       const willValidate =
-        shouldValidate === undefined ? validateOnBlur : shouldValidate;
+          shouldValidate ?? (validateAfterSubmit && !state.submitCount ? false : validateOnBlur);
       return willValidate
         ? validateFormWithHighPriority(state.values)
         : Promise.resolve();
@@ -980,6 +982,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     validateOnBlur,
     validateOnChange,
     validateOnMount,
+    validateAfterSubmit,
   };
 
   return ctx;

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -160,6 +160,8 @@ export interface FormikSharedConfig<Props = {}> {
   validateOnBlur?: boolean;
   /** Tells Formik to validate upon mount */
   validateOnMount?: boolean;
+  /** Tells Formik to only validate after the initial submit event */
+  validateAfterSubmit?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
   isInitialValid?: boolean | ((props: Props) => boolean);
   /** Should Formik reset the form when new initialValues change */

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -160,7 +160,7 @@ export interface FormikSharedConfig<Props = {}> {
   validateOnBlur?: boolean;
   /** Tells Formik to validate upon mount */
   validateOnMount?: boolean;
-  /** Tells Formik to only validate after the initial submit event */
+  /** Tells Formik to only validate after the initial submission attempt */
   validateAfterSubmit?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
   isInitialValid?: boolean | ((props: Props) => boolean);

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -249,6 +249,30 @@ describe('<Formik>', () => {
         expect(validate).not.toHaveBeenCalled();
       });
     });
+
+    it('does NOT run validations if validateAfterSubmit is true and the form has not been submitted', async () => {
+      const validate = jest.fn(() => Promise.resolve());
+      const validationSchema = {
+        validate,
+      };
+      const { rerender } = renderFormik({
+        validate,
+        validationSchema,
+        validateAfterSubmit: true,
+      });
+
+      fireEvent.change(screen.getByTestId('name-input'), {
+        persist: noop,
+        target: {
+          name: 'name',
+          value: 'ian',
+        },
+      });
+      rerender();
+      await waitFor(() => {
+        expect(validate).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('handleBlur', () => {

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -112,6 +112,7 @@ describe('withFormik()', () => {
       validateOnBlur: true,
       validateOnMount: false,
       validateOnChange: true,
+      validateAfterSubmit: false,
     });
   });
 


### PR DESCRIPTION
Fixes #1251
Fixes #3375

Adds the `validateAfterSubmit` prop to `<Formik />`. This will prevent form validation until after the first submission attempt, where it will then follow the logic defined by `validateOnBlur` and `validateOnChange`.