### PR TITLE
'Edit this page on GitHub' link doesn't work on the Formik Docs

### DIFF
--- a/website/src/siteConfig.tsx
+++ b/website/src/siteConfig.tsx
@@ -1,7 +1,7 @@
 // List of projects/orgs using your project for the users page.
 
 export const siteConfig = {
-  editUrl: 'https://github.com/formik/formik/edit/master/docs/src/pages',
+  editUrl: 'https://github.com/jaredpalmer/formik/tree/master/docs',
   copyright: `Copyright © ${new Date().getFullYear()} Jared Palmer. All Rights Reserved.`,
   repoUrl: 'https://github.com/formik/formik',
   discordUrl: 'https://discord.com/invite/pJSg287',


### PR DESCRIPTION
The "Edit this page on GitHub" link at the footer of Formik.org sends you to a 404 page on Github.
#3548
