### PR TITLE
docs: [fix] some items in the sidebar is highlighted even though it is not selected

### DIFF
--- a/website/src/pages/docs/[...slug].tsx
+++ b/website/src/pages/docs/[...slug].tsx
@@ -185,7 +185,7 @@ function SidebarRoutes({
     ({ path, title, routes, heading, open }, idx) => {
       if (routes) {
         const pathname = getCategoryPath(routes);
-        const selected = slug.startsWith(pathname as any);
+        const selected = slug === pathname;
         const opened = selected || isMobile ? false : open;
 
         if (heading) {


### PR DESCRIPTION
This PR fixes a bug that some items in the sidebar is active without being selected.

In https://formik.org/docs/api/formik, only formik item should be highlighted but two (formik, form) are highlighted.
<img width="271" alt="Screenshot 2022-03-02 at 16 27 15" src="https://user-images.githubusercontent.com/14245930/156314742-2fa88564-79bb-4b1d-b80c-01955a3e38ef.png">
