### PR TITLE
add string[] to setFieldValue type definiton

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -94,7 +94,7 @@ export interface FormikHelpers<Values> {
   ) => Promise<void | FormikErrors<Values>>;
   /** Set value of form field directly */
   setFieldValue: (
-    field: string,
+    field: string | string[],
     value: any,
     shouldValidate?: boolean
   ) => Promise<void | FormikErrors<Values>>;


### PR DESCRIPTION
**Issue**
```
   onChange={(v) => {
                              setFieldValue(field, v)
                       }}
```

   Issue: The above code does not work as intended if field contains a period. It results in creating a new key/value pair in the values array instead of just updating the value, so the form input doesn't get updated.

  To get around this, I used:
  
```
    onChange={(v) => {
                              setFieldValue([`${field}`], v)
                       }}
```

This allows the form to work but now there is a type error because field is set to type string.

**Solution**:
  Change type definition of field in setFieldValue to string | string[]
                       
  