### PR TITLE
fix: add missing @types/hoist-non-react-statics

### DIFF
--- a/.changeset/dry-pots-float.md
+++ b/.changeset/dry-pots-float.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+add missing @types/hoist-non-react-statics dependency

--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -51,11 +51,11 @@
     "lodash-es": "^4.17.21",
     "react-fast-compare": "^2.0.1",
     "tiny-warning": "^1.0.2",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "@types/hoist-non-react-statics": "^3.3.1"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
-    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/lodash": "^4.14.119",
     "@types/react": "^18.2.7",
     "@types/react-dom": "^18.2.4",


### PR DESCRIPTION
This is the continuation of https://github.com/jaredpalmer/formik/pull/3860

close https://github.com/jaredpalmer/formik/issues/3837
close https://github.com/jaredpalmer/formik/issues/3885