### PR TITLE
Improve documentation on `setValues`

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -212,7 +212,7 @@ Set `touched` imperatively. Calling this will trigger validation to run if `vali
 
 #### `setValues: (fields: React.SetStateAction<{ [field: string]: any }>, shouldValidate?: boolean) => void`
 
-Set `values` imperatively. Calling this will trigger validation to run if `validateOnChange` is set to `true` (which it is by default). You can also explicitly prevent/skip validation by passing a second argument as `false`.
+Set `values` imperatively. `field` can be either the new value object or a function that takes the current values as an argument and allows you to return a new value object based on the current form values. Calling this will trigger validation to run if `validateOnChange` is set to `true` (which it is by default). You can also explicitly prevent/skip validation by passing a second argument as `false`.
 
 #### `status?: any`
 


### PR DESCRIPTION
I suggest adding a note on this to the documentation again. I lost four hours today by missing this feature and trying to come up with a workaround.

From the current documentation, it's easy to miss the fact that `setValues` also allows for passing a function to set the new values based on the current ones.

Thanks to everyone involved for making Formik, it is by far one of the best React libraries out there!