### PR TITLE
chore: update CHANGELOG.md

### DIFF
--- a/packages/formik/CHANGELOG.md
+++ b/packages/formik/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Patch Changes
 
-- [`ae0fe6c`](https://github.com/jaredpalmer/formik/commit/ae0fe6cbd11f2d2664142008225abc237b5bff82) [#3873](https://github.com/jaredpalmer/formik/pull/3873) Thanks [@probablyup](https://github.com/probablyup)! - Forward `className` for custom components used with `Field` 41720c2
+-   [`41720c2`](https://github.com/jaredpalmer/formik/commit/41720c2f69407e41c27b325923bce63436b07f45) [#3862](https://github.com/jaredpalmer/formik/pull/3862) Thanks @yazaldefilimonepinto! - Forward `className` for custom components used with `Field`
 
-* [`ae0fe6c`](https://github.com/jaredpalmer/formik/commit/ae0fe6cbd11f2d2664142008225abc237b5bff82) [#3873](https://github.com/jaredpalmer/formik/pull/3873) Thanks [@probablyup](https://github.com/probablyup)! - Remove use of deprecated `StatelessComponent` type in favor of `FunctionComponent` (da58b29)
+
+-   [`da58b29`](https://github.com/jaredpalmer/formik/commit/da58b292c9c0b6029ae21ab4b5edff09dd877c1b) [#3858](https://github.com/jaredpalmer/formik/pull/3858) Thanks @alaanescobedo! - Remove use of deprecated `StatelessComponent` type in favor of `FunctionComponent`
+
+-   [`5c01ee7`](https://github.com/jaredpalmer/formik/commit/5c01ee77b312ff6c375d43f841fe9fbe5846ebd9) [#3872](https://github.com/jaredpalmer/formik/pull/3872) Thanks @rajpatelbot! - FIX: Fixed resetForm function dependency issue
+
 
 ## 2.4.3
 

--- a/packages/formik/CHANGELOG.md
+++ b/packages/formik/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 -   [`41720c2`](https://github.com/jaredpalmer/formik/commit/41720c2f69407e41c27b325923bce63436b07f45) [#3862](https://github.com/jaredpalmer/formik/pull/3862) Thanks @yazaldefilimonepinto! - Forward `className` for custom components used with `Field`
 
-
 -   [`da58b29`](https://github.com/jaredpalmer/formik/commit/da58b292c9c0b6029ae21ab4b5edff09dd877c1b) [#3858](https://github.com/jaredpalmer/formik/pull/3858) Thanks @alaanescobedo! - Remove use of deprecated `StatelessComponent` type in favor of `FunctionComponent`
 
 -   [`5c01ee7`](https://github.com/jaredpalmer/formik/commit/5c01ee77b312ff6c375d43f841fe9fbe5846ebd9) [#3872](https://github.com/jaredpalmer/formik/pull/3872) Thanks @rajpatelbot! - FIX: Fixed resetForm function dependency issue


### PR DESCRIPTION
Already fixed the release summary to reflect the true contributors/commits, the change history got a little muddy due to submitting the changesets separately.