### PR TITLE
fix: infinite loop when initialValues prop changes and enableReinitialize is falsy (#3639)

### DIFF
--- a/.changeset/shy-ties-explode.md
+++ b/.changeset/shy-ties-explode.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Fix potential infinite loop scenario when `initialValues` changes but `enableReinitialize` is not truthy.

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -417,10 +417,9 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       if (enableReinitialize) {
         initialValues.current = props.initialValues;
         resetForm();
-      }
-
-      if (validateOnMount) {
-        validateFormWithHighPriority(initialValues.current);
+        if (validateOnMount) {
+          validateFormWithHighPriority(initialValues.current);
+        }
       }
     }
   }, [


### PR DESCRIPTION
Closes #3642 