### PR TITLE
Early return when event is not defined

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -687,6 +687,8 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   const executeBlur = React.useCallback(
     (e: any, path?: string) => {
+      if (!e) return
+      
       if (e.persist) {
         e.persist();
       }


### PR DESCRIPTION
There are cases when the `event` become undefined by the time it gets to this function, such as if the code triggers a navigation at the end of the `onSubmit` function, causing the component to unmount. Cases such as that lead to:

`cannot read properties of undefined (reading 'persist')`

![image](https://github.com/user-attachments/assets/089ad60b-d741-4544-9845-a6957ab4b243)

Add an early return to avoid this happening.