### PR TITLE
Add ValidValues generic to FormikConfig / useFormik

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -129,7 +129,7 @@ interface FieldRegistry {
   };
 }
 
-export function useFormik<Values extends FormikValues = FormikValues>({
+export function useFormik<Values extends FormikValues = FormikValues, ValidValues extends Values = Values>({
   validateOnChange = true,
   validateOnBlur = true,
   validateOnMount = false,
@@ -137,7 +137,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   enableReinitialize = false,
   onSubmit,
   ...rest
-}: FormikConfig<Values>) {
+}: FormikConfig<Values, ValidValues>) {
   const props = {
     validateOnChange,
     validateOnBlur,

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -169,7 +169,7 @@ export interface FormikSharedConfig<Props = {}> {
 /**
  * <Formik /> props
  */
-export interface FormikConfig<Values> extends FormikSharedConfig {
+export interface FormikConfig<Values, ValidValues extends Values = Values> extends FormikSharedConfig {
   /**
    * Form component to render
    */
@@ -213,8 +213,8 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
    * Submission handler
    */
   onSubmit: (
-    values: Values,
-    formikHelpers: FormikHelpers<Values>
+    values: ValidValues,
+    formikHelpers: FormikHelpers<ValidValues>
   ) => void | Promise<any>;
   /**
    * A Yup Schema or a function that returns a Yup schema


### PR DESCRIPTION
this change allows for describing both initialState and validState to formik which can be helpful in scenarios where using Yup.

```ts
const validationSchema = Yup.object({
  termsOfService: Yup.boolean().required().isTrue("You must accept the terms of service"),
  username: Yup.string().required(),
  password: Yup.string().required(),
})
type Values = Yup.TypeOf<typeof validationSchema>;
// Values = {
//  termsOfService: boolean;
//  username: string | undefined;
//  password: string | undefined;
// }
type ValidValues = Yup.Asserts<typeof validationSchema>;
// ValidValues = {
//   termsOfService: true,
//   username: string;
//   password: string;
// }

const createUser = async (username: string, password: string) => {
   // ...
}

const formik = useFormik<Values, ValidValues>({
  initialValues: {
    termsOfService: false,
    username: '',
    password: '',
  },
  validationSchema,
  async onSubmit(values) {
    // values is ValidValues as that's the only state it can be in after Yup transformation.
    await createUser(values.username, values.password); // this type-checks correctly now.
  }
});
```