### PR TITLE
Fix bug with setNestedObjectValues

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -13,7 +13,7 @@ title: Utils
 
 #### `setIn(obj: any, path: string, value: any): any`
 
-#### `setNestedObjectValues<T>(object: any, value: any, visited?: any, path?: string, response?: any): T`
+#### `setNestedObjectValues<T>(object: any, value: any, response?: any): T`
 
 #### `isEmptyArray: (value?: any) => boolean`
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -13,7 +13,7 @@ title: Utils
 
 #### `setIn(obj: any, path: string, value: any): any`
 
-#### `setNestedObjectValues<T>(object: any, value: any, visited?: any, response?: any): T`
+#### `setNestedObjectValues<T>(object: any, value: any, visited?: any, path?: string, response?: any): T`
 
 #### `isEmptyArray: (value?: any) => boolean`
 

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -147,24 +147,27 @@ export function setIn(obj: any, path: string, value: any): any {
  * @param object
  * @param value
  * @param visited
+ * @param path
  * @param response
  */
 export function setNestedObjectValues<T>(
   object: any,
   value: any,
-  visited: any = new WeakMap(),
+  visited: any = new Set(),
+  path: string = "",
   response: any = {}
 ): T {
   for (let k of Object.keys(object)) {
     const val = object[k];
+    const currentPath = path ? `${path}.${k}` : `${k}`;
     if (isObject(val)) {
-      if (!visited.get(val)) {
-        visited.set(val, true);
+      if (!visited.has(currentPath)) {
+        visited.add(currentPath);
         // In order to keep array values consistent for both dot path  and
         // bracket syntax, we need to check if this is an array so that
         // this will output  { friends: [true] } and not { friends: { "0": true } }
         response[k] = Array.isArray(val) ? [] : {};
-        setNestedObjectValues(val, value, visited, response[k]);
+        setNestedObjectValues(val, value, visited, currentPath, response[k]);
       }
     } else {
       response[k] = value;

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -146,29 +146,21 @@ export function setIn(obj: any, path: string, value: any): any {
  * Recursively a set the same value for all keys and arrays nested object, cloning
  * @param object
  * @param value
- * @param visited
- * @param path
  * @param response
  */
 export function setNestedObjectValues<T>(
   object: any,
   value: any,
-  visited: any = new Set(),
-  path: string = "",
   response: any = {}
 ): T {
   for (let k of Object.keys(object)) {
     const val = object[k];
-    const currentPath = path ? `${path}.${k}` : `${k}`;
     if (isObject(val)) {
-      if (!visited.has(currentPath)) {
-        visited.add(currentPath);
-        // In order to keep array values consistent for both dot path  and
-        // bracket syntax, we need to check if this is an array so that
-        // this will output  { friends: [true] } and not { friends: { "0": true } }
-        response[k] = Array.isArray(val) ? [] : {};
-        setNestedObjectValues(val, value, visited, currentPath, response[k]);
-      }
+      // In order to keep array values consistent for both dot path  and
+      // bracket syntax, we need to check if this is an array so that
+      // this will output  { friends: [true] } and not { friends: { "0": true } }
+      response[k] = Array.isArray(val) ? [] : {};
+      setNestedObjectValues(val, value, response[k]);
     } else {
       response[k] = value;
     }


### PR DESCRIPTION
I'm aware that this project is seemingly no longer maintained, but I'd like to propose this fix for https://github.com/jaredpalmer/formik/issues/3674, in case it's useful to someone.

The problem with the current version of the `setNestedObjectValues` function is that if you're using objects for your form values (instead of strings) and they happen to be identical (in my case I'm using an object like `{name: "English", iso639: "en"}` with two distinct Material UI `Autocomplete` widgets), the fact that `visited` is implemented as a `WeakMap` will cause trouble, because the values will collide. The result is that your `touched` object (which is what is being computed by this function) will miss certain values for certain fields.

The first commit in this PR is actually my first solution to this problem, which was to replace the `WeakMap` by a `Set`, and use the "path" into the object structure as the keys. So if you have a value structure like `{ names: ["aa", "bb"]}`, the paths `names.0` and `names.1` would be used as keys.

But then I realized that the `visited` mechanism is not needed in this context, as there is no need to prevent any infinite recursion, as the value object structure is necessarily a tree, and not a graph. I might be wrong about this last analysis, as I could not test extensively, but I simply cannot see any reason for this mechanism whatsoever. If I'm wrong for any reason, the solution is very easy: revert my second commit, and simply keep the first.