### PR TITLE
types: improve handlers type

### DIFF
--- a/examples/basic-typescript-2/index.html
+++ b/examples/basic-typescript-2/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Playground</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="./index.tsx"></script>
+  </body>
+</html>

--- a/examples/basic-typescript-2/index.tsx
+++ b/examples/basic-typescript-2/index.tsx
@@ -1,0 +1,51 @@
+import { useFormik } from 'formik';
+import * as React from 'react';
+import 'react-app-polyfill/ie11';
+import * as ReactDOM from 'react-dom';
+
+const App = () => {
+  const formik = useFormik({
+    initialValues: {
+      name: {
+        first: '',
+        last: '',
+      },
+      email: '',
+    },
+    onSubmit(_values, _helpers) {}
+  });
+
+  React.useEffect(() => {
+    formik.setFieldValue('name.first', 'john');
+  }, []);
+  
+  return (
+    <div>
+      <h1>Signup</h1>
+      <form onSubmit={formik.handleSubmit}>
+          <label>
+          First Name
+          <input name="user.first" placeholder="John" />
+          </label>
+
+          <label>
+            Last Name
+            <input name="name.last" placeholder="Doe" />
+          </label>
+
+          <label>
+            Email
+            <input
+              name="email"
+              placeholder="john@acme.com"
+              type="email"
+            />
+          </label>
+
+          <button type="submit">Submit</button>
+        </form>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/examples/basic-typescript-2/package.json
+++ b/examples/basic-typescript-2/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "formik-basic-typescript-example-2",
+  "version": "0.1.0",
+  "description": "This example demonstrates how to use Formik with TypeScript",
+  "main": "index.tsx",
+  "dependencies": {
+    "@types/react-dom": "^16.8.4",
+    "@types/react": "^16.9.11",
+    "formik": "latest",
+    "parcel": "latest",
+    "react-app-polyfill": "^1.0.5",
+    "react-dom": "latest",
+    "react": "latest",
+    "typescript": "latest"
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "semi": true
+  }
+}

--- a/examples/basic-typescript-2/tsconfig.json
+++ b/examples/basic-typescript-2/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": false,
+    "target": "es5",
+    "module": "commonjs",
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "removeComments": true,
+    "strictNullChecks": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "lib": ["es2015", "es2016", "dom"],
+    "baseUrl": ".",
+    "types": ["node"]
+  }
+}

--- a/packages/formik/src/ErrorMessage.tsx
+++ b/packages/formik/src/ErrorMessage.tsx
@@ -53,7 +53,4 @@ class ErrorMessageImpl extends React.Component<
   }
 }
 
-export const ErrorMessage = connect<
-  ErrorMessageProps,
-  ErrorMessageProps & { formik: FormikContextType<any> }
->(ErrorMessageImpl);
+export const ErrorMessage = connect<ErrorMessageProps, any>(ErrorMessageImpl);

--- a/packages/formik/src/FastField.tsx
+++ b/packages/formik/src/FastField.tsx
@@ -6,6 +6,7 @@ import {
   FormikContextType,
   FieldMetaProps,
   FieldInputProps,
+  FormikValues,
 } from './types';
 import invariant from 'tiny-warning';
 import { getIn, isEmptyChildren, isFunction } from './utils';
@@ -14,10 +15,10 @@ import { connect } from './connect';
 
 type $FixMe = any;
 
-export interface FastFieldProps<V = any> {
-  field: FieldInputProps<V>;
-  meta: FieldMetaProps<V>;
-  form: FormikProps<V>; // if ppl want to restrict this for a given form, let them.
+export interface FastFieldProps<TFormikValues extends FormikValues = any, TFieldValue = any> {
+  field: FieldInputProps<TFieldValue>;
+  meta: FieldMetaProps<TFieldValue>;
+  form: FormikProps<TFormikValues>; // if ppl want to restrict this for a given form, let them.
 }
 
 export type FastFieldConfig<T> = FieldConfig & {
@@ -32,7 +33,7 @@ export type FastFieldAttributes<T> = GenericFieldHTMLAttributes &
   FastFieldConfig<T> &
   T;
 
-type FastFieldInnerProps<Values = {}, Props = {}> = FastFieldAttributes<
+type FastFieldInnerProps<Values extends FormikValues = {}, Props = {}> = FastFieldAttributes<
   Props
 > & { formik: FormikContextType<Values> };
 
@@ -40,7 +41,7 @@ type FastFieldInnerProps<Values = {}, Props = {}> = FastFieldAttributes<
  * Custom Field component for quickly hooking into Formik
  * context and wiring up forms.
  */
-class FastFieldInner<Values = {}, Props = {}> extends React.Component<
+class FastFieldInner<Values extends FormikValues = {}, Props = {}> extends React.Component<
   FastFieldInnerProps<Values, Props>,
   {}
 > {
@@ -147,14 +148,14 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
       initialError: getIn(formik.initialErrors, name),
     };
 
-    const bag = { field, meta, form: restOfFormik };
+    const bag: FastFieldProps<Values> = { field, meta, form: restOfFormik };
 
     if (render) {
       return (render as any)(bag);
     }
 
     if (isFunction(children)) {
-      return (children as (props: FastFieldProps<any>) => React.ReactNode)(bag);
+      return (children as (props: FastFieldProps<Values>) => React.ReactNode)(bag);
     }
 
     if (component) {

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -6,12 +6,13 @@ import {
   FieldHelperProps,
   FieldInputProps,
   FieldValidator,
+  FormikValues,
 } from './types';
 import { useFormikContext } from './FormikContext';
 import { isFunction, isEmptyChildren, isObject } from './utils';
 import invariant from 'tiny-warning';
 
-export interface FieldProps<V = any, FormValues = any> {
+export interface FieldProps<V = any, FormValues extends FormikValues = any> {
   field: FieldInputProps<V>;
   form: FormikProps<FormValues>; // if ppl want to restrict this for a given form, let them.
   meta: FieldMetaProps<V>;

--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -6,6 +6,7 @@ import {
   FormikContextType,
   FormikProps,
   FormikState,
+  FormikValues,
   SharedRenderProps,
 } from './types';
 import {
@@ -17,8 +18,8 @@ import {
   setIn,
 } from './utils';
 
-export type FieldArrayRenderProps = ArrayHelpers & {
-  form: FormikProps<any>;
+export type FieldArrayRenderProps<T extends FormikValues = any> = ArrayHelpers & {
+  form: FormikProps<T>;
   name: string;
 };
 
@@ -137,7 +138,7 @@ const createAlterationHandler = (
   };
 };
 
-class FieldArrayInner<Values = {}> extends React.Component<
+class FieldArrayInner<Values extends FormikValues = {}> extends React.Component<
   FieldArrayConfig & { formik: FormikContextType<Values> },
   {}
 > {
@@ -369,7 +370,7 @@ class FieldArrayInner<Values = {}> extends React.Component<
       },
     } = this.props;
 
-    const props: FieldArrayRenderProps = {
+    const props: FieldArrayRenderProps<Values> = {
       ...arrayHelpers,
       form: restOfFormik,
       name,

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -9,14 +9,15 @@ import {
   FieldHelperProps,
   FieldInputProps,
   FieldMetaProps,
+  FormikBlurHandlerFn,
+  FormikChangeHandlerFn,
   FormikConfig,
-  FormikErrors,
-  FormikHandlers,
+  FormikErrors, 
   FormikHelpers,
   FormikProps,
   FormikState,
   FormikTouched,
-  FormikValues,
+  FormikValues
 } from './types';
 import {
   getActiveElement,
@@ -27,10 +28,10 @@ import {
   isPromise,
   isString,
   setIn,
-  setNestedObjectValues,
+  setNestedObjectValues
 } from './utils';
 
-type FormikMessage<Values> =
+type FormikMessage<Values extends FormikValues> =
   | { type: 'SUBMIT_ATTEMPT' }
   | { type: 'SUBMIT_FAILURE' }
   | { type: 'SUBMIT_SUCCESS' }
@@ -53,7 +54,7 @@ type FormikMessage<Values> =
     };
 
 // State reducer
-function formikReducer<Values>(
+function formikReducer<Values extends FormikValues>(
   state: FormikState<Values>,
   msg: FormikMessage<Values>
 ) {
@@ -119,8 +120,8 @@ function formikReducer<Values>(
 }
 
 // Initial empty states // objects
-const emptyErrors: FormikErrors<unknown> = {};
-const emptyTouched: FormikTouched<unknown> = {};
+const emptyErrors: FormikErrors<{}> = {};
+const emptyTouched: FormikTouched<{}> = {};
 
 // This is an object that contains a map of all registered fields
 // and their validate functions
@@ -138,7 +139,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   enableReinitialize = false,
   onSubmit,
   ...rest
-}: FormikConfig<Values>) {
+}: FormikConfig<Values>): FormikProps<Values> {
   const props = {
     validateOnChange,
     validateOnBlur,
@@ -653,7 +654,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     [setFieldValue, state.values]
   );
 
-  const handleChange = useEventCallback<FormikHandlers['handleChange']>(
+  const handleChange = useEventCallback<FormikChangeHandlerFn>(
     (
       eventOrPath: string | React.ChangeEvent<any>
     ): void | ((eventOrTextValue: string | React.ChangeEvent<any>) => void) => {
@@ -703,7 +704,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     [setFieldTouched]
   );
 
-  const handleBlur = useEventCallback<FormikHandlers['handleBlur']>(
+  const handleBlur = useEventCallback<FormikBlurHandlerFn>(
     (eventOrString: any): void | ((e: any) => void) => {
       if (isString(eventOrString)) {
         return event => executeBlur(event, eventOrString);
@@ -959,7 +960,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     [isInitialValid, dirty, state.errors, props]
   );
 
-  const ctx = {
+  const ctx: FormikProps<Values> = {
     ...state,
     initialValues: initialValues.current,
     initialErrors: initialErrors.current,
@@ -1018,7 +1019,7 @@ export function Formik<
     }, []);
   }
   return (
-    <FormikProvider value={formikbag}>
+    <FormikProvider value={formikbag as unknown as FormikProps<FormikValues>}>
       {component
         ? React.createElement(component as any, formikbag)
         : render
@@ -1056,7 +1057,7 @@ function warnAboutMissingIdentifier({
 /**
  * Transform Yup ValidationError to a more usable object
  */
-export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
+export function yupToFormErrors<Values extends FormikValues>(yupError: any): FormikErrors<Values> {
   let errors: FormikErrors<Values> = {};
   if (yupError.inner) {
     if (yupError.inner.length === 0) {

--- a/packages/formik/src/FormikContext.tsx
+++ b/packages/formik/src/FormikContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormikContextType } from './types';
+import { FormikContextType, FormikValues } from './types';
 import invariant from 'tiny-warning';
 
 export const FormikContext = React.createContext<FormikContextType<any>>(
@@ -10,8 +10,8 @@ FormikContext.displayName = 'FormikContext';
 export const FormikProvider = FormikContext.Provider;
 export const FormikConsumer = FormikContext.Consumer;
 
-export function useFormikContext<Values>() {
-  const formik = React.useContext<FormikContextType<Values>>(FormikContext);
+export function useFormikContext<Values extends FormikValues>() {
+  const formik = React.useContext<FormikContextType<Values>>(FormikContext as unknown as React.Context<FormikContextType<Values>>);
 
   invariant(
     !!formik,

--- a/packages/formik/src/connect.tsx
+++ b/packages/formik/src/connect.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
-import { FormikContextType } from './types';
+import { FormikContextType, FormikValues } from './types';
 import { FormikConsumer } from './FormikContext';
 import invariant from 'tiny-warning';
 
@@ -9,10 +9,10 @@ import invariant from 'tiny-warning';
  * Connect any component to Formik context, and inject as a prop called `formik`;
  * @param Comp React Component
  */
-export function connect<OuterProps, Values = {}>(
-  Comp: React.ComponentType<OuterProps & { formik: FormikContextType<Values> }>
+export function connect<TOuterProps, TFormikValues extends FormikValues = {}>(
+  Comp: React.ComponentType<TOuterProps & { formik: FormikContextType<TFormikValues> }>
 ) {
-  const C: React.FC<OuterProps> = props => (
+  const C: React.FC<TOuterProps> = props => (
     <FormikConsumer>
       {formik => {
         invariant(
@@ -32,7 +32,7 @@ export function connect<OuterProps, Values = {}>(
 
   // Assign Comp to C.WrappedComponent so we can access the inner component in tests
   // For example, <Field.WrappedComponent /> gets us <FieldInner/>
-  (C as React.FC<OuterProps> & {
+  (C as React.FC<TOuterProps> & {
     WrappedComponent: typeof Comp;
   }).WrappedComponent = Comp;
 
@@ -41,7 +41,7 @@ export function connect<OuterProps, Values = {}>(
   return hoistNonReactStatics(
     C,
     Comp as React.ComponentClass<
-      OuterProps & { formik: FormikContextType<Values> }
+      TOuterProps & { formik: FormikContextType<TFormikValues> }
     > // cast type to ComponentClass (even if SFC)
   );
 }

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -148,7 +148,7 @@ export interface FormikHandlers<TValues extends FormikValues> {
   handleBlur: FormikBlurHandlerFn;
   handleChange: FormikChangeHandlerFn;
 
-  getFieldProps: <TFieldValue>(props: string | FieldConfig<TFieldValue>) => FieldInputProps<TFieldValue>;
+  getFieldProps: <TFieldValue>(props: FormikValueKeys<TValues> | FieldConfig<TFieldValue>) => FieldInputProps<TFieldValue>;
   getFieldMeta: <TFieldValue>(name: FormikValueKeys<TValues>) => FieldMetaProps<TFieldValue>;
   getFieldHelpers: <TFieldValue>(name: FormikValueKeys<TValues>) => FieldHelperProps<TFieldValue>;
 }

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -328,10 +328,12 @@ export type FieldValidator = (
 export type FormikValueKeys<TValues extends object> = FlatProperties<TValues, '.'>;
 
 type FlatProperties<TObject extends object, TSeparator extends string> = 
-| `${keyof TObject & (string | number)}`
-| {
-  [K in keyof TObject]: 
-    TObject[K] extends object ?
-    `${K & (string | number)}${TSeparator}${FlatProperties<TObject[K], TSeparator>}` :
-    never;
-}[keyof TObject];
+  TObject extends object ?
+    | `${keyof TObject & (string | number)}`
+    | {
+      [K in keyof TObject]: 
+        TObject[K] extends object ?
+        `${K & (string | number)}${TSeparator}${FlatProperties<TObject[K], TSeparator>}` :
+        never;
+    }[keyof TObject]
+  : never;

--- a/packages/formik/src/withFormik.tsx
+++ b/packages/formik/src/withFormik.tsx
@@ -17,12 +17,12 @@ import { isFunction } from './utils';
  *
  * @deprecated  Use `OuterProps & FormikProps<Values>` instead.
  */
-export type InjectedFormikProps<Props, Values> = Props & FormikProps<Values>;
+export type InjectedFormikProps<Props, Values extends FormikValues> = Props & FormikProps<Values>;
 
 /**
  * Formik helpers + { props }
  */
-export type FormikBag<P, V> = { props: P } & FormikHelpers<V>;
+export type FormikBag<P, V extends FormikValues> = { props: P } & FormikHelpers<V>;
 
 /**
  * withFormik() configuration options. Backwards compatible.

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -443,7 +443,9 @@ describe('Field / FastField', () => {
         rerender();
 
         act(() => {
-          getFormProps().validateField('user.name');
+          type FormikPropsWithNewValues = FormikProps<Values & Yup.InferType<typeof validationSchema>>;
+
+          (getFormProps() as unknown as FormikPropsWithNewValues).validateField('user.name');
         });
 
         await waitFor(() =>

--- a/packages/formik/test/types.test.tsx
+++ b/packages/formik/test/types.test.tsx
@@ -1,4 +1,4 @@
-import { FormikTouched, FormikErrors } from '../src';
+import { FormikErrors, FormikProps, FormikTouched } from '../src';
 
 describe('Formik Types', () => {
   describe('FormikTouched', () => {
@@ -43,4 +43,45 @@ describe('Formik Types', () => {
       expect(facebook).toBe('error');
     });
   });
+
+  it('FormikProps', () => {
+    type Values = {
+      user: { 
+        lastName: string; 
+        firstName: string; 
+        10: string;
+      };
+      action: 'testing';
+    };
+    type Props = FormikProps<Values>;
+    
+    function expectType<T>(_: T) {
+      expect(true).toBe(true);
+    }
+
+    // @ts-expect-error
+    expectType<Parameters<Props['getFieldHelpers']>[0]>('unexpected');
+      
+    // @ts-expect-error
+    expectType<Parameters<Props['getFieldMeta']>[0]>('randomText');
+
+    // @ts-expect-error
+    expectType<Parameters<Props['getFieldProps']>[0]>('');
+
+    // @ts-expect-error
+    expectType<Parameters<Props['setFieldValue']>[0]>('ucer');
+
+    // @ts-expect-error
+    expectType<Parameters<Props['setFieldError']>[0]>('firstName');
+
+    // @ts-expect-error
+    expectType<Parameters<Props['setFieldTouched']>[0]>('action10');
+
+    expectType<Parameters<Props['getFieldHelpers']>[0]>('user');
+    expectType<Parameters<Props['getFieldMeta']>[0]>('action');
+    expectType<Parameters<Props['getFieldProps']>[0]>('user.firstName');
+    expectType<Parameters<Props['setFieldValue']>[0]>('user.lastName');
+    expectType<Parameters<Props['setFieldError']>[0]>('user.10');
+    expectType<Parameters<Props['setFieldTouched']>[0]>('action');
+  })
 });


### PR DESCRIPTION
Hi, I noticed that when using `getFieldMeta` and `getFieldHelpers`, IDE does not provide the list of the names of the form fields. So I made a **non-breaking** update to `FormikHandlers` interface.

This way we are able to leverage typed argument in `getFieldMeta` and `getFieldHelpers` to (1) avoid possible bugs after refactoring and (2) get a better DX when working with formik.

Example:
<img width="696" alt="Screen Shot 2023-04-10 at 10 12 05" src="https://user-images.githubusercontent.com/37013688/230857982-59f0841e-cbd3-4d29-9d28-7aed967263d3.png">



Please let me know if more updates or clarifications needed. Thanks!