### PR TITLE
docs(formik api): replace `formikBag` with `formikHelpers` on `onSubmit` method signature

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -377,18 +377,17 @@ Note: `initialValues` not available to the higher-order component, use
 Your optional form reset handler. It is passed your forms `values` and the
 "FormikBag".
 
-### `onSubmit: (values: Values, formikBag: FormikBag) => void | Promise<any>`
+### `onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void | Promise<any>`
 
 Your form submission handler. It is passed your forms `values` and the
-"FormikBag", which includes an object containing a subset of the
+"FormikHelpers", which includes an object containing a subset of the
 [injected props and methods](#formik-render-methods-and-props) (i.e. all the methods
-with names that start with `set<Thing>` + `resetForm`) and any props that were
-passed to the wrapped component.
+with names that start with `set<Thing>`).
 
 Note: `errors`, `touched`, `status` and all event handlers are NOT
 included in the `FormikBag`.
 
-> IMPORTANT: If `onSubmit` is async, then Formik will automatically set `isSubmitting` to `false` on your behalf once it has resolved. This means you do NOT need to call `formikBag.setSubmitting(false)` manually. However, if your `onSubmit` function is synchronous, then you need to call `setSubmitting(false)` on your own.
+> IMPORTANT: If `onSubmit` is async, then Formik will automatically set `isSubmitting` to `false` on your behalf once it has resolved. This means you do NOT need to call `formikHelper.setSubmitting(false)` manually. However, if your `onSubmit` function is synchronous, then you need to call `setSubmitting(false)` on your own.
 
 ### `validate?: (values: Values) => FormikErrors<Values> | Promise<any>`
 


### PR DESCRIPTION
## The problem 🏚️ 

The documentation for the method `onSubmit` in the [<Formik /> API Reference](https://formik.org/docs/api/formik#onsubmit-values-values-formikbag-formikbag--void--promiseany) is wrong. The method signature describes two parameters, `values: Values` and `formikBag: FormikBag` but the code expects `values:  Values` and `formikHelpers: FormikHelpers<Values>`, which throws an error for any user following the documentation. 

![image](https://user-images.githubusercontent.com/42848561/166129495-06eb4597-d616-4ac0-a8ca-9ac47a296661.png)


## The solution this PR brings 🏠 

Updated the method signature to reflect what the `onSubmit` method expects. 