### PR TITLE
fix: ensure correct error structure for array field with error that becomes empty

### DIFF
--- a/.changeset/fair-students-fix.md
+++ b/.changeset/fair-students-fix.md
@@ -1,6 +1,7 @@
 ---
 'formik': patch
-'formik-native': patch
 ---
 
-Fixes array fields not beeing cleanup up properly if the get deleted
+Fixed field error state for array fields that have an error and become empty through an API like `arrayHelpers.remove`.
+
+The prior behavior resolved the field error to `[undefined]`, now it is simply `undefined`.

--- a/.changeset/fair-students-fix.md
+++ b/.changeset/fair-students-fix.md
@@ -1,0 +1,6 @@
+---
+'formik': patch
+'formik-native': patch
+---
+
+Fixes array fields not beeing cleanup up properly if the get deleted

--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -288,7 +288,12 @@ class FieldArrayInner<Values = {}> extends React.Component<
         if (isFunction(copy.splice)) {
           copy.splice(index, 1);
         }
-        return copy;
+        // if the array only includes undefined values we have to return an empty array
+        return isFunction(copy.every)
+          ? copy.every(v => v === undefined)
+            ? []
+            : copy
+          : copy;
       },
       true,
       true

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -382,6 +382,14 @@ describe('<FieldArray />', () => {
       expect(formikBag.errors.friends).toEqual(undefined);
       expect(formikBag.touched.friends).toEqual(undefined);
     });
+    it('should clean up errors', () => {
+      act(() => {
+        formikBag.setFieldError('friends.1', 'Field error');
+        arrayHelpers.remove(1);
+      });
+
+      expect(formikBag.errors.friends).toEqual(undefined);
+    });
   });
 
   describe('given array-like object representing errors', () => {


### PR DESCRIPTION
Closes #3406 