### PR TITLE
Make typings compatible with v19

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -279,9 +279,9 @@ export interface SharedRenderProps<T> {
 }
 
 export type GenericFieldHTMLAttributes =
-  | JSX.IntrinsicElements['input']
-  | JSX.IntrinsicElements['select']
-  | JSX.IntrinsicElements['textarea'];
+  | React.JSX.IntrinsicElements['input']
+  | React.JSX.IntrinsicElements['select']
+  | React.JSX.IntrinsicElements['textarea'];
 
 /** Field metadata */
 export interface FieldMetaProps<Value> {

--- a/website/src/components/Container.tsx
+++ b/website/src/components/Container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cn from 'classnames';
 import { HTMLProps } from 'react';
 
-export const Container: React.FC<JSX.IntrinsicElements['div']> = ({
+export const Container: React.FC<React.JSX.IntrinsicElements['div']> = ({
   className,
   ...props
 }) => {

--- a/website/src/components/FormiumLogo.tsx
+++ b/website/src/components/FormiumLogo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export const FormiumLogo: React.FC<JSX.IntrinsicElements['svg']> = props => {
+export const FormiumLogo: React.FC<React.JSX.IntrinsicElements['svg']> = props => {
   return (
     <svg
       width={'101px'}

--- a/website/src/components/forwardRefWithAs.tsx
+++ b/website/src/components/forwardRefWithAs.tsx
@@ -96,7 +96,7 @@ export function forwardRefWithAs<Props, ComponentType extends As>(
 Test components to make sure our dynamic As prop components work as intended 
 type PopupProps = {
   lol: string;
-  children?: React.ReactNode | ((value?: number) => JSX.Element);
+  children?: React.ReactNode | ((value?: number) => React.JSX.Element);
 };
 export const Popup = forwardRefWithAs<PopupProps, 'input'>(
   ({ as: Comp = 'input', lol, className, children, ...props }, ref) => {


### PR DESCRIPTION
Fixes #4011.

To test this, I ran `yarn install` locally and verified that the aforementioned dist files no longer reference global `JSX`, but use `React.JSX` instead.