### PR TITLE
fix typo in MyCheckbox description

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -831,7 +831,7 @@ const MyTextInput = ({ label, ...props }) => {
 };
 
 const MyCheckbox = ({ children, ...props }) => {
-  // React treats radios and checkbox inputs differently other input types, select, and textarea.
+  // React treats radios and checkbox inputs differently from other input types: select and textarea.
   // Formik does this too! When you specify `type` to useField(), it will
   // return the correct bag of props for you -- a `checked` prop will be included
   // in `field` alongside `name`, `value`, `onChange`, and `onBlur`


### PR DESCRIPTION
I noticed a typo while taking the `Formik` tutorial. 
This PR fixes that so the sentence makes more sense with proper punctuation.