### PR TITLE
Helper method's field type update

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -92,12 +92,16 @@ export interface FormikHelpers<Values> {
     shouldValidate?: boolean
   ) => void;
   /** Set value of form field directly */
-  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+  setFieldValue: (
+    field: keyof Values,
+    value: any,
+    shouldValidate?: boolean
+  ) => void;
   /** Set error message of a form field directly */
-  setFieldError: (field: string, message: string | undefined) => void;
+  setFieldError: (field: keyof Values, message: string | undefined) => void;
   /** Set whether field has been touched directly */
   setFieldTouched: (
-    field: string,
+    field: keyof Values,
     isTouched?: boolean,
     shouldValidate?: boolean
   ) => void;


### PR DESCRIPTION
I updated the types for `setFieldValue`, `setFieldError`, and `setFieldTouched` methods field parameters from `string` to the key of the values provided.