### PR TITLE
fix: memoize field helpers to avoid infinite loop scenarios with React.useEffect

### DIFF
--- a/.changeset/pretty-suns-applaud.md
+++ b/.changeset/pretty-suns-applaud.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Fix infinite loop issue in `Field` when field helpers (`setTouched`, etc) are used as an argument in `React.useEffect`.

--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -119,11 +119,12 @@ export function useField<Val = any>(
     'Invalid field name. Either pass `useField` a string or an object containing a `name` key.'
   );
 
-  return [
-    getFieldProps(props),
-    getFieldMeta(fieldName),
-    getFieldHelpers(fieldName),
-  ];
+  const fieldHelpers = React.useMemo(() => getFieldHelpers(fieldName), [
+    getFieldHelpers,
+    fieldName,
+  ]);
+
+  return [getFieldProps(props), getFieldMeta(fieldName), fieldHelpers];
 }
 
 export function Field({


### PR DESCRIPTION
Closes #3715