### PR TITLE
fix: broken link

### DIFF
--- a/docs/api/useFormik.md
+++ b/docs/api/useFormik.md
@@ -3,7 +3,7 @@ id: useFormik
 title: useFormik()
 ---
 
-`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite its name, it is not meant for the majority of use cases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext](useFormikContext). Only use this hook if you are NOT using `<Formik>` or `withFormik`.
+`useFormik()` is a custom React hook that will return all Formik state and helpers directly. Despite its name, it is not meant for the majority of use cases. Internally, Formik uses `useFormik` to create the `<Formik>` component (which renders a [React Context](https://reactjs.org/docs/context.html) Provider). If you are trying to access Formik state via context, use [useFormikContext](/docs/api/useFormikContext). Only use this hook if you are NOT using `<Formik>` or `withFormik`.
 
 \*\* Be aware that `<Field>`, `<FastField>`, `<ErrorMessage>`, `connect()`, and `<FieldArray>` will NOT work with `useFormik()` as they all require React Context.
 


### PR DESCRIPTION
broken link to `useFormikContext` 