### PR TITLE
feat: provide current values as context to yup validation by default

### DIFF
--- a/.changeset/lemon-crabs-explain.md
+++ b/.changeset/lemon-crabs-explain.md
@@ -1,0 +1,38 @@
+---
+'formik': minor
+---
+
+Yup by default only allows for cross-field validation within the
+same field object. This is not that useful in most scenarios because
+a sufficiently-complex form will have several `yup.object()` in the
+schema.
+
+```ts
+const deepNestedSchema = Yup.object({
+  object: Yup.object({
+    nestedField: Yup.number().required(),
+  }),
+  object2: Yup.object({
+    // this doesn't work because `object.nestedField` is outside of `object2`
+    nestedFieldWithRef: Yup.number().min(0).max(Yup.ref('object.nestedField')),
+  }),
+});
+```
+
+However, Yup offers something called `context` which can operate across
+the entire schema when using a \$ prefix:
+
+```ts
+const deepNestedSchema = Yup.object({
+  object: Yup.object({
+    nestedField: Yup.number().required(),
+  }),
+  object2: Yup.object({
+    // this works because of the "context" feature, enabled by $ prefix
+    nestedFieldWithRef: Yup.number().min(0).max(Yup.ref('$object.nestedField')),
+  }),
+});
+```
+
+With this change, you may now validate against any field in the entire schema,
+regardless of position when using the \$ prefix.

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1066,12 +1066,13 @@ export function validateYupSchema<T extends FormikValues>(
   values: T,
   schema: any,
   sync: boolean = false,
-  context: any = {}
+  context?: any
 ): Promise<Partial<T>> {
-  const validateData: FormikValues = prepareDataForValidation(values);
-  return schema[sync ? 'validateSync' : 'validate'](validateData, {
+  const normalizedValues: FormikValues = prepareDataForValidation(values);
+
+  return schema[sync ? 'validateSync' : 'validate'](normalizedValues, {
     abortEarly: false,
-    context: context,
+    context: context || normalizedValues,
   });
 }
 


### PR DESCRIPTION
Yup by default only allows for cross-field validation within the same field object. This is not that useful in most scenarios because a sufficiently-complex form will have several `yup.object()` in the schema.

```ts
const deepNestedSchema = Yup.object({
  object: Yup.object({
    nestedField: Yup.number().required(),
  }),
  object2: Yup.object({
    // this doesn't work because `object.nestedField` is outside of `object2`
    nestedFieldWithRef: Yup.number().min(0).max(Yup.ref('object.nestedField')),
  }),
});
```

However, Yup offers something called `context` which can operate across the entire schema when using a $ prefix:

```ts
const deepNestedSchema = Yup.object({
  object: Yup.object({
    nestedField: Yup.number().required(),
  }),
  object2: Yup.object({
    // this works because of the "context" feature, enabled by $ prefix
    nestedFieldWithRef: Yup.number().min(0).max(Yup.ref('$object.nestedField')),
  }),
});
```

With this change, you may now validate against any field in the entire schema, regardless of position, when using the $ prefix.