### PR TITLE
fix: make validateField return type consistent 

### DIFF
--- a/.changeset/nine-adults-turn.md
+++ b/.changeset/nine-adults-turn.md
@@ -1,0 +1,9 @@
+---
+'formik': patch
+---
+
+The validateField function now consistently returns Promise<string | undefined> across all validation paths, matching its type definition where `string` represents a validation error message, `undefined` represents a successful validation.
+
+while previous implementation:
+- field-level validation returned Promise<string | undefined>
+- default case and schema validation returned Promise<void>

--- a/.changeset/nine-adults-turn.md
+++ b/.changeset/nine-adults-turn.md
@@ -2,8 +2,8 @@
 'formik': patch
 ---
 
-The validateField function now consistently returns Promise<string | undefined> across all validation paths, matching its type definition where `string` represents a validation error message, `undefined` represents a successful validation.
+The validateField function now consistently returns Promise<string | undefined> across all validation paths, where `string` represents a validation error message, `undefined` represents a successful validation.
 
 while previous implementation:
-- field-level validation returned Promise<string | undefined>
-- default case and schema validation returned Promise<void>
+- validation via `<Field validate={...}>` returned Promise<string | undefined>
+- validation via schema returned Promise<void>

--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -245,7 +245,7 @@ component.
 
 Imperatively call your `validate` or `validateSchema` depending on what was specified. You can optionally pass values to validate against and this modify Formik state accordingly, otherwise this will use the current `values` of the form.
 
-#### `validateField: (field: string) => void`
+#### `validateField: (field: string) => Promise<string | undefined>`
 
 Imperatively call field's `validate` function if specified for given field or run schema validation using [Yup's `schema.validateAt`](https://github.com/jquense/yup#mixedvalidateatpath-string-value-any-options-object-promiseany-validationerror) and the provided top-level `validationSchema` prop. Formik will use the current field value.
 

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -109,7 +109,7 @@ export interface FormikHelpers<Values> {
   /** Validate form values */
   validateForm: (values?: any) => Promise<FormikErrors<Values>>;
   /** Validate field value */
-  validateField: (field: string) => Promise<void> | Promise<string | undefined>;
+  validateField: (field: string) => Promise<string | undefined>;
   /** Reset form */
   resetForm: (nextState?: Partial<FormikState<Values>>) => void;
   /** Submit the form imperatively */

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -385,15 +385,16 @@ describe('Field / FastField', () => {
           component: 'input',
         });
         rerender();
-
-        act(() => {
-          getFormProps().validateField('name');
+        
+        const error = await act(async () => {
+          return await getFormProps().validateField('name');
         });
 
         rerender();
         await waitFor(() => {
           expect(validate).toHaveBeenCalled();
           expect(getFormProps().errors.name).toBe('Error!');
+          expect(error).toBe('Error!');
         });
       }
     );
@@ -408,12 +409,15 @@ describe('Field / FastField', () => {
         // workaround for `useEffect` to run: https://github.com/facebook/react/issues/14050
         rerender();
 
-        act(() => {
-          getFormProps().validateField('name');
+        const error = await act(async () => {
+          return await getFormProps().validateField('name');
         });
 
         expect(validate).toHaveBeenCalled();
-        await waitFor(() => expect(getFormProps().errors.name).toBe('Error!'));
+        await waitFor(() => {
+          expect(getFormProps().errors.name).toBe('Error!')
+          expect(error).toBe('Error!')
+        });
       }
     );
 
@@ -432,15 +436,16 @@ describe('Field / FastField', () => {
 
         rerender();
 
-        act(() => {
-          getFormProps().validateField('name');
+        const error = await act(async () => {
+          return await getFormProps().validateField('name');
         });
 
-        await waitFor(() =>
+        await waitFor(() => {
           expect(getFormProps().errors).toEqual({
             name: errorMessage,
           })
-        );
+          expect(error).toBe(errorMessage)
+        });
       }
     );
 
@@ -460,13 +465,12 @@ describe('Field / FastField', () => {
 
         rerender();
 
-        act(() => {
-          getFormProps().validateField('user.name');
-        });
+        const error = await act(async () => await getFormProps().validateField('user.name'));
 
-        await waitFor(() =>
+        await waitFor(() => {
           expect(getFormProps().errors).toEqual({ user: { name: 'required' } })
-        );
+          expect(error).toBe('required')
+        });
       }
     );
   });


### PR DESCRIPTION
The validateField function now consistently returns `Promise<string | undefined>`, where `string` represents a validation error message, `undefined` represents a successful validation.

before this change:
- validation via `<Field validate={...}>` returned `Promise<string | undefined>`
- validation via schema returned `Promise<void>`

Closes https://github.com/jaredpalmer/formik/issues/2021