### PR TITLE
#4065 fixed Horizontal padding issue on large screens

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -26,7 +26,7 @@ const Home: React.FC<HomeProps> = props => {
       <Head>
         <title>Formik: Build forms in React, without the tears</title>
       </Head>
-      <div className={cn('bg-gray-50 h-full min-h-full', inter.className)}>
+      <div className={cn('bg-gray-50 h-full min-h-full lg:px-8', inter.className)}>
         <Banner />
         <Sticky>
           <Nav />


### PR DESCRIPTION
for large screen i have add lg:px-8 padding .now consistent horizontal padding across screen sizes.
**BEFORE**
<img width="1533" height="775" alt="image" src="https://github.com/user-attachments/assets/9241c8ea-37b9-4ab8-bfa8-286cbeaf7f37" />

**AFTER**
<img width="1532" height="777" alt="image" src="https://github.com/user-attachments/assets/7da2f116-fcce-4d83-80a5-e20aad8475b4" />
