### PR TITLE
feat(validationSchema): support yup transforms in validate & submit

### DIFF
--- a/.changeset/fluffy-rivers-rest.md
+++ b/.changeset/fluffy-rivers-rest.md
@@ -1,0 +1,5 @@
+---
+'formik': minor
+---
+
+Add support for Yup ["transforms"](https://github.com/jquense/yup#parsing-transforms).

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1435,8 +1435,8 @@ describe('<Formik>', () => {
     await act(async () => {
       try {
         await getProps().validateForm();
-      } catch ({ message }) {
-        caughtError = message;
+      } catch (err) {
+        caughtError = (err as Yup.ValidationError).message;
       }
     });
 
@@ -1449,5 +1449,69 @@ describe('<Formik>', () => {
     const { getProps } = renderFormik({ innerRef });
 
     expect(innerRef.current).toEqual(getProps());
+  });
+
+  it('transforms in yup schema are applied on validation', async () => {
+    const validationSchema = Yup.object({
+      users: Yup.array().of(
+        Yup.object({
+          firstName: Yup.string()
+            .transform(currentValue =>
+              currentValue.split('').reverse().join('')
+            )
+            // @ts-expect-error incorrect typing for second arg
+            .oneOf(['foo'], x => x.value),
+        })
+      ),
+    });
+
+    const { getProps } = renderFormik({
+      initialValues: { users: [{ firstName: 'foo' }] },
+      validationSchema,
+    });
+
+    await act(async () => {
+      await getProps().validateForm();
+
+      expect(getProps().errors).toEqual({
+        users: [
+          {
+            // the transform reverses "foo" to "oof", which then fails the `oneOf` assertion
+            firstName: 'oof',
+          },
+        ],
+      });
+    });
+  });
+
+  it('transforms in yup schema are applied on submit', async () => {
+    const validationSchema = Yup.object({
+      users: Yup.array().of(
+        Yup.object({
+          firstName: Yup.string().transform(currentValue =>
+            currentValue.split('').reverse().join('')
+          ),
+        })
+      ),
+    });
+
+    const spy = jest.fn();
+
+    const { getProps } = renderFormik({
+      initialValues: { users: [{ firstName: 'foo' }] },
+      onSubmit: spy,
+      validationSchema,
+    });
+
+    await act(async () => {
+      await getProps().submitForm();
+
+      expect(spy).toHaveBeenCalledWith(
+        {
+          users: [{ firstName: 'oof' }],
+        },
+        expect.anything()
+      );
+    });
   });
 });

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -134,15 +134,18 @@ describe('withFormik()', () => {
   });
 
   it('calls validationSchema', async () => {
-    const validate = jest.fn(() => Promise.resolve());
+    const validationSchema = Yup.object();
+
+    jest.spyOn(validationSchema, 'validate');
+
     const { getProps } = renderWithFormik({
-      validationSchema: { validate },
+      validationSchema,
     });
 
     act(() => {
       getProps().submitForm();
     });
-    await waitFor(() => expect(validate).toHaveBeenCalled());
+    await waitFor(() => expect(validationSchema.validate).toHaveBeenCalled());
   });
 
   it('calls validationSchema function with props', async () => {


### PR DESCRIPTION
Closes #728 
Closes #608

Add support for Yup ["transforms"](https://github.com/jquense/yup#parsing-transforms).

I do not believe this is a semver-major change as it's an optional Yup feature; it's actually probably confusing that it _hasn't_ worked to date.

Original credit for this work belongs to @sshmyg, I just modernized it and added tests.