### PR TITLE
feat: Added typed checking and value suggestions to field related methods

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -14,6 +14,7 @@ import {
   FieldInputProps,
   FormikHelpers,
   FormikHandlers,
+  FieldKey,
 } from './types';
 import {
   isFunction,
@@ -561,7 +562,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   const setFieldError = React.useCallback(
-    (field: string, value: string | undefined) => {
+    (field: FieldKey<Values>, value: string | undefined) => {
       dispatch({
         type: 'SET_FIELD_ERROR',
         payload: { field, value },
@@ -571,7 +572,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   const setFieldValue = useEventCallback(
-    (field: string, value: any, shouldValidate?: boolean) => {
+    (field: FieldKey<Values>, value: any, shouldValidate?: boolean) => {
       dispatch({
         type: 'SET_FIELD_VALUE',
         payload: {
@@ -656,7 +657,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   const setFieldTouched = useEventCallback(
-    (field: string, touched: boolean = true, shouldValidate?: boolean) => {
+    (field: FieldKey<Values>, touched: boolean = true, shouldValidate?: boolean) => {
       dispatch({
         type: 'SET_FIELD_TOUCHED',
         payload: {

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -92,12 +92,12 @@ export interface FormikHelpers<Values> {
     shouldValidate?: boolean
   ) => void;
   /** Set value of form field directly */
-  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+  setFieldValue: (field: FieldKey<Values>, value: any, shouldValidate?: boolean) => void;
   /** Set error message of a form field directly */
-  setFieldError: (field: string, message: string | undefined) => void;
+  setFieldError: (field: FieldKey<Values>, message: string | undefined) => void;
   /** Set whether field has been touched directly */
   setFieldTouched: (
-    field: string,
+    field: FieldKey<Values>,
     isTouched?: boolean,
     shouldValidate?: boolean
   ) => void;
@@ -321,3 +321,8 @@ export interface FieldInputProps<Value> {
 export type FieldValidator = (
   value: any
 ) => string | void | Promise<string | void>;
+
+/**
+ * Generic field name type to help intellisense in suggesting field names
+ */
+ export type FieldKey<Values> = keyof Values & string;


### PR DESCRIPTION
## Problem
- When calling some formik methods such as "setFieldValue", "setFieldTouched", etc., the "field" parameter does not suggest field names alloying for mistakes.

## Solution
- A new type has been created "FieldKey<Values>" to replace the basic string type of those method parameters.
- This change allows intellisense to suggest and type check the field names provided to these methods.
