### PR TITLE
fix(docs/examples): fix broken codesandbox links

### DIFF
--- a/docs/examples/async-submission.md
+++ b/docs/examples/async-submission.md
@@ -7,7 +7,7 @@ This example demonstrates how to use `async`/`await` to submit a Formik form.
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/async-submission?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/async-submission?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -7,7 +7,7 @@ This example demonstrates how to use Formik in its most basic way.
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/basic?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/basic?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/checkboxes.md
+++ b/docs/examples/checkboxes.md
@@ -7,7 +7,7 @@ This example demonstrates how to use Formik with a checkbox group. Given that th
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/checkboxes?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/checkboxes?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/dependent-fields-async-api-request.md
+++ b/docs/examples/dependent-fields-async-api-request.md
@@ -7,7 +7,7 @@ This is an example of a complex dependent field in Formik. In this example, one 
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/dependent-fields-async-api-request?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/dependent-fields-async-api-request?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/dependent-fields.md
+++ b/docs/examples/dependent-fields.md
@@ -7,7 +7,7 @@ This is an example of how to set the value of one field based on the current val
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/dependent-fields?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/dependent-fields?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/field-arrays.md
+++ b/docs/examples/field-arrays.md
@@ -6,7 +6,7 @@ This example demonstrates how to work with array fields in Formik.
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/field-arrays?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/field-arrays?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/instant-feedback.md
+++ b/docs/examples/instant-feedback.md
@@ -6,7 +6,7 @@ Instant feedback during typing can be extremely helpful in certain situations. F
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/instant-feedback?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/instant-feedback?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/more-examples.md
+++ b/docs/examples/more-examples.md
@@ -2,4 +2,4 @@
 title: More Examples
 ---
 
-You can find additional examples in [`examples` folder of the Formik GitHub repository](https://github.com/formik/formik/tree/master/examples/).
+You can find additional examples in [`examples` folder of the Formik GitHub repository](https://github.com/formik/formik/tree/main/examples/).

--- a/docs/examples/radio-group.md
+++ b/docs/examples/radio-group.md
@@ -7,7 +7,7 @@ This example demonstrates how to create a radio group with Formik.
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/radio-group?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/radio-group?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/typescript.md
+++ b/docs/examples/typescript.md
@@ -7,7 +7,7 @@ This example demonstrates how to use Formik in its most basic way with TypeScrip
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/basic-typescript?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/basic-typescript?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/docs/examples/with-material-ui.md
+++ b/docs/examples/with-material-ui.md
@@ -7,7 +7,7 @@ Formik can be easily used/integrated with [Material UI](https://material-ui.com/
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe
-  src="https://codesandbox.io/embed/github/formik/formik/tree/master/examples/with-material-ui?fontsize=14&hidenavigation=1&theme=dark"
+  src="https://codesandbox.io/embed/github/formik/formik/tree/main/examples/with-material-ui?fontsize=14&hidenavigation=1&theme=dark"
   style={{ width:'100%', height: '100%', border:0, borderRadius: 4, overflow: 'hidden'}}
   title="formik/formik: async-submission"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"


### PR DESCRIPTION
Closes #3818 

- Replace `master` with `main` to fix 404 at all codesandbox examples 