### PR TITLE
getFieldProps names autocomplete

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -145,7 +145,7 @@ export interface FormikHandlers {
       : (e: string | React.ChangeEvent<any>) => void;
   };
 
-  getFieldProps: <Value = any>(props: any) => FieldInputProps<Value>;
+  getFieldProps: <Value = any>(props: keyof Value) => FieldInputProps<Value>;
   getFieldMeta: <Value>(name: string) => FieldMetaProps<Value>;
   getFieldHelpers: <Value = any>(name: string) => FieldHelperProps<Value>;
 }


### PR DESCRIPTION
**getFieldProps** had a current input type of any.
I believe that in order to reflect the names of data fields, input type should be changed accordingly to :

```js
// types.tsx
getFieldProps: <Value = any>(props: keyof Value) => FieldInputProps<Value>;
```

This allow for better code completion in editors, simmilar to [react hook form](https://react-hook-form.com/)'s. `...register("example")` function does.