### PR TITLE
refactor(ArrayHelpers): revise array typing and override pattern

### DIFF
--- a/.changeset/warm-seals-stare.md
+++ b/.changeset/warm-seals-stare.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Fixed the use of generics for the `ArrayHelpers` type such that `any[]` is the default array type and for each individual method the array item type can be overridden if necessary.

--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -30,11 +30,11 @@ export type FieldArrayConfig = {
   /** Override FieldArray's default shouldComponentUpdate */
   shouldUpdate?: (nextProps: {}, props: {}) => boolean;
 } & SharedRenderProps<FieldArrayRenderProps>;
-export interface ArrayHelpers<T = unknown[]> {
+export interface ArrayHelpers<T extends any[] = any[]> {
   /** Imperatively add a value to the end of an array */
-  push: (obj: T) => void;
+  push<X = T[number]>(obj: X): void;
   /** Curried fn to add a value to the end of an array */
-  handlePush: (obj: T) => () => void;
+  handlePush<X = T[number]>(obj: X): () => void;
   /** Imperatively swap two values in an array */
   swap: (indexA: number, indexB: number) => void;
   /** Curried fn to swap two values in an array */
@@ -44,25 +44,25 @@ export interface ArrayHelpers<T = unknown[]> {
   /** Imperatively move an element in an array to another index */
   handleMove: (from: number, to: number) => () => void;
   /** Imperatively insert an element at a given index into the array */
-  insert: (index: number, value: T) => void;
+  insert<X = T[number]>(index: number, value: X): void;
   /** Curried fn to insert an element at a given index into the array */
-  handleInsert: (index: number, value: T) => () => void;
+  handleInsert<X = T[number]>(index: number, value: X): () => void;
   /** Imperatively replace a value at an index of an array  */
-  replace: (index: number, value: T) => void;
+  replace<X = T[number]>(index: number, value: X): void;
   /** Curried fn to replace an element at a given index into the array */
-  handleReplace: (index: number, value: T) => () => void;
+  handleReplace<X = T[number]>(index: number, value: X): () => void;
   /** Imperatively add an element to the beginning of an array and return its length */
-  unshift: (value: T) => number;
+  unshift<X = T[number]>(value: X): number;
   /** Curried fn to add an element to the beginning of an array */
-  handleUnshift: (value: T) => () => void;
+  handleUnshift<X = T[number]>(value: X): () => void;
   /** Curried fn to remove an element at an index of an array */
   handleRemove: (index: number) => () => void;
   /** Curried fn to remove a value from the end of the array */
   handlePop: () => () => void;
   /** Imperatively remove and element at an index of an array */
-  remove<T>(index: number): T | undefined;
+  remove<X = T[number]>(index: number): X | undefined;
   /** Imperatively remove and return value from the end of the array */
-  pop<T>(): T | undefined;
+  pop<X = T[number]>(): X | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixed the use of generics for the `ArrayHelpers` type such that `any[]` is the default array type and for each individual method the array item type can be overridden if necessary.

Fixes #3797 