### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@1.4.8
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
This old style of tag seems to have been removed and just migrating to the recommended way to specify version based on the changeset action [README](https://github.com/changesets/action?tab=readme-ov-file#with-publishing).