### PR TITLE
 Fixing style bug on the side menu of Formik Doc

### DIFF
--- a/website/src/pages/docs/[...slug].tsx
+++ b/website/src/pages/docs/[...slug].tsx
@@ -221,7 +221,7 @@ function SidebarRoutes({
       const href = '/docs/[...slug]';
       const pagePath = removeFromLast(path!, '.');
       const pathname = addTagToSlug(pagePath, tag);
-      const selected = slug.startsWith(pagePath);
+      const selected = slug === pagePath;
       const route = { href, path, title, pathname, selected };
       return (
         <SidebarPost


### PR DESCRIPTION
## The problem
#3540 
When we previously clicked on "**FieldArray**" the state of this element becomes "selected" but also "**Field**" and we encounter the same behavior when clicking on "**Formik**" that also selects "**Form**".

### Old Behavior :
<img width="255" alt="Screenshot 2022-04-22 at 16 57 13" src="https://user-images.githubusercontent.com/65896178/164740384-7ff50af0-637e-4a0f-ba7a-ed2c34ea1168.png">

### Fixed Behavior : 
<img width="238" alt="Screenshot 2022-04-22 at 16 59 33" src="https://user-images.githubusercontent.com/65896178/164740824-fc1546c8-14b0-4d5a-a0a0-0cb1a854fc99.png">


## What was the cause
![code](https://user-images.githubusercontent.com/65896178/164741245-70bcb61a-46dd-421a-afa4-31b0207b5595.png)

The reason was that when mapping through the list of routes, javascript compared the value of the current slug with the page path by using the function "**includes()**". If true, the style of the link becomes bold but the problem was that return true on values that start with the same value.

For example : 
```js
const slug = '/docs/api/fieldArray';
const pagePath = '/docs/api/fieldArray';

const selected = slug.includes(pathName);
// selected will return true.
```
But this can also create this problem too

```js
const slug = '/docs/api/fieldArray';
const pagePath = '/docs/api/field';

const selected = slug.includes(pathName);
// selected will also return true.
```

### The solution 
![code1](https://user-images.githubusercontent.com/65896178/164745013-8fc479cd-1160-49d3-9bae-9ff1a4d91793.png)

We create strict equality between the slug and the page path

