### PR TITLE
docs: Change resource article link Hackernoon -> Medium

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -33,7 +33,7 @@ description: Formik conference talks, courses, videos, blog posts, learning reso
 - [Accessible Formik forms](https://dev.to/ptrin/accessible-formik-forms-2gld) by [Perry Trinier](https://twitter.com/ptrin) - Oct 16, 2019
 - [Building dynamic forms with Formik with React and TypeScript](https://scottdj92.ghost.io/building-dynamic-forms-with-formik-with-react-and-typescript/) by [Scott Jones](https://twitter.com/sdj2964) - Sep 1, 2018
 - [Simple React form validation with Formik, Yup and/or Spected](https://itnext.io/simple-react-form-validation-with-formik-yup-and-or-spected-206ebe9e7dcc) by [Jakub Kočí](https://github.com/jakubkoci) - May 21, 2018
-- [ Formik —Handling files and reCaptcha](https://hackernoon.com/formik-handling-files-and-recaptcha-209cbeae10bc) by [João Miguel Cunha](https://twitter.com/lokuzt) - Dec 18, 2017
+- [ Formik —Handling files and reCaptcha](https://medium.com/hackernoon/formik-handling-files-and-recaptcha-209cbeae10bc) by [João Miguel Cunha](https://twitter.com/lokuzt) - Dec 18, 2017
 - [Better React Forms with Formik](https://mead.io/formik/?utm_source=github&utm_campaign=formikrepo) by [Andrew Mead](https://twitter.com/andrew_j_mead) - Nov 28, 2017
 - [The Joy of Forms with React and Formik](https://keyholesoftware.com/2017/10/23/the-joy-of-forms-with-react-and-formik/) by [Mat Warger](https://twitter.com/mwarger) - Oct 23, 2017
 - [Painless React Forms with Formik](https://hackernoon.com/painless-react-forms-with-formik-e61b70473c60) by [João Miguel Cunha](https://twitter.com/lokuzt) - Sep 8, 2017


### PR DESCRIPTION
The article  **Formik —Handling files and reCaptcha by João Miguel Cunha - Dec 18, 2017** has most of the code as embedded CodeSandbox, but hackernoon doesn't support CodeSandbox embeds and the fallback image doesn't link to the sandbox. I had to go hunt for this same article on other platforms to get the code, found that it's on Medium too and shows the sandbox properly.

[Hackernoon article link](https://hackernoon.com/formik-handling-files-and-recaptcha-209cbeae10bc) - CodeSandbox not accessible
[Medium article link](https://medium.com/hackernoon/formik-handling-files-and-recaptcha-209cbeae10bc) - CodeSandbox embeds are loaded