### PR TITLE
Update React Native gist

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -24,11 +24,11 @@ export const MyReactNativeForm = props => (
     initialValues={{ email: '' }}
     onSubmit={values => console.log(values)}
   >
-    {({ handleChange, handleBlur, handleSubmit, values }) => (
+    {({ setFieldValue, setFieldTouched, handleSubmit, values }) => (
       <View>
         <TextInput
-          onChangeText={handleChange('email')}
-          onBlur={handleBlur('email')}
+          onChangeText={value => setFieldValue('email', value)}
+          onBlur={() => setFieldTouched('email', true)}
           value={values.email}
         />
         <Button onPress={handleSubmit} title="Submit" />
@@ -44,4 +44,4 @@ DOM and React Native are:
 1. Formik's `handleSubmit` is passed to a `<Button onPress={...} />`
    instead of HTML `<form onSubmit={...} />` component (since there is no
    `<form />` element in React Native).
-2. `<TextInput />` uses Formik's `handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with React Native we can't get it automatically like in web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setFieldTouched(fieldName, bool)` as an alternative.
+2. `<TextInput />` must call `setFieldValue(fieldName, value)` and `setFieldTouched(fieldName, bool)` because Formik can't retrieve field names and values from DOM events, like in web (using input name attribute).


### PR DESCRIPTION
The example doesn't work out of the box, throwing `TypeError: undefined is not an object (evaluating 'target.type')` because there is no DOM change event in Native.