### PR TITLE
feat: Added ability to provide patching function to setStatus method

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -200,7 +200,7 @@ Set the value of a field imperatively. `field` should match the key of
 
 If `validateOnChange` is set to `true` and there are errors, they will be resolved in the returned `Promise`.
 
-#### `setStatus: (status?: any) => void`
+#### `setStatus: (status?: React.SetStateAction<any>) => void`
 
 Set a top-level `status` to anything you want imperatively. Useful for
 controlling arbitrary top-level state related to your form. For example, you can

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -728,9 +728,10 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     []
   );
 
-  const setStatus = React.useCallback((status: any) => {
-    dispatch({ type: 'SET_STATUS', payload: status });
-  }, []);
+  const setStatus = React.useCallback((status: React.SetStateAction<any>) => {
+    const resolvedStatus = isFunction(status) ? status(state.status) : status;
+    dispatch({ type: 'SET_STATUS', payload: resolvedStatus });
+  }, []);  
 
   const setSubmitting = React.useCallback((isSubmitting: boolean) => {
     dispatch({ type: 'SET_ISSUBMITTING', payload: isSubmitting });

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -77,7 +77,7 @@ export interface FormikComputedProps<Values> {
  */
 export interface FormikHelpers<Values> {
   /** Manually set top level status. */
-  setStatus: (status?: any) => void;
+  setStatus: (status: React.SetStateAction<any>) => void;
   /** Manually set errors object */
   setErrors: (errors: FormikErrors<Values>) => void;
   /** Manually set isSubmitting */

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -829,6 +829,20 @@ describe('<Formik>', () => {
 
         expect(getProps().status).toEqual(status);
       });
+
+      it('setStatus takes a function which can patch status', () => {
+        const initialStatus = { name: 'sam' };
+        const { getProps } = renderFormik({ initialStatus: initialStatus });
+
+        act(() => {
+          getProps().setStatus((status: typeof initialStatus) => ({
+            ...status,
+            age: 80,
+          }));
+        });
+        expect(getProps().status.name).toEqual('sam');
+        expect(getProps().status.age).toEqual(80);
+      });
     });
   });
 


### PR DESCRIPTION
Problem
When setting status, sometimes user needs to update the existing value. When used inside a useCallback hook for instance, it introduces an unnecessary variable to the dependency list.
Solution
setStatus now acepts a patching function