### PR TITLE
fix(3280): submitForm should reject on validation fail

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -797,6 +797,9 @@ export function useFormik<Values extends FormikValues = FormikValues>({
           // throw combinedErrors;
           if (isInstanceOfError) {
             throw combinedErrors;
+          } else {
+            // need to fulfill contract: submitForm will throw if validation fails
+            throw new Error();
           }
         }
         return;

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -609,6 +609,21 @@ describe('<Formik>', () => {
           );
         });
       });
+      it('submit should reject if validate returns error', async () => {
+        const onSubmit = jest.fn();
+        const validate = jest.fn().mockResolvedValue({ error: 'error' });
+        // expect(global.console.warn).not.toHaveBeenCalled();
+
+        const { getProps } = renderFormik({ onSubmit, validate });
+
+        await act(async () => {
+          await expect(getProps().submitForm()).rejects.toThrow();
+        });
+
+        await waitFor(() => {
+          expect(onSubmit).not.toBeCalled();
+        });
+      });
     });
 
     describe('with validationSchema (ASYNC)', () => {


### PR DESCRIPTION
Fixes https://github.com/jaredpalmer/formik/issues/3280

Formik docs says this about submitForm:
> Trigger a form submission. The promise will be rejected if form is invalid.

If the validate callback returns an object, rather than rejecting, this is still a validation failure (object is error data). The promise returned by submitForm should reject.