### PR TITLE
docs: Expand on cleanup behaviour for submission handlers

### DIFF
--- a/docs/guides/form-submission.md
+++ b/docs/guides/form-submission.md
@@ -57,8 +57,9 @@ Disable whatever is triggering submission if `isSubmitting` is `true`.
 If `isValidating` is `true` and `isSubmitting` is `true`.
 
 </details>
-<summary>Why does `isSubmitting` remain `true` after submission?</summary>
+
 <details>
+<summary>Why does isSubmitting remain true after submission?</summary>
   If the submission handler returns a promise, make sure it is correctly resolved or rejected when called.
   If the submission handler does not return a promise, make sure `setSubmitting(false)` is called at the end of the handler.
 </details>

--- a/docs/guides/form-submission.md
+++ b/docs/guides/form-submission.md
@@ -60,6 +60,9 @@ If `isValidating` is `true` and `isSubmitting` is `true`.
 
 <details>
 <summary>Why does isSubmitting remain true after submission?</summary>
-  If the submission handler returns a promise, make sure it is correctly resolved or rejected when called.
-  If the submission handler does not return a promise, make sure `setSubmitting(false)` is called at the end of the handler.
+  
+If the submission handler returns a promise, make sure it is correctly resolved or rejected when called.
+
+If the submission handler does not return a promise, make sure `setSubmitting(false)` is called at the end of the handler.
+
 </details>

--- a/docs/guides/form-submission.md
+++ b/docs/guides/form-submission.md
@@ -23,10 +23,10 @@ To submit a form in Formik, you need to somehow fire off the provided `handleSub
 
 ### Submission
 
-- Proceed with running your submission handler (i.e. `onSubmit` or `handleSubmit`)
+- Proceed with running the submission handler (i.e. `onSubmit` or `handleSubmit`)
 - Did the submit handler return a promise?
   - Yes: Wait until it is resolved or rejected, then set `setSubmitting` to `false`
-  - No: _You call `setSubmitting(false)`_ in your handler to finish the cycle
+  - No: _Call `setSubmitting(false)`_ to finish the cycle
 
 ## Frequently Asked Questions
 
@@ -59,7 +59,7 @@ If `isValidating` is `true` and `isSubmitting` is `true`.
 </details>
 
 <details>
-<summary>Why does isSubmitting remain true after submission?</summary>
+<summary>Why does `isSubmitting` remain true after submission?</summary>
   
 If the submission handler returns a promise, make sure it is correctly resolved or rejected when called.
 

--- a/docs/guides/form-submission.md
+++ b/docs/guides/form-submission.md
@@ -23,8 +23,10 @@ To submit a form in Formik, you need to somehow fire off the provided `handleSub
 
 ### Submission
 
-- Proceed with running your submission handler (i.e.`onSubmit` or `handleSubmit`)
-- _you call `setSubmitting(false)`_ in your handler to finish the cycle
+- Proceed with running your submission handler (i.e. `onSubmit` or `handleSubmit`)
+- Did the submit handler return a promise?
+  - Yes: Wait until it is resolved or rejected, then set `setSubmitting` to `false`
+  - No: _You call `setSubmitting(false)`_ in your handler to finish the cycle
 
 ## Frequently Asked Questions
 
@@ -54,4 +56,9 @@ Disable whatever is triggering submission if `isSubmitting` is `true`.
 
 If `isValidating` is `true` and `isSubmitting` is `true`.
 
+</details>
+<summary>Why does `isSubmitting` remain `true` after submission?</summary>
+<details>
+  If the submission handler is returning a promise, make sure the promise has resolved or rejected.
+  If the submission handler is not returning a promise, make sure `setSubmitting(false)` is called at the end of the handler.
 </details>

--- a/docs/guides/form-submission.md
+++ b/docs/guides/form-submission.md
@@ -59,6 +59,6 @@ If `isValidating` is `true` and `isSubmitting` is `true`.
 </details>
 <summary>Why does `isSubmitting` remain `true` after submission?</summary>
 <details>
-  If the submission handler is returning a promise, make sure the promise has resolved or rejected.
-  If the submission handler is not returning a promise, make sure `setSubmitting(false)` is called at the end of the handler.
+  If the submission handler returns a promise, make sure it is correctly resolved or rejected when called.
+  If the submission handler does not return a promise, make sure `setSubmitting(false)` is called at the end of the handler.
 </details>


### PR DESCRIPTION
Cover use cases for both using a submission handler that returns a promise, and for a one which does not.

Add FAQ entry about submission handler cleanup.

Following submission handling logic from https://github.com/jaredpalmer/formik/blob/main/packages/formik/src/Formik.tsx#L754-L782