### PR TITLE
Feat: Improve onReset to get the new values provided by resetForm

### DIFF
--- a/.changeset/afraid-garlics-destroy.md
+++ b/.changeset/afraid-garlics-destroy.md
@@ -1,0 +1,5 @@
+---
+'formik': major
+---
+
+Feat: Improve onReset to get the new values provided by resetForm

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -406,7 +406,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       if (props.onReset) {
         const maybePromisedOnReset = (props.onReset as any)(
           state.values,
-          imperativeMethods
+          imperativeMethods,
+          values
         );
 
         if (isPromise(maybePromisedOnReset)) {

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -214,7 +214,7 @@ export interface FormikConfig<Values> extends FormikSharedConfig {
   /**
    * Reset handler
    */
-  onReset?: (values: Values, formikHelpers: FormikHelpers<Values>) => void;
+  onReset?: (values: Values, formikHelpers: FormikHelpers<Values>, newValues?: Values) => void;
 
   /**
    * Submission handler

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1009,7 +1009,39 @@ describe('<Formik>', () => {
           setSubmitting: expect.any(Function),
           setTouched: expect.any(Function),
           setValues: expect.any(Function),
-        })
+        }),
+        InitialValues
+      );
+    });
+
+    it('should call onReset with values and actions and new initial values when form is reset with values', () => {
+      const onReset = jest.fn();
+      const { getProps } = renderFormik({
+        initialValues: InitialValues,
+        onSubmit: noop,
+        onReset,
+      });
+
+      const newInitialValues = { name: 'jared', age: 31,}
+
+      act(() => {
+        getProps().resetForm({values: newInitialValues});
+      });
+
+      expect(onReset).toHaveBeenCalledWith(
+        InitialValues,
+        expect.objectContaining({
+          resetForm: expect.any(Function),
+          setErrors: expect.any(Function),
+          setFieldError: expect.any(Function),
+          setFieldTouched: expect.any(Function),
+          setFieldValue: expect.any(Function),
+          setStatus: expect.any(Function),
+          setSubmitting: expect.any(Function),
+          setTouched: expect.any(Function),
+          setValues: expect.any(Function),
+        }),
+        newInitialValues
       );
     });
 


### PR DESCRIPTION
Sometimes  need to get the new initial values provided by `resetForm` in `onReset` for example:
```
resetForm({values: newInitialValues});

const onReset = (currentValues, imperativeMethods, initialValues)
```