### PR TITLE
Changing a field does not rerenders other fields

### DIFF
--- a/examples/re-renders-test/package.json
+++ b/examples/re-renders-test/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "re-renders-test",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "dependencies": {
+    "@types/react": "^16.9.55",
+    "@types/react-dom": "^16.9.9",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-scripts": "5.0.0",
+    "formik": "latest",
+    "typescript": "^4.7.4"
+  },
+  "scripts": {
+    "start": "BROWSER=0 PORT=3010 react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/examples/re-renders-test/public/index.html
+++ b/examples/re-renders-test/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Re-renders test</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./src/index.tsx"></script>
+  </body>
+</html>

--- a/examples/re-renders-test/src/App.tsx
+++ b/examples/re-renders-test/src/App.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { ErrorMessage, Field, Form, Formik, FormikHelpers } from 'formik';
+import { Debug } from './Debug';
+import {
+  ButtonSetFieldError,
+  Input,
+  InputWithIsSubmitting,
+  InputWithUseField,
+  WithFieldArray,
+  WithUseFormikContext,
+  WatchFieldWithUseField,
+  WatchFieldWithUseFormikSelector,
+} from './components';
+
+const initialValues = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  friends: [
+    {
+      name: '',
+      email: '',
+    },
+  ],
+};
+
+export type InitialValuesType = typeof initialValues;
+
+const App = () => {
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={(
+        values: InitialValuesType,
+        { setSubmitting }: FormikHelpers<InitialValuesType>
+      ) => {
+        setTimeout(() => {
+          alert(JSON.stringify(values, null, 2));
+          setSubmitting(false);
+        }, 500);
+      }}
+    >
+      <Form>
+        <WithUseFormikContext />
+        <WatchFieldWithUseFormikSelector name="firstName" />
+        <label htmlFor="firstName">First Name</label>
+        <Field name="firstName" placeholder="Jane" as={Input} />
+        <div>
+          <ButtonSetFieldError name={`firstName`} />
+          <ErrorMessage
+            name={`firstName`}
+            component="div"
+            className="field-error"
+          />
+        </div>
+
+        <div>
+          <WatchFieldWithUseField name="lastName" />
+          <label htmlFor="lastName">Last Name</label>
+          <InputWithUseField name="lastName" />
+        </div>
+        <label htmlFor="email">Email</label>
+        <Field
+          id="email"
+          name="email"
+          placeholder="john@acme.com"
+          type="email"
+          as={InputWithIsSubmitting}
+        />
+
+        <WithFieldArray />
+
+        <p>
+          <button type="submit">Submit</button>
+        </p>
+
+        <Debug />
+      </Form>
+    </Formik>
+  );
+};
+
+export default App;

--- a/examples/re-renders-test/src/Debug.js
+++ b/examples/re-renders-test/src/Debug.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useFormikSelector } from 'formik';
+
+export const Debug = () => {
+  const rest = useFormikSelector(
+    ({ validationSchema, validate, onSubmit, ...rest }) => rest
+  );
+
+  return (
+    <div
+      style={{
+        margin: '3rem 1rem',
+        borderRadius: 4,
+        background: '#f6f8fa',
+        boxShadow: '0 0 1px  #eee inset',
+      }}
+    >
+      <div
+        style={{
+          textTransform: 'uppercase',
+          fontSize: 11,
+          borderTopLeftRadius: 4,
+          borderTopRightRadius: 4,
+          fontWeight: 500,
+          padding: '.5rem',
+          background: '#555',
+          color: '#fff',
+          letterSpacing: '1px',
+        }}
+      >
+        Formik State
+      </div>
+      <pre
+        style={{
+          fontSize: '.85rem',
+          padding: '.25rem .5rem',
+          overflowX: 'scroll',
+        }}
+      >
+        {JSON.stringify(rest, null, 2)}
+      </pre>
+    </div>
+  );
+};

--- a/examples/re-renders-test/src/components.tsx
+++ b/examples/re-renders-test/src/components.tsx
@@ -1,0 +1,170 @@
+import React, { useRef } from 'react';
+import {
+  ErrorMessage,
+  Field,
+  FieldArray,
+  useField,
+  useFormikContext,
+  useFormikSelector,
+} from 'formik';
+import { InitialValuesType } from './App';
+
+export const RenderCount = ({ title }: { title: string }) => {
+  const renderCountRef = useRef(0);
+  return (
+    <>
+      {title} of renders: {renderCountRef.current++}
+    </>
+  );
+};
+
+export const Input = (props: React.InputHTMLAttributes<HTMLInputElement>) => {
+  return (
+    <>
+      <input {...props} />
+      <RenderCount title="Input" />
+    </>
+  );
+};
+
+export const InputWithIsSubmitting = (
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) => {
+  const isSubmitting = useFormikSelector<InitialValuesType>(
+    ({ isSubmitting }) => isSubmitting
+  ) as boolean;
+  return (
+    <>
+      <input {...props} disabled={isSubmitting} />
+      <RenderCount title="InputWithIsSubmitting" />
+    </>
+  );
+};
+
+export const InputWithUseField = ({ name }: { name: string }) => {
+  const [field] = useField(name);
+  return (
+    <>
+      <input {...field} placeholder={name} />
+      <RenderCount title="InputWithUseField" />
+    </>
+  );
+};
+
+export const WithUseFormikContext = () => {
+  const formik = useFormikContext();
+  return (
+    <p>
+      <RenderCount title="WithUseFormikContext" />
+    </p>
+  );
+};
+
+export const WatchFieldWithUseFormikSelector = ({
+  name,
+}: {
+  name: keyof InitialValuesType;
+}) => {
+  const value = useFormikSelector<InitialValuesType>(
+    ({ values }) => values[name]
+  );
+  return (
+    <div>
+      <RenderCount
+        title={`Watch with useFormikSelector: ${name}, value: ${value}`}
+      />
+    </div>
+  );
+};
+
+export const WatchFieldWithUseField = ({
+  name,
+}: {
+  name: keyof InitialValuesType;
+}) => {
+  const [{ value }] = useField(name);
+  return (
+    <div>
+      <RenderCount title={`Watch with useField: ${name}, value: ${value}`} />
+    </div>
+  );
+};
+
+export const WithFieldArray = () => {
+  return (
+    <div>
+      <h3>Invite friends</h3>
+
+      <FieldArray name="friends">
+        {({ remove, push, form: { values } }) => (
+          <div>
+            {values.friends.length > 0 &&
+              (values as InitialValuesType).friends.map((friend, index) => {
+                return (
+                  <div key={index}>
+                    <p>
+                      <label htmlFor={`friends.${index}.name`}>Name</label>
+                      <InputWithUseField name={`friends.${index}.name`} />
+                      <ErrorMessage
+                        name={`friends.${index}.name`}
+                        component="div"
+                        className="field-error"
+                      />
+                    </p>
+                    <p>
+                      <label htmlFor={`friends.${index}.email`}>Email</label>
+                      <Field
+                        name={`friends.${index}.email`}
+                        placeholder="jane@acme.com"
+                        type="email"
+                        as={Input}
+                      />
+                      <ErrorMessage
+                        name={`friends.${index}.email`}
+                        component="div"
+                        className="field-error"
+                      />
+                    </p>
+                    <div>
+                      <button
+                        type="button"
+                        className="secondary"
+                        onClick={() => remove(index)}
+                      >
+                        X
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            <p>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => push({ name: '', email: '' })}
+              >
+                Add Friend
+              </button>
+              <ButtonSetFieldError name={`friends.0.name`} />
+            </p>
+          </div>
+        )}
+      </FieldArray>
+    </div>
+  );
+};
+
+export const ButtonSetFieldError = ({ name }: { name: string }) => {
+  const formik = useFormikContext();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        formik.setFieldError(name, `error ${Date.now()}`);
+      }}
+    >
+      Set error {name}
+    </button>
+  );
+};

--- a/examples/re-renders-test/src/index.tsx
+++ b/examples/re-renders-test/src/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/re-renders-test/tsconfig.json
+++ b/examples/re-renders-test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es2015", "es2016", "dom"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react",
+    "baseUrl": ".",
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -49,7 +49,7 @@
     "lodash-es": "^4.17.21",
     "react-fast-compare": "^2.0.1",
     "tiny-warning": "^1.0.2",
-    "tslib": "^1.10.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@testing-library/react": "^11.1.0",

--- a/packages/formik/src/EventManager.ts
+++ b/packages/formik/src/EventManager.ts
@@ -1,0 +1,93 @@
+export type EventListener = (...args: any[]) => void;
+
+export interface EventListenerOptions {
+    isFirst?: boolean;
+}
+
+interface EventListenerCollection<L extends EventListener> {
+    /**
+     * List of listeners to run before the others
+     * They are ran in the opposite order of the registration order
+     */
+    highPriority: Map<L, true>;
+
+    /**
+     * List of events to run after the high priority listeners
+     * They are ran in the registration order
+     */
+    regular: Map<L, true>;
+}
+
+// Used https://gist.github.com/mudge/5830382 as a starting point.
+// See https://github.com/browserify/events/blob/master/events.js for
+// the Node.js (https://nodejs.org/api/events.html) polyfill used by webpack.
+export class EventManager<L extends EventListener> {
+    events: {[eventName: string]: EventListenerCollection<L>} = {};
+
+    on<LT extends L>(eventName: string, listener: LT, options: EventListenerOptions = {}) {
+        let collection = this.events[eventName];
+
+        if (!collection) {
+            collection = {
+                highPriority: new Map(),
+                regular: new Map(),
+            };
+            this.events[eventName] = collection;
+        }
+
+        if (options.isFirst) {
+            collection.highPriority.set(listener, true);
+        } else {
+            collection.regular.set(listener, true);
+        }
+
+        return () => {
+            this.removeListener(eventName, listener);
+        };
+    }
+
+    removeListener<LT extends L>(eventName: string, listener: LT): void {
+        if (this.events[eventName]) {
+            this.events[eventName].regular.delete(listener);
+            this.events[eventName].highPriority.delete(listener);
+        }
+    }
+
+    removeAllListeners(): void {
+        this.events = {};
+    }
+
+    emit(eventName: string, ...args: any[]): void {
+        const collection = this.events[eventName];
+        if (!collection) {
+            return;
+        }
+
+        const highPriorityListeners = Array.from(collection.highPriority.keys());
+        const regularListeners = Array.from(collection.regular.keys());
+
+        for (let i = highPriorityListeners.length - 1; i >= 0; i -= 1) {
+            const listener = highPriorityListeners[i];
+            if (collection.highPriority.has(listener)) {
+                listener.apply(this, args);
+            }
+        }
+
+        for (let i = 0; i < regularListeners.length; i += 1) {
+            const listener = regularListeners[i];
+            if (collection.regular.has(listener)) {
+                listener.apply(this, args);
+            }
+        }
+    }
+
+    once(eventName: string, listener: L): void {
+        const that = this;
+        const oneTimeListener: EventListener = (...args: any[]) => {
+            listener.apply(that, args);
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            this.removeListener(eventName, oneTimeListener as L);
+        };
+        this.on(eventName, listener);
+    }
+}

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -8,7 +8,8 @@ import {
   FieldValidator,
 } from './types';
 import { useFormikContext } from './FormikContext';
-import { isFunction, isEmptyChildren, isObject } from './utils';
+import { useFormikSelector } from './useFormikSelector';
+import { isFunction, isEmptyChildren, isObject, getIn } from './utils';
 import invariant from 'tiny-warning';
 
 export interface FieldProps<V = any, FormValues = any> {
@@ -94,6 +95,12 @@ export function useField<Val = any>(
 
   const { name: fieldName, validate: validateFn } = props;
 
+  useFormikSelector(({ values, errors, touched }) => ({
+    value: getIn(values, fieldName),
+    error: getIn(errors, fieldName),
+    touched: getIn(touched, fieldName),
+  }));
+
   React.useEffect(() => {
     if (fieldName) {
       registerField(fieldName, {
@@ -141,6 +148,12 @@ export function Field({
 
     ...formik
   } = useFormikContext();
+
+  useFormikSelector(({ values, errors, touched }) => ({
+    value: getIn(values, name),
+    error: getIn(errors, name),
+    touched: getIn(touched, name),
+  }));
 
   if (__DEV__) {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/formik/src/index.tsx
+++ b/packages/formik/src/index.tsx
@@ -9,3 +9,5 @@ export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
 export * from './FastField';
+export * from './useFormikSelector';
+export * from './EventManager';

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { EventManager } from './EventManager';
 /**
  * Values of fields in the form
  */
@@ -252,7 +253,9 @@ export interface FormikRegistration {
  * State, handlers, and helpers made available to Formik's primitive components through context.
  */
 export type FormikContextType<Values> = FormikProps<Values> &
-  Pick<FormikConfig<Values>, 'validate' | 'validationSchema'>;
+  Pick<FormikConfig<Values>, 'validate' | 'validationSchema'> & {
+    eventManager: EventManager<FormikEventListener<Values>>;
+  };
 
 export interface SharedRenderProps<T> {
   /**
@@ -321,3 +324,12 @@ export interface FieldInputProps<Value> {
 export type FieldValidator = (
   value: any
 ) => string | void | Promise<string | void>;
+
+export type FormikEventListener<Values> = (
+  formikState: FormikState<Values>,
+  actions: FormikContextType<Values>
+) => void;
+
+export const FormikEvents = {
+  stateUpdate: 'stateUpdate',
+};

--- a/packages/formik/src/useFormikSelector.ts
+++ b/packages/formik/src/useFormikSelector.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import isEqual from 'react-fast-compare';
+import { useFormikContext } from './FormikContext';
+import { FormikEvents, FormikContextType } from './types';
+
+export type FormikSelector<Values, RT = unknown> = (
+  formik: FormikContextType<Values>
+) => RT;
+
+export function useFormikSelector<Values, RT = unknown>(
+  selector: FormikSelector<Values, RT>
+) {
+  const formik = useFormikContext<Values>();
+  const [, setForceUpdate] = React.useState(false);
+  const valueRef = React.useRef<RT>(selector(formik));
+
+  React.useEffect(
+    () =>
+      formik.eventManager.on(FormikEvents.stateUpdate, (_, formik) => {
+        const newValue = selector(formik);
+
+        if (!isEqual(newValue, valueRef.current)) {
+          valueRef.current = newValue;
+          setForceUpdate(p => !p);
+        }
+      }),
+    [formik]
+  );
+
+  return valueRef.current;
+}

--- a/packages/formik/test/ErrorMessage.test.tsx
+++ b/packages/formik/test/ErrorMessage.test.tsx
@@ -22,8 +22,8 @@ fdescribe('<ErrorMessage />', () => {
     let actualFProps: any;
     let message = 'Wrong';
     render(
-      <TestForm
-        render={(fProps: FormikProps<TestFormValues>) => {
+      <TestForm>
+        {(fProps: FormikProps<TestFormValues>) => {
           actualFProps = fProps;
           return (
             <div>
@@ -33,7 +33,7 @@ fdescribe('<ErrorMessage />', () => {
             </div>
           );
         }}
-      />
+      </TestForm>
     );
 
     await act(async () => {

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1413,7 +1413,9 @@ describe('<Formik>', () => {
 
     await act(async () => {
       await getProps().validateForm();
+    });
 
+    await act(async () => {
       expect(getProps().errors).toEqual({
         users: [{ firstName: 'required', lastName: 'required' }],
       });
@@ -1435,8 +1437,10 @@ describe('<Formik>', () => {
     await act(async () => {
       try {
         await getProps().validateForm();
-      } catch ({ message }) {
-        caughtError = message;
+      } catch (e) {
+        if (e instanceof Error) {
+          caughtError = e.message;
+        }
       }
     });
 

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import * as Yup from 'yup';
 
-import { withFormik, FormikProps } from '../src';
+import { withFormik, FormikProps, EventManager } from '../src';
 import { noop } from './testHelpers';
 
 interface Values {
@@ -112,6 +112,7 @@ describe('withFormik()', () => {
       validateOnBlur: true,
       validateOnMount: false,
       validateOnChange: true,
+      eventManager: new EventManager(),
     });
   });
 

--- a/packages/formik/test/yupHelpers.test.ts
+++ b/packages/formik/test/yupHelpers.test.ts
@@ -31,7 +31,7 @@ describe('Yup helpers', () => {
     it('should validate', async () => {
       try {
         await validateYupSchema({}, schema);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.name).toEqual('ValidationError');
         expect(e.errors).toEqual(['required']);
       }


### PR DESCRIPTION
Hi. 
If a field change then all fields and component use useFormikCotext rerenders. It see to example https://codesandbox.io/s/formik-rerender-test-v8gw7x. It is not really good.

After my change:
https://user-images.githubusercontent.com/8194467/183079431-5629cb92-caf2-43d5-90df-94b66968c90a.mov

I wanted do Formik like React.Component and useFormik functions moved to Formik. Example here is https://github.com/DjoSmer/react-form-context-example/blob/master/src/features/profile/components/PersonalNames/FormControl.tsx.

Sorry for my english.